### PR TITLE
fix: history panel — CJK copy bug, scroll-to-search, and markdown rendering

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -164,6 +164,13 @@ body,
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   transition: background-color 0.2s, color 0.2s;
+  /* Disable Chromium's CJK punctuation compression and auto-spacing.
+     These features cause text selection offsets when the primary font
+     (Geist Sans) falls back to a system CJK font — the compressed
+     glyph positions drift from the selection rectangles, making the
+     first character after CJK punctuation invisible when selected. */
+  text-spacing-trim: space-all;
+  text-autospace: no-autospace;
 }
 
 /* Custom scrollbar */

--- a/src/renderer/src/components/history/HistoryPanel.tsx
+++ b/src/renderer/src/components/history/HistoryPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { ArrowPathIcon, ClockIcon, PlayIcon } from '@heroicons/react/24/outline'
 import { cn } from '../../lib/utils'
+import { MarkdownRenderer } from '../files/MarkdownRenderer'
 import { useHistoryStore } from '../../store/history-store'
 import { useSessionStore } from '../../store/session-store'
 
@@ -21,7 +22,7 @@ function highlightText(content: string, needle: string): ReactNode {
     <>
       {parts.map((part, index) =>
         part.toLowerCase() === needle.toLowerCase() ? (
-          <mark key={`${part}-${index}`} className="bg-yellow-300/70 text-current rounded px-0.5">
+          <mark key={`${part}-${index}`} className="bg-yellow-300/70 text-current rounded">
             {part}
           </mark>
         ) : (
@@ -108,14 +109,40 @@ export function HistoryPanel() {
 
   useEffect(() => {
     if (!targetMessageId) return
-    const target = messageRefs.current[targetMessageId]
-    if (!target) return
+    const card = messageRefs.current[targetMessageId]
+    if (!card) return
 
-    target.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    // Prefer scrolling to the highlighted <mark> inside the card (for long messages),
+    // fall back to the card itself if no highlight exists.
+    const scrollTarget = card.querySelector('mark') ?? card
+
+    let cancelled = false
+    const scrollContainer = card.closest('.overflow-y-auto')
+
+    const isInView = () => {
+      if (!scrollContainer) return false
+      const containerRect = scrollContainer.getBoundingClientRect()
+      const rect = scrollTarget.getBoundingClientRect()
+      return rect.top >= containerRect.top && rect.bottom <= containerRect.bottom
+    }
+
+    const attemptScroll = (remaining: number) => {
+      if (cancelled) return
+      scrollTarget.scrollIntoView({ behavior: 'instant', block: 'center' })
+      if (remaining > 0 && !isInView()) {
+        setTimeout(() => attemptScroll(remaining - 1), 100)
+      }
+    }
+
+    requestAnimationFrame(() => attemptScroll(3))
+
     const timer = window.setTimeout(() => {
       clearTargetMessage()
     }, 1800)
-    return () => window.clearTimeout(timer)
+    return () => {
+      cancelled = true
+      window.clearTimeout(timer)
+    }
   }, [targetMessageId, clearTargetMessage, messages])
 
   const restoreSession = async () => {
@@ -239,6 +266,10 @@ export function HistoryPanel() {
                   content={message.content}
                   renderedContent={highlightText(message.content, searchQuery)}
                 />
+              ) : message.role === 'assistant' && !searchQuery.trim() ? (
+                <div className="text-sm leading-6 text-text-primary prose-sm max-w-none">
+                  <MarkdownRenderer content={message.content} />
+                </div>
               ) : (
                 <div className="text-sm leading-6 text-text-primary whitespace-pre-wrap break-words">
                   {highlightText(message.content, searchQuery)}


### PR DESCRIPTION
## Summary

- **Fix CJK text copy dropping first character**: Chromium 134's `text-spacing-trim` and `text-autospace` compress fullwidth CJK punctuation widths, but selection rectangles are calculated from the original positions. This causes the first glyph after punctuation (：，etc.) to be invisible when selected and lost on copy. Fix: disable both features globally via CSS.
- **Fix search result scroll for long messages**: Previously `scrollIntoView` targeted the message card — for long messages the matched text could be off-screen. Now scrolls to the `<mark>` highlight element within the card. Includes retry mechanism (up to 3 attempts, 100ms apart) for reliable positioning after layout settles.
- **Render assistant messages as Markdown**: Use the existing `MarkdownRenderer` for assistant messages (headings, bold, code blocks, tables render properly). Falls back to plain text with yellow search-term highlighting when a search query is active.
- **Remove `px-0.5` from search highlight `<mark>`**: The inline padding caused text selection boundary offsets at element edges.

## Test plan
- [ ] Copy CJK text containing fullwidth punctuation (：，) — first character after punctuation should be visible in selection and preserved on paste
- [ ] Search a term, click result — highlighted text should appear in first visible screen, even in long messages
- [ ] View history without search — assistant messages should render with proper Markdown formatting
- [ ] View history with search — assistant messages should show plain text with yellow highlights
- [ ] IME input (pinyin) should work normally with no cursor/layout artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)