### PR TITLE
feat: transform task queue into kanban board with session tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ Thumbs.db
 # Planning docs
 next-features.md
 prd-*.md
+docs/
 
 # Environment variables
 .env

--- a/src/main/board-manager.ts
+++ b/src/main/board-manager.ts
@@ -2,18 +2,44 @@ import * as fs from 'fs'
 import * as path from 'path'
 import { app } from 'electron'
 
+export type ColumnBehavior = 'default-inbox' | 'active' | 'terminal' | 'none'
+
+export interface BoardColumn {
+  id: string
+  title: string
+  order: number
+  builtIn: boolean
+  behavior: ColumnBehavior
+  locked?: boolean
+  color?: string
+}
+
 export interface BoardTask {
   id: string
   title: string
   prompt: string
+  notes: string
   cwd: string
   dangerousMode: boolean
   createdAt: number
   updatedAt: number
+  columnId: string
+  order: number
+  sessionId?: string
 }
 
 export interface BoardData {
   tasks: BoardTask[]
+  columns: BoardColumn[]
+}
+
+function createDefaultColumns(): BoardColumn[] {
+  return [
+    { id: crypto.randomUUID(), title: 'Backlog', order: 0, builtIn: true, behavior: 'default-inbox' },
+    { id: crypto.randomUUID(), title: 'Ready', order: 1, builtIn: true, behavior: 'none' },
+    { id: crypto.randomUUID(), title: 'Running', order: 2, builtIn: true, behavior: 'active' },
+    { id: crypto.randomUUID(), title: 'Done', order: 3, builtIn: true, behavior: 'terminal' }
+  ]
 }
 
 class BoardManager {
@@ -26,24 +52,39 @@ class BoardManager {
   load(): BoardData {
     try {
       const raw = fs.readFileSync(this.filePath, 'utf-8')
-      const data = JSON.parse(raw) as BoardData
-      // Migrate old kanban tasks: only keep unrun tasks (status 'todo' or no status)
-      // and strip removed fields
-      const raw_tasks = data.tasks as unknown as Array<Record<string, unknown>>
-      data.tasks = raw_tasks
+      const data = JSON.parse(raw) as Record<string, unknown>
+
+      // Ensure columns exist (migration from flat task list)
+      let columns: BoardColumn[]
+      if (Array.isArray(data.columns) && data.columns.length > 0) {
+        columns = data.columns as BoardColumn[]
+      } else {
+        columns = createDefaultColumns()
+      }
+
+      const inboxColumn = columns.find((c) => c.behavior === 'default-inbox') ?? columns[0]
+
+      // Migrate tasks: filter old kanban statuses, add new fields
+      const rawTasks = (data.tasks ?? []) as Array<Record<string, unknown>>
+      const tasks: BoardTask[] = rawTasks
         .filter((t) => !t.status || t.status === 'todo')
-        .map((t) => ({
+        .map((t, index) => ({
           id: t.id as string,
           title: (t.title as string) ?? '',
           prompt: (t.prompt as string) ?? '',
+          notes: (t.notes as string) ?? '',
           cwd: t.cwd as string,
           dangerousMode: t.dangerousMode === true,
           createdAt: t.createdAt as number,
-          updatedAt: t.updatedAt as number
+          updatedAt: t.updatedAt as number,
+          columnId: (t.columnId as string) ?? inboxColumn.id,
+          order: typeof t.order === 'number' ? (t.order as number) : index,
+          sessionId: (t.sessionId as string) ?? undefined
         }))
-      return data
+
+      return { tasks, columns }
     } catch {
-      return { tasks: [] }
+      return { tasks: [], columns: createDefaultColumns() }
     }
   }
 

--- a/src/main/board-manager.ts
+++ b/src/main/board-manager.ts
@@ -35,7 +35,13 @@ export interface BoardData {
 
 function createDefaultColumns(): BoardColumn[] {
   return [
-    { id: crypto.randomUUID(), title: 'Backlog', order: 0, builtIn: true, behavior: 'default-inbox' },
+    {
+      id: crypto.randomUUID(),
+      title: 'Backlog',
+      order: 0,
+      builtIn: true,
+      behavior: 'default-inbox'
+    },
     { id: crypto.randomUUID(), title: 'Ready', order: 1, builtIn: true, behavior: 'none' },
     { id: crypto.randomUUID(), title: 'Running', order: 2, builtIn: true, behavior: 'active' },
     { id: crypto.randomUUID(), title: 'Done', order: 3, builtIn: true, behavior: 'terminal' }

--- a/src/main/board-manager.ts
+++ b/src/main/board-manager.ts
@@ -14,6 +14,11 @@ export interface BoardColumn {
   color?: string
 }
 
+export interface TagDefinition {
+  name: string
+  color: string
+}
+
 export interface BoardTask {
   id: string
   title: string
@@ -26,11 +31,13 @@ export interface BoardTask {
   columnId: string
   order: number
   sessionId?: string
+  tags: string[]
 }
 
 export interface BoardData {
   tasks: BoardTask[]
   columns: BoardColumn[]
+  tags: TagDefinition[]
 }
 
 function createDefaultColumns(): BoardColumn[] {
@@ -85,12 +92,15 @@ class BoardManager {
           updatedAt: t.updatedAt as number,
           columnId: (t.columnId as string) ?? inboxColumn.id,
           order: typeof t.order === 'number' ? (t.order as number) : index,
-          sessionId: (t.sessionId as string) ?? undefined
+          sessionId: (t.sessionId as string) ?? undefined,
+          tags: Array.isArray(t.tags) ? (t.tags as string[]) : []
         }))
 
-      return { tasks, columns }
+      const tags: TagDefinition[] = Array.isArray(data.tags) ? (data.tags as TagDefinition[]) : []
+
+      return { tasks, columns, tags }
     } catch {
-      return { tasks: [], columns: createDefaultColumns() }
+      return { tasks: [], columns: createDefaultColumns(), tags: [] }
     }
   }
 

--- a/src/main/board-manager.ts
+++ b/src/main/board-manager.ts
@@ -31,6 +31,7 @@ export interface BoardTask {
   columnId: string
   order: number
   sessionId?: string
+  claudeSessionId?: string
   tags: string[]
 }
 
@@ -93,6 +94,7 @@ class BoardManager {
           columnId: (t.columnId as string) ?? inboxColumn.id,
           order: typeof t.order === 'number' ? (t.order as number) : index,
           sessionId: (t.sessionId as string) ?? undefined,
+          claudeSessionId: (t.claudeSessionId as string) ?? undefined,
           tags: Array.isArray(t.tags) ? (t.tags as string[]) : []
         }))
 

--- a/src/main/board-manager.ts
+++ b/src/main/board-manager.ts
@@ -19,6 +19,12 @@ export interface TagDefinition {
   color: string
 }
 
+export interface TaskAttachment {
+  id: string
+  path: string
+  name: string
+}
+
 export interface BoardTask {
   id: string
   title: string
@@ -33,6 +39,7 @@ export interface BoardTask {
   sessionId?: string
   claudeSessionId?: string
   tags: string[]
+  attachments: TaskAttachment[]
 }
 
 export interface BoardData {
@@ -100,7 +107,8 @@ class BoardManager {
           order: typeof t.order === 'number' ? (t.order as number) : index,
           sessionId: (t.sessionId as string) ?? undefined,
           claudeSessionId: (t.claudeSessionId as string) ?? undefined,
-          tags: Array.isArray(t.tags) ? (t.tags as string[]) : []
+          tags: Array.isArray(t.tags) ? (t.tags as string[]) : [],
+          attachments: Array.isArray(t.attachments) ? (t.attachments as TaskAttachment[]) : []
         }))
 
       const tags: TagDefinition[] = Array.isArray(data.tags) ? (data.tags as TagDefinition[]) : []

--- a/src/main/board-manager.ts
+++ b/src/main/board-manager.ts
@@ -51,7 +51,7 @@ function createDefaultColumns(): BoardColumn[] {
       behavior: 'default-inbox'
     },
     { id: crypto.randomUUID(), title: 'Ready', order: 1, builtIn: true, behavior: 'none' },
-    { id: crypto.randomUUID(), title: 'Running', order: 2, builtIn: true, behavior: 'active' },
+    { id: crypto.randomUUID(), title: 'Running', order: 2, builtIn: true, behavior: 'active', locked: true },
     { id: crypto.randomUUID(), title: 'Done', order: 3, builtIn: true, behavior: 'terminal' }
   ]
 }
@@ -75,6 +75,11 @@ class BoardManager {
       } else {
         columns = createDefaultColumns()
       }
+
+      // Migration: lock the active-behavior column
+      columns = columns.map((c) =>
+        c.behavior === 'active' && !c.locked ? { ...c, locked: true } : c
+      )
 
       const inboxColumn = columns.find((c) => c.behavior === 'default-inbox') ?? columns[0]
 

--- a/src/main/ipc-handlers/shell-handlers.ts
+++ b/src/main/ipc-handlers/shell-handlers.ts
@@ -46,12 +46,7 @@ export function registerShellHandlers(): void {
   ipcMain.handle('dialog:openFiles', async (_event) => {
     const win = BrowserWindow.fromWebContents(_event.sender)
     const result = await dialog.showOpenDialog(win!, {
-      properties: ['openFile', 'multiSelections'],
-      filters: [
-        { name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg'] },
-        { name: 'Text Files', extensions: ['csv', 'json', 'txt', 'md', 'ts', 'js', 'py', 'yaml', 'yml'] },
-        { name: 'All Files', extensions: ['*'] }
-      ]
+      properties: ['openFile', 'multiSelections']
     })
     if (result.canceled || result.filePaths.length === 0) {
       return null

--- a/src/main/ipc-handlers/shell-handlers.ts
+++ b/src/main/ipc-handlers/shell-handlers.ts
@@ -42,4 +42,20 @@ export function registerShellHandlers(): void {
     }
     return result.filePaths[0]
   })
+
+  ipcMain.handle('dialog:openFiles', async (_event) => {
+    const win = BrowserWindow.fromWebContents(_event.sender)
+    const result = await dialog.showOpenDialog(win!, {
+      properties: ['openFile', 'multiSelections'],
+      filters: [
+        { name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg'] },
+        { name: 'Text Files', extensions: ['csv', 'json', 'txt', 'md', 'ts', 'js', 'py', 'yaml', 'yml'] },
+        { name: 'All Files', extensions: ['*'] }
+      ]
+    })
+    if (result.canceled || result.filePaths.length === 0) {
+      return null
+    }
+    return result.filePaths
+  })
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -122,6 +122,12 @@ export interface TagDefinition {
   color: string   // Color ID from palette (e.g., 'blue', 'green', 'amber')
 }
 
+export interface TaskAttachment {
+  id: string
+  path: string
+  name: string
+}
+
 export interface BoardTask {
   id: string
   title: string
@@ -136,6 +142,7 @@ export interface BoardTask {
   sessionId?: string
   claudeSessionId?: string
   tags: string[]
+  attachments: TaskAttachment[]
 }
 
 export interface BoardData {
@@ -313,6 +320,7 @@ export interface ElectronAPI {
   checkPort: (port: number) => Promise<boolean>
   openPath: (filePath: string) => Promise<string>
   openFolderDialog: () => Promise<string | null>
+  openFileDialog: () => Promise<string[] | null>
   onUpdateAvailable: (callback: (version: string) => void) => () => void
   onUpdateDownloaded: (callback: (version: string) => void) => () => void
   onDownloadProgress: (callback: (progress: DownloadProgress) => void) => () => void

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -105,18 +105,35 @@ export interface FileReadResult {
   binary: boolean
 }
 
+export type ColumnBehavior = 'default-inbox' | 'active' | 'terminal' | 'none'
+
+export interface BoardColumn {
+  id: string
+  title: string
+  order: number
+  builtIn: boolean
+  behavior: ColumnBehavior
+  locked?: boolean
+  color?: string
+}
+
 export interface BoardTask {
   id: string
   title: string
   prompt: string
+  notes: string
   cwd: string
   dangerousMode: boolean
   createdAt: number
   updatedAt: number
+  columnId: string
+  order: number
+  sessionId?: string
 }
 
 export interface BoardData {
   tasks: BoardTask[]
+  columns: BoardColumn[]
 }
 
 export interface ModelTokenUsage {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -134,6 +134,7 @@ export interface BoardTask {
   columnId: string
   order: number
   sessionId?: string
+  claudeSessionId?: string
   tags: string[]
 }
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -117,6 +117,11 @@ export interface BoardColumn {
   color?: string
 }
 
+export interface TagDefinition {
+  name: string    // Normalized: lowercase, trimmed, no leading #
+  color: string   // Color ID from palette (e.g., 'blue', 'green', 'amber')
+}
+
 export interface BoardTask {
   id: string
   title: string
@@ -129,11 +134,13 @@ export interface BoardTask {
   columnId: string
   order: number
   sessionId?: string
+  tags: string[]
 }
 
 export interface BoardData {
   tasks: BoardTask[]
   columns: BoardColumn[]
+  tags: TagDefinition[]
 }
 
 export interface ModelTokenUsage {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -64,6 +64,7 @@ const electronAPI = {
   openPath: (filePath: string) => ipcRenderer.invoke('shell:openPath', filePath),
 
   openFolderDialog: () => ipcRenderer.invoke('dialog:openFolder'),
+  openFileDialog: () => ipcRenderer.invoke('dialog:openFiles'),
 
   onUpdateAvailable: (callback: (version: string) => void) =>
     createIpcListener<[string]>('updater:update-available', callback),

--- a/src/renderer/src/components/board/AttachmentList.tsx
+++ b/src/renderer/src/components/board/AttachmentList.tsx
@@ -51,7 +51,9 @@ export function AttachmentList({ attachments, onChange }: AttachmentListProps) {
     }
   }, [attachments, thumbnails])
 
-  const handleAddFiles = useCallback(async () => {
+  const handleAddFiles = useCallback(async (e: React.MouseEvent) => {
+    e.stopPropagation()
+    e.preventDefault()
     const paths = await window.electronAPI?.openFileDialog()
     if (!paths) return
 
@@ -116,7 +118,11 @@ export function AttachmentList({ attachments, onChange }: AttachmentListProps) {
   }, [])
 
   return (
-    <div>
+    <div
+      onDrop={handleDrop}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+    >
       <label className="block text-xs font-medium text-text-secondary mb-1">
         Attachments
       </label>
@@ -147,7 +153,10 @@ export function AttachmentList({ attachments, onChange }: AttachmentListProps) {
               </span>
               <button
                 type="button"
-                onClick={() => handleRemove(a.id)}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  handleRemove(a.id)
+                }}
                 className="w-4 h-4 flex items-center justify-center rounded opacity-0 group-hover/attachment:opacity-100 hover:bg-surface-300 text-text-tertiary hover:text-text-primary transition-all flex-shrink-0"
               >
                 <XMarkIcon className="w-3 h-3" />
@@ -159,9 +168,6 @@ export function AttachmentList({ attachments, onChange }: AttachmentListProps) {
 
       {/* Drop zone / add button */}
       <div
-        onDrop={handleDrop}
-        onDragOver={handleDragOver}
-        onDragLeave={handleDragLeave}
         className={`flex items-center justify-center gap-1.5 h-8 rounded-lg border border-dashed text-xs transition-colors cursor-pointer ${
           isDragOver
             ? 'border-accent bg-accent/5 text-accent'

--- a/src/renderer/src/components/board/AttachmentList.tsx
+++ b/src/renderer/src/components/board/AttachmentList.tsx
@@ -1,0 +1,177 @@
+import { useState, useCallback, useEffect } from 'react'
+import { PaperClipIcon, XMarkIcon, PhotoIcon, DocumentTextIcon } from '@heroicons/react/24/outline'
+import type { TaskAttachment } from '../../../../preload/index.d'
+
+const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico'])
+
+function isImageFile(name: string): boolean {
+  const ext = name.split('.').pop()?.toLowerCase() ?? ''
+  return IMAGE_EXTENSIONS.has(ext)
+}
+
+function basename(filePath: string): string {
+  return filePath.split('/').pop() ?? filePath
+}
+
+interface AttachmentListProps {
+  attachments: TaskAttachment[]
+  onChange: (attachments: TaskAttachment[]) => void
+}
+
+export function AttachmentList({ attachments, onChange }: AttachmentListProps) {
+  const [thumbnails, setThumbnails] = useState<Record<string, string>>({})
+  const [isDragOver, setIsDragOver] = useState(false)
+
+  // Load thumbnails for image attachments
+  useEffect(() => {
+    let cancelled = false
+    const imageAttachments = attachments.filter((a) => isImageFile(a.name))
+    const missing = imageAttachments.filter((a) => !thumbnails[a.id])
+
+    if (missing.length === 0) return
+
+    Promise.all(
+      missing.map(async (a) => {
+        const dataUrl = await window.electronAPI?.readImageAsDataUrl(a.path)
+        return { id: a.id, dataUrl }
+      })
+    ).then((results) => {
+      if (cancelled) return
+      setThumbnails((prev) => {
+        const next = { ...prev }
+        for (const r of results) {
+          if (r.dataUrl) next[r.id] = r.dataUrl
+        }
+        return next
+      })
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [attachments, thumbnails])
+
+  const handleAddFiles = useCallback(async () => {
+    const paths = await window.electronAPI?.openFileDialog()
+    if (!paths) return
+
+    const newAttachments: TaskAttachment[] = paths
+      .filter((p) => !attachments.some((a) => a.path === p))
+      .map((p) => ({
+        id: crypto.randomUUID(),
+        path: p,
+        name: basename(p)
+      }))
+
+    if (newAttachments.length > 0) {
+      onChange([...attachments, ...newAttachments])
+    }
+  }, [attachments, onChange])
+
+  const handleRemove = useCallback(
+    (id: string) => {
+      onChange(attachments.filter((a) => a.id !== id))
+      setThumbnails((prev) => {
+        const next = { ...prev }
+        delete next[id]
+        return next
+      })
+    },
+    [attachments, onChange]
+  )
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault()
+      setIsDragOver(false)
+
+      const files = Array.from(e.dataTransfer.files)
+      const newAttachments: TaskAttachment[] = files
+        .map((f) => {
+          const path = window.electronAPI?.getPathForFile(f)
+          if (!path) return null
+          if (attachments.some((a) => a.path === path)) return null
+          return {
+            id: crypto.randomUUID() as string,
+            path,
+            name: f.name
+          }
+        })
+        .filter((a): a is TaskAttachment => a !== null)
+
+      if (newAttachments.length > 0) {
+        onChange([...attachments, ...newAttachments])
+      }
+    },
+    [attachments, onChange]
+  )
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    setIsDragOver(true)
+  }, [])
+
+  const handleDragLeave = useCallback(() => {
+    setIsDragOver(false)
+  }, [])
+
+  return (
+    <div>
+      <label className="block text-xs font-medium text-text-secondary mb-1">
+        Attachments
+      </label>
+
+      {/* File list */}
+      {attachments.length > 0 && (
+        <div className="space-y-1.5 mb-2">
+          {attachments.map((a) => (
+            <div
+              key={a.id}
+              className="flex items-center gap-2 px-2.5 py-1.5 rounded-lg bg-surface-200 group/attachment"
+            >
+              {isImageFile(a.name) ? (
+                thumbnails[a.id] ? (
+                  <img
+                    src={thumbnails[a.id]}
+                    alt={a.name}
+                    className="w-6 h-6 rounded object-cover flex-shrink-0"
+                  />
+                ) : (
+                  <PhotoIcon className="w-4 h-4 text-text-tertiary flex-shrink-0" />
+                )
+              ) : (
+                <DocumentTextIcon className="w-4 h-4 text-text-tertiary flex-shrink-0" />
+              )}
+              <span className="text-xs text-text-primary truncate flex-1" title={a.path}>
+                {a.name}
+              </span>
+              <button
+                type="button"
+                onClick={() => handleRemove(a.id)}
+                className="w-4 h-4 flex items-center justify-center rounded opacity-0 group-hover/attachment:opacity-100 hover:bg-surface-300 text-text-tertiary hover:text-text-primary transition-all flex-shrink-0"
+              >
+                <XMarkIcon className="w-3 h-3" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Drop zone / add button */}
+      <div
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        className={`flex items-center justify-center gap-1.5 h-8 rounded-lg border border-dashed text-xs transition-colors cursor-pointer ${
+          isDragOver
+            ? 'border-accent bg-accent/5 text-accent'
+            : 'border-border-subtle text-text-tertiary hover:border-border hover:text-text-secondary'
+        }`}
+        onClick={handleAddFiles}
+      >
+        <PaperClipIcon className="w-3.5 h-3.5" />
+        {isDragOver ? 'Drop files here' : 'Add files or drop here'}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/board/KanbanBoard.tsx
+++ b/src/renderer/src/components/board/KanbanBoard.tsx
@@ -1,51 +1,49 @@
 import { useState, useCallback, useMemo } from 'react'
-import { MagnifyingGlassIcon, PlusIcon, FolderIcon } from '@heroicons/react/24/outline'
+import { PlusIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline'
 import { useBoardStore } from '../../store/board-store'
 import { useSessionStore } from '../../store/session-store'
 import { useBoardPersistence } from '../../hooks/use-board-persistence'
+import { KanbanColumn } from './KanbanColumn'
 import { TaskForm } from './TaskForm'
+import { TaskDetailPanel } from './TaskDetailPanel'
 import { ContextMenu } from '../ui/ContextMenu'
-import { cn } from '../../lib/utils'
 import type { BoardTask } from '../../../../preload/index.d'
-
-function shortenCwd(cwd: string): string {
-  const parts = cwd.split('/')
-  if (parts.length <= 3) return cwd
-  return '~/' + parts.slice(-2).join('/')
-}
-
-function formatDate(ts: number): string {
-  const d = new Date(ts)
-  const now = new Date()
-  const diffMs = now.getTime() - d.getTime()
-  const diffMin = Math.floor(diffMs / 60000)
-  if (diffMin < 1) return 'just now'
-  if (diffMin < 60) return `${diffMin}m ago`
-  const diffHr = Math.floor(diffMin / 60)
-  if (diffHr < 24) return `${diffHr}h ago`
-  const diffDay = Math.floor(diffHr / 24)
-  if (diffDay < 7) return `${diffDay}d ago`
-  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
-}
 
 export function TaskQueue() {
   const tasks = useBoardStore((s) => s.tasks)
-  const removeTask = useBoardStore((s) => s.removeTask)
+  const columns = useBoardStore((s) => s.columns)
   const deleteTask = useBoardStore((s) => s.deleteTask)
+  const moveTask = useBoardStore((s) => s.moveTask)
+  const updateTask = useBoardStore((s) => s.updateTask)
+  const addColumn = useBoardStore((s) => s.addColumn)
+  const updateColumn = useBoardStore((s) => s.updateColumn)
+  const deleteColumn = useBoardStore((s) => s.deleteColumn)
+  const getColumnByBehavior = useBoardStore((s) => s.getColumnByBehavior)
 
   const addSession = useSessionStore((s) => s.addSession)
 
+  useBoardPersistence()
+
   const [formOpen, setFormOpen] = useState(false)
+  const [formColumnId, setFormColumnId] = useState<string | undefined>(undefined)
   const [editTask, setEditTask] = useState<BoardTask | null>(null)
+  const [detailTask, setDetailTask] = useState<BoardTask | null>(null)
   const [search, setSearch] = useState('')
 
   const [contextMenu, setContextMenu] = useState<{
-    x: number
-    y: number
+    x: number; y: number
     items: { label: string; onClick: () => void; danger?: boolean }[]
   } | null>(null)
 
-  useBoardPersistence()
+  const sortedColumns = useMemo(
+    () => [...columns].sort((a, b) => a.order - b.order),
+    [columns]
+  )
+
+  const inboxColumnCount = useMemo(
+    () => columns.filter((c) => c.behavior === 'default-inbox').length,
+    [columns]
+  )
 
   const filteredTasks = useMemo(() => {
     if (!search.trim()) return tasks
@@ -54,27 +52,73 @@ export function TaskQueue() {
       (t) =>
         t.title.toLowerCase().includes(q) ||
         t.prompt.toLowerCase().includes(q) ||
+        t.notes.toLowerCase().includes(q) ||
         t.cwd.toLowerCase().includes(q)
     )
   }, [tasks, search])
 
-  const handleEdit = useCallback((task: BoardTask) => {
-    setEditTask(task)
+  const tasksByColumn = useMemo(() => {
+    const map = new Map<string, BoardTask[]>()
+    for (const col of columns) {
+      map.set(col.id, [])
+    }
+    for (const task of filteredTasks) {
+      const arr = map.get(task.columnId)
+      if (arr) arr.push(task)
+    }
+    return map
+  }, [columns, filteredTasks])
+
+  const handleAddTask = useCallback((columnId: string) => {
+    setEditTask(null)
+    setFormColumnId(columnId)
     setFormOpen(true)
   }, [])
 
-  const handleNewTask = useCallback(() => {
-    setEditTask(null)
+  const handleEditTask = useCallback((task: BoardTask) => {
+    setEditTask(task)
+    setFormColumnId(undefined)
     setFormOpen(true)
   }, [])
 
   const handleCloseForm = useCallback(() => {
     setFormOpen(false)
     setEditTask(null)
+    setFormColumnId(undefined)
   }, [])
+
+  const handleClickTask = useCallback((task: BoardTask) => {
+    const current = useBoardStore.getState().tasks.find((t) => t.id === task.id)
+    setDetailTask(current ?? task)
+  }, [])
+
+  const handleCloseDetail = useCallback(() => {
+    setDetailTask(null)
+  }, [])
+
+  const handleContextMenuTask = useCallback(
+    (e: React.MouseEvent, task: BoardTask) => {
+      e.preventDefault()
+      setContextMenu({
+        x: e.clientX,
+        y: e.clientY,
+        items: [
+          { label: 'Edit', onClick: () => handleEditTask(task) },
+          { label: 'Delete', onClick: () => deleteTask(task.id), danger: true }
+        ]
+      })
+    },
+    [handleEditTask, deleteTask]
+  )
 
   const runTask = useCallback(
     async (task: BoardTask) => {
+      if (!task.prompt.trim()) {
+        const current = useBoardStore.getState().tasks.find((t) => t.id === task.id)
+        setDetailTask(current ?? task)
+        return
+      }
+
       if (!window.electronAPI?.spawnSession) return
 
       const dangerousMode = task.dangerousMode ?? false
@@ -97,7 +141,12 @@ export function TaskQueue() {
         sessionType: 'local'
       })
 
-      removeTask(task.id)
+      const activeCol = getColumnByBehavior('active')
+      if (activeCol) {
+        moveTask(task.id, activeCol.id, 0)
+      }
+      updateTask(task.id, { sessionId: sessionInfo.id })
+
       useSessionStore.getState().selectSession(sessionInfo.id, false)
 
       if (task.prompt) {
@@ -124,27 +173,16 @@ export function TaskQueue() {
         setTimeout(sendPrompt, 20000)
       }
     },
-    [addSession, removeTask]
+    [addSession, moveTask, updateTask, getColumnByBehavior]
   )
 
-  const handleContextMenu = useCallback(
-    (e: React.MouseEvent, task: BoardTask) => {
-      e.preventDefault()
-      setContextMenu({
-        x: e.clientX,
-        y: e.clientY,
-        items: [
-          { label: 'Edit', onClick: () => handleEdit(task) },
-          { label: 'Delete', onClick: () => deleteTask(task.id), danger: true }
-        ]
-      })
-    },
-    [handleEdit, deleteTask]
-  )
+  const handleAddNewColumn = useCallback(() => {
+    addColumn('New Column')
+  }, [addColumn])
 
   return (
     <div className="flex-1 flex flex-col min-h-0 bg-surface-0">
-      {/* Search bar + actions */}
+      {/* Top bar: search */}
       <div className="flex items-center gap-2 px-4 py-3 border-b border-border-subtle flex-shrink-0">
         <div className="flex-1 relative">
           <MagnifyingGlassIcon className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-tertiary pointer-events-none" />
@@ -152,112 +190,53 @@ export function TaskQueue() {
             type="text"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search tasks by prompt or folder..."
+            placeholder="Search tasks..."
             className="w-full h-7 pl-8 pr-3 rounded bg-surface-100 border border-border-subtle text-xs text-text-primary placeholder:text-text-tertiary outline-none focus:ring-1 focus:ring-accent/40 focus:border-accent/40 transition-all"
           />
         </div>
-        <button
-          onClick={handleNewTask}
-          className="h-7 px-2.5 rounded text-xs font-medium bg-accent text-white hover:bg-accent/90 transition-colors flex items-center gap-1.5 flex-shrink-0"
-        >
-          <PlusIcon className="w-3 h-3" />
-          Add Task
-        </button>
       </div>
 
-      {/* Task list */}
-      <div className="flex-1 overflow-y-auto">
-        {filteredTasks.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-20 text-text-tertiary">
-            {tasks.length === 0 ? (
-              <>
-                <div className="w-10 h-10 rounded-xl bg-surface-100 flex items-center justify-center mb-3">
-                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" className="opacity-40">
-                    <path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                  </svg>
-                </div>
-                <span className="text-sm font-medium text-text-secondary">No tasks yet</span>
-                <span className="text-xs mt-1">Create tasks to queue them for later</span>
-              </>
-            ) : (
-              <>
-                <span className="text-sm font-medium text-text-secondary">No matching tasks</span>
-                <span className="text-xs mt-1">Try a different search term</span>
-              </>
-            )}
-          </div>
-        ) : (
-          <div className="divide-y divide-border-subtle">
-            {filteredTasks.map((task) => (
-              <div
-                key={task.id}
-                onContextMenu={(e) => handleContextMenu(e, task)}
-                className="group flex items-center gap-4 px-4 py-3 hover:bg-surface-50 transition-colors cursor-default"
-              >
-                {/* Left content */}
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
-                    {task.title ? (
-                      <span className="text-sm font-medium text-text-primary truncate">
-                        {task.title}
-                      </span>
-                    ) : (
-                      <span className="text-sm text-text-primary truncate">
-                        {task.prompt}
-                      </span>
-                    )}
-                    {task.dangerousMode && (
-                      <span className="flex-shrink-0 px-1.5 py-0.5 rounded text-[10px] font-medium bg-red-500/10 text-red-400">
-                        skip-perms
-                      </span>
-                    )}
-                  </div>
+      {/* Board: horizontal scrolling columns */}
+      <div className="flex-1 overflow-x-auto overflow-y-hidden p-4">
+        <div className="flex gap-4 h-full items-start">
+          {sortedColumns.map((column) => (
+            <KanbanColumn
+              key={column.id}
+              column={column}
+              tasks={tasksByColumn.get(column.id) ?? []}
+              onAddTask={handleAddTask}
+              onRunTask={runTask}
+              onClickTask={handleClickTask}
+              onContextMenuTask={handleContextMenuTask}
+              onRenameColumn={(id, title) => updateColumn(id, { title })}
+              onDeleteColumn={deleteColumn}
+              onAddColumnAfter={(id) => addColumn('New Column', id)}
+              isOnlyInbox={inboxColumnCount <= 1}
+            />
+          ))}
 
-                  {/* Description line: prompt (if title exists) + metadata */}
-                  <div className="flex items-center gap-2 mt-1">
-                    {task.title && task.prompt && (
-                      <span className="text-xs text-text-tertiary truncate max-w-[300px]">
-                        {task.prompt}
-                      </span>
-                    )}
-                    {task.title && task.prompt && (
-                      <span className="text-text-tertiary/30">·</span>
-                    )}
-                    <span className="flex items-center gap-1 text-[11px] text-text-tertiary flex-shrink-0">
-                      <FolderIcon className="w-3 h-3" />
-                      <span className="truncate max-w-[160px]" title={task.cwd}>
-                        {shortenCwd(task.cwd)}
-                      </span>
-                    </span>
-                    <span className="text-text-tertiary/30">·</span>
-                    <span className="text-[11px] text-text-tertiary flex-shrink-0">
-                      {formatDate(task.createdAt)}
-                    </span>
-                  </div>
-                </div>
-
-                {/* Run button — visible on hover */}
-                <button
-                  onClick={() => runTask(task)}
-                  className={cn(
-                    'flex-shrink-0 h-7 px-3 rounded-md text-xs font-medium transition-all flex items-center gap-1.5',
-                    'bg-green-500/10 hover:bg-green-500/20 text-green-500',
-                    'opacity-0 group-hover:opacity-100'
-                  )}
-                  title="Run this task"
-                >
-                  <svg width="10" height="10" viewBox="0 0 12 12" fill="none">
-                    <path d="M3 1.5L10 6L3 10.5V1.5Z" fill="currentColor" />
-                  </svg>
-                  Run
-                </button>
-              </div>
-            ))}
-          </div>
-        )}
+          {/* Add column button */}
+          <button
+            onClick={handleAddNewColumn}
+            className="w-72 flex-shrink-0 h-12 rounded-xl border-2 border-dashed border-border-subtle hover:border-border text-text-tertiary hover:text-text-secondary flex items-center justify-center gap-2 text-sm transition-colors"
+          >
+            <PlusIcon className="w-4 h-4" />
+            Add Column
+          </button>
+        </div>
       </div>
 
-      <TaskForm isOpen={formOpen} onClose={handleCloseForm} editTask={editTask} />
+      <TaskForm
+        isOpen={formOpen}
+        onClose={handleCloseForm}
+        columnId={formColumnId}
+        editTask={editTask}
+      />
+
+      <TaskDetailPanel
+        task={detailTask}
+        onClose={handleCloseDetail}
+      />
 
       {contextMenu && (
         <ContextMenu

--- a/src/renderer/src/components/board/KanbanBoard.tsx
+++ b/src/renderer/src/components/board/KanbanBoard.tsx
@@ -8,6 +8,7 @@ import { KanbanColumn } from './KanbanColumn'
 import { useBoardDnd } from '../../hooks/use-board-dnd'
 import { TaskForm } from './TaskForm'
 import { TaskDetailPanel } from './TaskDetailPanel'
+import { TagPill } from './TagPill'
 import { ContextMenu } from '../ui/ContextMenu'
 import { ConfirmDialog } from '../ui/ConfirmDialog'
 import type { BoardTask } from '../../../../preload/index.d'
@@ -22,6 +23,9 @@ export function TaskQueue() {
   const updateColumn = useBoardStore((s) => s.updateColumn)
   const deleteColumn = useBoardStore((s) => s.deleteColumn)
   const getColumnByBehavior = useBoardStore((s) => s.getColumnByBehavior)
+  const boardTags = useBoardStore((s) => s.tags)
+  const activeTagFilter = useBoardStore((s) => s.activeTagFilter)
+  const setActiveTagFilter = useBoardStore((s) => s.setActiveTagFilter)
 
   const addSession = useSessionStore((s) => s.addSession)
 
@@ -51,16 +55,22 @@ export function TaskQueue() {
   )
 
   const filteredTasks = useMemo(() => {
-    if (!search.trim()) return tasks
-    const q = search.toLowerCase()
-    return tasks.filter(
-      (t) =>
-        t.title.toLowerCase().includes(q) ||
-        t.prompt.toLowerCase().includes(q) ||
-        t.notes.toLowerCase().includes(q) ||
-        t.cwd.toLowerCase().includes(q)
-    )
-  }, [tasks, search])
+    let result = tasks
+    if (search.trim()) {
+      const q = search.toLowerCase()
+      result = result.filter(
+        (t) =>
+          t.title.toLowerCase().includes(q) ||
+          t.prompt.toLowerCase().includes(q) ||
+          t.notes.toLowerCase().includes(q) ||
+          t.cwd.toLowerCase().includes(q)
+      )
+    }
+    if (activeTagFilter) {
+      result = result.filter((t) => t.tags?.includes(activeTagFilter))
+    }
+    return result
+  }, [tasks, search, activeTagFilter])
 
   const tasksByColumn = useMemo(() => {
     const map = new Map<string, BoardTask[]>()
@@ -244,18 +254,45 @@ export function TaskQueue() {
 
   return (
     <div className="flex-1 flex flex-col min-h-0 min-w-0 bg-surface-0">
-      {/* Top bar: search */}
-      <div className="flex items-center gap-2 px-4 py-3 border-b border-border-subtle flex-shrink-0">
-        <div className="flex-1 relative">
-          <MagnifyingGlassIcon className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-tertiary pointer-events-none" />
-          <input
-            type="text"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search tasks..."
-            className="w-full h-7 pl-8 pr-3 rounded bg-surface-100 border border-border-subtle text-xs text-text-primary placeholder:text-text-tertiary outline-none focus:ring-1 focus:ring-accent/40 focus:border-accent/40 transition-all"
-          />
+      {/* Top bar: search + tag filter */}
+      <div className="flex flex-col border-b border-border-subtle flex-shrink-0">
+        <div className="flex items-center gap-2 px-4 py-3">
+          <div className="flex-1 relative">
+            <MagnifyingGlassIcon className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-tertiary pointer-events-none" />
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search tasks..."
+              className="w-full h-7 pl-8 pr-3 rounded bg-surface-100 border border-border-subtle text-xs text-text-primary placeholder:text-text-tertiary outline-none focus:ring-1 focus:ring-accent/40 focus:border-accent/40 transition-all"
+            />
+          </div>
         </div>
+        {boardTags.length > 0 && (
+          <div className="flex items-center gap-1.5 px-4 pb-3 flex-wrap">
+            <span className="text-[11px] text-text-tertiary mr-0.5">Filter:</span>
+            {boardTags.map((tag) => (
+              <TagPill
+                key={tag.name}
+                name={tag.name}
+                color={tag.color}
+                size="md"
+                active={activeTagFilter === tag.name}
+                onClick={() =>
+                  setActiveTagFilter(activeTagFilter === tag.name ? null : tag.name)
+                }
+              />
+            ))}
+            {activeTagFilter && (
+              <button
+                onClick={() => setActiveTagFilter(null)}
+                className="text-[11px] text-text-tertiary hover:text-text-secondary ml-1"
+              >
+                Clear
+              </button>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Board: horizontal scrolling columns */}

--- a/src/renderer/src/components/board/KanbanBoard.tsx
+++ b/src/renderer/src/components/board/KanbanBoard.tsx
@@ -220,11 +220,17 @@ export function TaskQueue() {
         let sent = false
         let debounceTimer: ReturnType<typeof setTimeout> | null = null
 
+        // Prepend file paths for attachments
+        const filePaths = (task.attachments ?? []).map((a) => a.path)
+        const fullPrompt = filePaths.length > 0
+          ? filePaths.join('\n') + '\n\n' + task.prompt
+          : task.prompt
+
         const sendPrompt = (): void => {
           if (sent) return
           sent = true
           if (debounceTimer) clearTimeout(debounceTimer)
-          window.electronAPI?.writeSession(sessionInfo.id, task.prompt)
+          window.electronAPI?.writeSession(sessionInfo.id, fullPrompt)
           setTimeout(() => {
             window.electronAPI?.writeSession(sessionInfo.id, '\r')
           }, 150)

--- a/src/renderer/src/components/board/KanbanBoard.tsx
+++ b/src/renderer/src/components/board/KanbanBoard.tsx
@@ -138,13 +138,19 @@ export function TaskQueue() {
       const existingSession = task.sessionId
         ? useSessionStore.getState().sessions.find((s) => s.id === task.sessionId)
         : undefined
-      const canResume = existingSession && !existingSession.alive && existingSession.claudeSessionId
+      const canResumeFromSession = existingSession && !existingSession.alive && existingSession.claudeSessionId
 
-      if (canResume) {
-        // Resume the previous Claude session
+      // Cold-start fallback: use persisted claudeSessionId when runtime session is gone
+      const resumeId = canResumeFromSession
+        ? existingSession.claudeSessionId!
+        : (!existingSession && task.claudeSessionId)
+          ? task.claudeSessionId
+          : null
+
+      if (resumeId) {
         const sessionInfo = await window.electronAPI.spawnSession(task.cwd, {
           claudeMode: true,
-          resumeSessionId: existingSession.claudeSessionId!
+          resumeSessionId: resumeId
         })
 
         addSession({
@@ -165,7 +171,7 @@ export function TaskQueue() {
         if (activeCol) {
           moveTask(task.id, activeCol.id, 0)
         }
-        updateTask(task.id, { sessionId: sessionInfo.id })
+        updateTask(task.id, { sessionId: sessionInfo.id, claudeSessionId: sessionInfo.claudeSessionId ?? undefined })
 
         useSessionStore.getState().selectSession(sessionInfo.id, false)
         return
@@ -202,7 +208,7 @@ export function TaskQueue() {
       if (activeCol) {
         moveTask(task.id, activeCol.id, 0)
       }
-      updateTask(task.id, { sessionId: sessionInfo.id })
+      updateTask(task.id, { sessionId: sessionInfo.id, claudeSessionId: sessionInfo.claudeSessionId ?? undefined })
 
       useSessionStore.getState().selectSession(sessionInfo.id, false)
 

--- a/src/renderer/src/components/board/KanbanBoard.tsx
+++ b/src/renderer/src/components/board/KanbanBoard.tsx
@@ -302,7 +302,12 @@ export function TaskQueue() {
         editTask={editTask}
       />
 
-      <TaskDetailPanel task={detailTask} onClose={handleCloseDetail} />
+      <TaskDetailPanel
+        task={detailTask}
+        onClose={handleCloseDetail}
+        onRunTask={runTask}
+        onViewSession={handleViewSession}
+      />
 
       {contextMenu && (
         <ContextMenu

--- a/src/renderer/src/components/board/KanbanBoard.tsx
+++ b/src/renderer/src/components/board/KanbanBoard.tsx
@@ -97,6 +97,10 @@ export function TaskQueue() {
     setDetailTask(null)
   }, [])
 
+  const handleViewSession = useCallback((sessionId: string) => {
+    useSessionStore.getState().selectSession(sessionId, false)
+  }, [])
+
   const handleContextMenuTask = useCallback(
     (e: React.MouseEvent, task: BoardTask) => {
       e.preventDefault()
@@ -209,6 +213,7 @@ export function TaskQueue() {
               onRunTask={runTask}
               onClickTask={handleClickTask}
               onContextMenuTask={handleContextMenuTask}
+              onViewSession={handleViewSession}
               onRenameColumn={(id, title) => updateColumn(id, { title })}
               onDeleteColumn={deleteColumn}
               onAddColumnAfter={(id) => addColumn('New Column', id)}

--- a/src/renderer/src/components/board/KanbanBoard.tsx
+++ b/src/renderer/src/components/board/KanbanBoard.tsx
@@ -34,14 +34,12 @@ export function TaskQueue() {
   const [search, setSearch] = useState('')
 
   const [contextMenu, setContextMenu] = useState<{
-    x: number; y: number
+    x: number
+    y: number
     items: { label: string; onClick: () => void; danger?: boolean }[]
   } | null>(null)
 
-  const sortedColumns = useMemo(
-    () => [...columns].sort((a, b) => a.order - b.order),
-    [columns]
-  )
+  const sortedColumns = useMemo(() => [...columns].sort((a, b) => a.order - b.order), [columns])
 
   const inboxColumnCount = useMemo(
     () => columns.filter((c) => c.behavior === 'default-inbox').length,
@@ -239,10 +237,7 @@ export function TaskQueue() {
         editTask={editTask}
       />
 
-      <TaskDetailPanel
-        task={detailTask}
-        onClose={handleCloseDetail}
-      />
+      <TaskDetailPanel task={detailTask} onClose={handleCloseDetail} />
 
       {contextMenu && (
         <ContextMenu

--- a/src/renderer/src/components/board/KanbanBoard.tsx
+++ b/src/renderer/src/components/board/KanbanBoard.tsx
@@ -3,11 +3,13 @@ import { PlusIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline'
 import { useBoardStore } from '../../store/board-store'
 import { useSessionStore } from '../../store/session-store'
 import { useBoardPersistence } from '../../hooks/use-board-persistence'
+import { useBoardSessionSync } from '../../hooks/use-board-session-sync'
 import { KanbanColumn } from './KanbanColumn'
 import { useBoardDnd } from '../../hooks/use-board-dnd'
 import { TaskForm } from './TaskForm'
 import { TaskDetailPanel } from './TaskDetailPanel'
 import { ContextMenu } from '../ui/ContextMenu'
+import { ConfirmDialog } from '../ui/ConfirmDialog'
 import type { BoardTask } from '../../../../preload/index.d'
 
 export function TaskQueue() {
@@ -24,6 +26,7 @@ export function TaskQueue() {
   const addSession = useSessionStore((s) => s.addSession)
 
   useBoardPersistence()
+  useBoardSessionSync()
 
   const { draggingTaskId, dropTarget, onPointerDown } = useBoardDnd()
 
@@ -38,6 +41,7 @@ export function TaskQueue() {
     y: number
     items: { label: string; onClick: () => void; danger?: boolean }[]
   } | null>(null)
+  const [deleteTaskTarget, setDeleteTaskTarget] = useState<BoardTask | null>(null)
 
   const sortedColumns = useMemo(() => [...columns].sort((a, b) => a.order - b.order), [columns])
 
@@ -109,22 +113,60 @@ export function TaskQueue() {
         y: e.clientY,
         items: [
           { label: 'Edit', onClick: () => handleEditTask(task) },
-          { label: 'Delete', onClick: () => deleteTask(task.id), danger: true }
+          { label: 'Delete', onClick: () => setDeleteTaskTarget(task), danger: true }
         ]
       })
     },
-    [handleEditTask, deleteTask]
+    [handleEditTask]
   )
 
   const runTask = useCallback(
     async (task: BoardTask) => {
+      if (!window.electronAPI?.spawnSession) return
+
+      // Check if this task has an ended session we can resume
+      const existingSession = task.sessionId
+        ? useSessionStore.getState().sessions.find((s) => s.id === task.sessionId)
+        : undefined
+      const canResume = existingSession && !existingSession.alive && existingSession.claudeSessionId
+
+      if (canResume) {
+        // Resume the previous Claude session
+        const sessionInfo = await window.electronAPI.spawnSession(task.cwd, {
+          claudeMode: true,
+          resumeSessionId: existingSession.claudeSessionId!
+        })
+
+        addSession({
+          id: sessionInfo.id,
+          cwd: sessionInfo.cwd,
+          folderName: sessionInfo.folderName,
+          name: task.title || task.prompt.slice(0, 40),
+          alive: sessionInfo.alive,
+          activityStatus: 'idle',
+          promptWaiting: null,
+          claudeMode: true,
+          dangerousMode: task.dangerousMode ?? false,
+          claudeSessionId: sessionInfo.claudeSessionId,
+          sessionType: 'local'
+        })
+
+        const activeCol = getColumnByBehavior('active')
+        if (activeCol) {
+          moveTask(task.id, activeCol.id, 0)
+        }
+        updateTask(task.id, { sessionId: sessionInfo.id })
+
+        useSessionStore.getState().selectSession(sessionInfo.id, false)
+        return
+      }
+
+      // Fresh run — requires a prompt
       if (!task.prompt.trim()) {
         const current = useBoardStore.getState().tasks.find((t) => t.id === task.id)
         setDetailTask(current ?? task)
         return
       }
-
-      if (!window.electronAPI?.spawnSession) return
 
       const dangerousMode = task.dangerousMode ?? false
       const sessionInfo = await window.electronAPI.spawnSession(task.cwd, {
@@ -181,12 +223,27 @@ export function TaskQueue() {
     [addSession, moveTask, updateTask, getColumnByBehavior]
   )
 
+  const reorderColumns = useBoardStore((s) => s.reorderColumns)
+
+  const handleMoveColumn = useCallback(
+    (columnId: string, direction: 'left' | 'right') => {
+      const ids = sortedColumns.map((c) => c.id)
+      const idx = ids.indexOf(columnId)
+      if (idx < 0) return
+      const swapIdx = direction === 'left' ? idx - 1 : idx + 1
+      if (swapIdx < 0 || swapIdx >= ids.length) return
+      ;[ids[idx], ids[swapIdx]] = [ids[swapIdx], ids[idx]]
+      reorderColumns(ids)
+    },
+    [sortedColumns, reorderColumns]
+  )
+
   const handleAddNewColumn = useCallback(() => {
     addColumn('New Column')
   }, [addColumn])
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 bg-surface-0">
+    <div className="flex-1 flex flex-col min-h-0 min-w-0 bg-surface-0">
       {/* Top bar: search */}
       <div className="flex items-center gap-2 px-4 py-3 border-b border-border-subtle flex-shrink-0">
         <div className="flex-1 relative">
@@ -203,8 +260,8 @@ export function TaskQueue() {
 
       {/* Board: horizontal scrolling columns */}
       <div className="flex-1 overflow-x-auto overflow-y-hidden p-4">
-        <div className="flex gap-4 h-full items-start">
-          {sortedColumns.map((column) => (
+        <div className="flex gap-4 h-full items-start min-w-min">
+          {sortedColumns.map((column, idx) => (
             <KanbanColumn
               key={column.id}
               column={column}
@@ -217,6 +274,9 @@ export function TaskQueue() {
               onRenameColumn={(id, title) => updateColumn(id, { title })}
               onDeleteColumn={deleteColumn}
               onAddColumnAfter={(id) => addColumn('New Column', id)}
+              onMoveColumn={handleMoveColumn}
+              isFirst={idx === 0}
+              isLast={idx === sortedColumns.length - 1}
               isOnlyInbox={inboxColumnCount <= 1}
               draggingTaskId={draggingTaskId}
               dropTarget={dropTarget}
@@ -252,6 +312,18 @@ export function TaskQueue() {
           onClose={() => setContextMenu(null)}
         />
       )}
+
+      <ConfirmDialog
+        isOpen={deleteTaskTarget !== null}
+        title="Delete task?"
+        message={`"${deleteTaskTarget?.title || deleteTaskTarget?.prompt?.slice(0, 40) || 'Untitled'}" will be permanently deleted.`}
+        confirmLabel="Delete"
+        onConfirm={() => {
+          if (deleteTaskTarget) deleteTask(deleteTaskTarget.id)
+          setDeleteTaskTarget(null)
+        }}
+        onCancel={() => setDeleteTaskTarget(null)}
+      />
     </div>
   )
 }

--- a/src/renderer/src/components/board/KanbanBoard.tsx
+++ b/src/renderer/src/components/board/KanbanBoard.tsx
@@ -131,8 +131,11 @@ export function TaskQueue() {
   )
 
   const runTask = useCallback(
-    async (task: BoardTask) => {
+    async (staleTask: BoardTask) => {
       if (!window.electronAPI?.spawnSession) return
+
+      // Read fresh task from store to get latest attachments/prompt
+      const task = useBoardStore.getState().tasks.find((t) => t.id === staleTask.id) ?? staleTask
 
       // Check if this task has an ended session we can resume
       const existingSession = task.sessionId
@@ -220,10 +223,12 @@ export function TaskQueue() {
         let sent = false
         let debounceTimer: ReturnType<typeof setTimeout> | null = null
 
-        // Prepend file paths for attachments
-        const filePaths = (task.attachments ?? []).map((a) => a.path)
+        // Prepend file paths for attachments (quote paths with spaces)
+        const filePaths = (task.attachments ?? []).map((a) =>
+          a.path.includes(' ') ? `'${a.path}'` : a.path
+        )
         const fullPrompt = filePaths.length > 0
-          ? filePaths.join('\n') + '\n\n' + task.prompt
+          ? filePaths.join(' ') + ' ' + task.prompt
           : task.prompt
 
         const sendPrompt = (): void => {

--- a/src/renderer/src/components/board/KanbanBoard.tsx
+++ b/src/renderer/src/components/board/KanbanBoard.tsx
@@ -153,6 +153,14 @@ export function TaskQueue() {
           resumeSessionId: resumeId
         })
 
+        // Link the card to the new session BEFORE adding it to the session store,
+        // so the sync hook sees it as already tracked and won't create a duplicate card.
+        updateTask(task.id, { sessionId: sessionInfo.id, claudeSessionId: sessionInfo.claudeSessionId ?? undefined })
+        const activeCol = getColumnByBehavior('active')
+        if (activeCol) {
+          moveTask(task.id, activeCol.id, 0)
+        }
+
         addSession({
           id: sessionInfo.id,
           cwd: sessionInfo.cwd,
@@ -166,12 +174,6 @@ export function TaskQueue() {
           claudeSessionId: sessionInfo.claudeSessionId,
           sessionType: 'local'
         })
-
-        const activeCol = getColumnByBehavior('active')
-        if (activeCol) {
-          moveTask(task.id, activeCol.id, 0)
-        }
-        updateTask(task.id, { sessionId: sessionInfo.id, claudeSessionId: sessionInfo.claudeSessionId ?? undefined })
 
         useSessionStore.getState().selectSession(sessionInfo.id, false)
         return
@@ -190,6 +192,14 @@ export function TaskQueue() {
         claudeMode: true
       })
 
+      // Link the card to the new session BEFORE adding it to the session store,
+      // so the sync hook sees it as already tracked and won't create a duplicate card.
+      updateTask(task.id, { sessionId: sessionInfo.id, claudeSessionId: sessionInfo.claudeSessionId ?? undefined })
+      const activeCol = getColumnByBehavior('active')
+      if (activeCol) {
+        moveTask(task.id, activeCol.id, 0)
+      }
+
       addSession({
         id: sessionInfo.id,
         cwd: sessionInfo.cwd,
@@ -203,12 +213,6 @@ export function TaskQueue() {
         claudeSessionId: sessionInfo.claudeSessionId,
         sessionType: 'local'
       })
-
-      const activeCol = getColumnByBehavior('active')
-      if (activeCol) {
-        moveTask(task.id, activeCol.id, 0)
-      }
-      updateTask(task.id, { sessionId: sessionInfo.id, claudeSessionId: sessionInfo.claudeSessionId ?? undefined })
 
       useSessionStore.getState().selectSession(sessionInfo.id, false)
 

--- a/src/renderer/src/components/board/KanbanBoard.tsx
+++ b/src/renderer/src/components/board/KanbanBoard.tsx
@@ -4,6 +4,7 @@ import { useBoardStore } from '../../store/board-store'
 import { useSessionStore } from '../../store/session-store'
 import { useBoardPersistence } from '../../hooks/use-board-persistence'
 import { KanbanColumn } from './KanbanColumn'
+import { useBoardDnd } from '../../hooks/use-board-dnd'
 import { TaskForm } from './TaskForm'
 import { TaskDetailPanel } from './TaskDetailPanel'
 import { ContextMenu } from '../ui/ContextMenu'
@@ -23,6 +24,8 @@ export function TaskQueue() {
   const addSession = useSessionStore((s) => s.addSession)
 
   useBoardPersistence()
+
+  const { draggingTaskId, dropTarget, onPointerDown } = useBoardDnd()
 
   const [formOpen, setFormOpen] = useState(false)
   const [formColumnId, setFormColumnId] = useState<string | undefined>(undefined)
@@ -212,6 +215,9 @@ export function TaskQueue() {
               onDeleteColumn={deleteColumn}
               onAddColumnAfter={(id) => addColumn('New Column', id)}
               isOnlyInbox={inboxColumnCount <= 1}
+              draggingTaskId={draggingTaskId}
+              dropTarget={dropTarget}
+              onPointerDown={onPointerDown}
             />
           ))}
 

--- a/src/renderer/src/components/board/KanbanCard.tsx
+++ b/src/renderer/src/components/board/KanbanCard.tsx
@@ -1,0 +1,109 @@
+import { FolderIcon, CommandLineIcon } from '@heroicons/react/24/outline'
+import { cn } from '../../lib/utils'
+import type { BoardTask, BoardColumn } from '../../../../preload/index.d'
+
+function shortenCwd(cwd: string): string {
+  const parts = cwd.split('/')
+  if (parts.length <= 3) return cwd
+  return '~/' + parts.slice(-2).join('/')
+}
+
+function formatDate(ts: number): string {
+  const d = new Date(ts)
+  const now = new Date()
+  const diffMs = now.getTime() - d.getTime()
+  const diffMin = Math.floor(diffMs / 60000)
+  if (diffMin < 1) return 'just now'
+  if (diffMin < 60) return `${diffMin}m ago`
+  const diffHr = Math.floor(diffMin / 60)
+  if (diffHr < 24) return `${diffHr}h ago`
+  const diffDay = Math.floor(diffHr / 24)
+  if (diffDay < 7) return `${diffDay}d ago`
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}
+
+interface KanbanCardProps {
+  task: BoardTask
+  column: BoardColumn
+  onRun: (task: BoardTask) => void
+  onClick: (task: BoardTask) => void
+  onContextMenu: (e: React.MouseEvent, task: BoardTask) => void
+  isDragging?: boolean
+  onPointerDown?: (e: React.PointerEvent) => void
+}
+
+export function KanbanCard({ task, column, onRun, onClick, onContextMenu, isDragging, onPointerDown }: KanbanCardProps) {
+  const label = task.title || task.notes.split('\n')[0] || task.prompt.split('\n')[0] || 'Untitled'
+  const canRun = column.behavior !== 'terminal' && column.behavior !== 'active'
+  const hasPrompt = task.prompt.trim().length > 0
+  const notesPreview = task.notes.trim() ? task.notes.split('\n').slice(0, 2).join(' ') : null
+
+  return (
+    <div
+      data-task-id={task.id}
+      onClick={() => onClick(task)}
+      onContextMenu={(e) => onContextMenu(e, task)}
+      onPointerDown={onPointerDown}
+      className={cn(
+        'group rounded-lg border border-border-subtle bg-surface-100 p-3 cursor-default transition-all hover:border-border hover:shadow-sm',
+        isDragging && 'opacity-40'
+      )}
+    >
+      {/* Title */}
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-medium text-text-primary truncate">{label}</span>
+        {task.dangerousMode && (
+          <span className="flex-shrink-0 px-1.5 py-0.5 rounded text-[10px] font-medium bg-red-500/10 text-red-400">
+            skip-perms
+          </span>
+        )}
+      </div>
+
+      {/* Notes preview */}
+      {notesPreview && (
+        <p className="mt-1 text-xs text-text-tertiary line-clamp-2">{notesPreview}</p>
+      )}
+
+      {/* Metadata row */}
+      <div className="flex items-center gap-2 mt-2">
+        {hasPrompt && (
+          <span className="flex items-center gap-1 text-[10px] text-accent/70" title="Has prompt">
+            <CommandLineIcon className="w-3 h-3" />
+          </span>
+        )}
+        <span className="flex items-center gap-1 text-[11px] text-text-tertiary">
+          <FolderIcon className="w-3 h-3" />
+          <span className="truncate max-w-[120px]" title={task.cwd}>{shortenCwd(task.cwd)}</span>
+        </span>
+        <span className="text-text-tertiary/30">·</span>
+        <span className="text-[11px] text-text-tertiary">{formatDate(task.createdAt)}</span>
+      </div>
+
+      {/* Hover actions */}
+      {canRun && (
+        <div className="mt-2 flex items-center gap-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              onRun(task)
+            }}
+            className="h-6 px-2.5 rounded text-[11px] font-medium bg-green-500/10 hover:bg-green-500/20 text-green-500 transition-colors flex items-center gap-1"
+          >
+            <svg width="8" height="8" viewBox="0 0 12 12" fill="none">
+              <path d="M3 1.5L10 6L3 10.5V1.5Z" fill="currentColor" />
+            </svg>
+            Run
+          </button>
+        </div>
+      )}
+
+      {/* Active session indicator */}
+      {task.sessionId && column.behavior === 'active' && (
+        <div className="mt-2 flex items-center gap-1.5">
+          <span className="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse" />
+          <span className="text-[11px] text-green-400">Running</span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/board/KanbanCard.tsx
+++ b/src/renderer/src/components/board/KanbanCard.tsx
@@ -1,4 +1,5 @@
 import { FolderIcon, CommandLineIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
+import { useSessionStore } from '../../store/session-store'
 import { cn } from '../../lib/utils'
 import type { BoardTask, BoardColumn } from '../../../../preload/index.d'
 
@@ -43,8 +44,18 @@ export function KanbanCard({
   isDragging,
   onPointerDown
 }: KanbanCardProps) {
+  const linkedSession = useSessionStore((s) =>
+    task.sessionId ? s.sessions.find((sess) => sess.id === task.sessionId) : undefined
+  )
+
+  const sessionAlive = linkedSession?.alive === true
+  const activityStatus = linkedSession?.activityStatus ?? null
+  const promptWaiting = linkedSession?.promptWaiting ?? null
   const label = task.title || task.notes.split('\n')[0] || task.prompt.split('\n')[0] || 'Untitled'
-  const canRun = column.behavior !== 'terminal' && column.behavior !== 'active'
+  const canResume = linkedSession != null && !sessionAlive
+  const canRun =
+    column.behavior !== 'terminal' &&
+    (column.behavior !== 'active' || canResume)
   const hasPrompt = task.prompt.trim().length > 0
   const notesPreview = task.notes.trim() ? task.notes.split('\n').slice(0, 2).join(' ') : null
 
@@ -104,27 +115,52 @@ export function KanbanCard({
             <svg width="8" height="8" viewBox="0 0 12 12" fill="none">
               <path d="M3 1.5L10 6L3 10.5V1.5Z" fill="currentColor" />
             </svg>
-            Run
+            {canResume ? 'Resume' : 'Run'}
           </button>
         </div>
       )}
 
-      {/* Active session indicator + view button */}
-      {task.sessionId && column.behavior === 'active' && (
+      {/* Session indicator */}
+      {task.sessionId && (
         <div className="mt-2 flex items-center gap-1.5">
-          <span className="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse" />
-          <span className="text-[11px] text-green-400">Running</span>
-          <button
-            onClick={(e) => {
-              e.stopPropagation()
-              onViewSession?.(task.sessionId!)
-            }}
-            className="ml-auto h-6 px-2 rounded text-[11px] font-medium bg-accent/10 hover:bg-accent/20 text-accent transition-colors flex items-center gap-1"
-            title="View session"
-          >
-            <ArrowTopRightOnSquareIcon className="w-3 h-3" />
-            View
-          </button>
+          {sessionAlive && promptWaiting ? (
+            <>
+              <span className="w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" />
+              <span className="text-[11px] text-amber-400 truncate">
+                {promptWaiting === 'is asking for permission'
+                  ? 'Needs permission'
+                  : 'Waiting for input'}
+              </span>
+            </>
+          ) : sessionAlive && activityStatus === 'active' ? (
+            <>
+              <span className="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse" />
+              <span className="text-[11px] text-green-400">Working</span>
+            </>
+          ) : sessionAlive && activityStatus === 'idle' ? (
+            <>
+              <span className="w-1.5 h-1.5 rounded-full bg-blue-400" />
+              <span className="text-[11px] text-blue-400">Idle</span>
+            </>
+          ) : (
+            <>
+              <span className="w-1.5 h-1.5 rounded-full bg-text-tertiary" />
+              <span className="text-[11px] text-text-tertiary">Session ended</span>
+            </>
+          )}
+          {linkedSession && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onViewSession?.(task.sessionId!)
+              }}
+              className="ml-auto h-6 px-2 rounded text-[11px] font-medium bg-accent/10 hover:bg-accent/20 text-accent transition-colors flex items-center gap-1"
+              title="View session"
+            >
+              <ArrowTopRightOnSquareIcon className="w-3 h-3" />
+              View
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/src/renderer/src/components/board/KanbanCard.tsx
+++ b/src/renderer/src/components/board/KanbanCard.tsx
@@ -102,7 +102,7 @@ export function KanbanCard({
       )}
 
       {/* Tags */}
-      {task.tags.length > 0 && (
+      {task.tags?.length > 0 && (
         <div className="flex flex-wrap gap-1 mt-1.5">
           {task.tags.map((tagName) => {
             const def = boardTags.find((t) => t.name === tagName)

--- a/src/renderer/src/components/board/KanbanCard.tsx
+++ b/src/renderer/src/components/board/KanbanCard.tsx
@@ -67,7 +67,7 @@ export function KanbanCard({
     return sess?.promptWaiting ?? null
   })
   const label = task.title || task.notes.split('\n')[0] || task.prompt.split('\n')[0] || 'Untitled'
-  const canResume = linkedSession != null && !sessionAlive
+  const canResume = (linkedSession != null && !sessionAlive) || (!linkedSession && !!task.claudeSessionId)
   const canRun =
     column.behavior !== 'terminal' &&
     (column.behavior !== 'active' || !sessionAlive)

--- a/src/renderer/src/components/board/KanbanCard.tsx
+++ b/src/renderer/src/components/board/KanbanCard.tsx
@@ -48,9 +48,21 @@ export function KanbanCard({
     task.sessionId ? s.sessions.find((sess) => sess.id === task.sessionId) : undefined
   )
 
-  const sessionAlive = linkedSession?.alive === true
-  const activityStatus = linkedSession?.activityStatus ?? null
-  const promptWaiting = linkedSession?.promptWaiting ?? null
+  const sessionAlive = useSessionStore((s) => {
+    if (!task.sessionId) return false
+    const sess = s.sessions.find((ss) => ss.id === task.sessionId)
+    return sess?.alive === true
+  })
+  const activityStatus = useSessionStore((s) => {
+    if (!task.sessionId) return null
+    const sess = s.sessions.find((ss) => ss.id === task.sessionId)
+    return sess?.activityStatus ?? null
+  })
+  const promptWaiting = useSessionStore((s) => {
+    if (!task.sessionId) return null
+    const sess = s.sessions.find((ss) => ss.id === task.sessionId)
+    return sess?.promptWaiting ?? null
+  })
   const label = task.title || task.notes.split('\n')[0] || task.prompt.split('\n')[0] || 'Untitled'
   const canResume = linkedSession != null && !sessionAlive
   const canRun =

--- a/src/renderer/src/components/board/KanbanCard.tsx
+++ b/src/renderer/src/components/board/KanbanCard.tsx
@@ -4,6 +4,7 @@ import { cn } from '../../lib/utils'
 import type { BoardTask, BoardColumn } from '../../../../preload/index.d'
 import { TagPill } from './TagPill'
 import { useBoardStore } from '../../store/board-store'
+import { useHistoryStore } from '../../store/history-store'
 
 function shortenCwd(cwd: string): string {
   const parts = cwd.split('/')
@@ -66,6 +67,15 @@ export function KanbanCard({
     const sess = s.sessions.find((ss) => ss.id === task.sessionId)
     return sess?.promptWaiting ?? null
   })
+  const historySession = useHistoryStore((s) => {
+    if (!task.claudeSessionId) return null
+    for (const sessions of Object.values(s.sessionsByProject)) {
+      const match = sessions.find((sess) => sess.sessionId === task.claudeSessionId)
+      if (match) return match
+    }
+    return null
+  })
+
   const label = task.title || task.notes.split('\n')[0] || task.prompt.split('\n')[0] || 'Untitled'
   const canResume = (linkedSession != null && !sessionAlive) || (!linkedSession && !!task.claudeSessionId)
   const canRun =
@@ -193,6 +203,18 @@ export function KanbanCard({
               View
             </button>
           )}
+        </div>
+      )}
+
+      {/* History summary for completed tasks */}
+      {!sessionAlive && task.claudeSessionId && historySession && (
+        <div className="mt-2 pt-2 border-t border-border-subtle">
+          <p className="text-[11px] text-text-tertiary line-clamp-2">
+            {historySession.summary || 'No summary available'}
+          </p>
+          <span className="text-[10px] text-text-tertiary">
+            {historySession.messageCount} messages
+          </span>
         </div>
       )}
     </div>

--- a/src/renderer/src/components/board/KanbanCard.tsx
+++ b/src/renderer/src/components/board/KanbanCard.tsx
@@ -32,7 +32,15 @@ interface KanbanCardProps {
   onPointerDown?: (e: React.PointerEvent) => void
 }
 
-export function KanbanCard({ task, column, onRun, onClick, onContextMenu, isDragging, onPointerDown }: KanbanCardProps) {
+export function KanbanCard({
+  task,
+  column,
+  onRun,
+  onClick,
+  onContextMenu,
+  isDragging,
+  onPointerDown
+}: KanbanCardProps) {
   const label = task.title || task.notes.split('\n')[0] || task.prompt.split('\n')[0] || 'Untitled'
   const canRun = column.behavior !== 'terminal' && column.behavior !== 'active'
   const hasPrompt = task.prompt.trim().length > 0
@@ -73,7 +81,9 @@ export function KanbanCard({ task, column, onRun, onClick, onContextMenu, isDrag
         )}
         <span className="flex items-center gap-1 text-[11px] text-text-tertiary">
           <FolderIcon className="w-3 h-3" />
-          <span className="truncate max-w-[120px]" title={task.cwd}>{shortenCwd(task.cwd)}</span>
+          <span className="truncate max-w-[120px]" title={task.cwd}>
+            {shortenCwd(task.cwd)}
+          </span>
         </span>
         <span className="text-text-tertiary/30">·</span>
         <span className="text-[11px] text-text-tertiary">{formatDate(task.createdAt)}</span>

--- a/src/renderer/src/components/board/KanbanCard.tsx
+++ b/src/renderer/src/components/board/KanbanCard.tsx
@@ -67,7 +67,7 @@ export function KanbanCard({
   const canResume = linkedSession != null && !sessionAlive
   const canRun =
     column.behavior !== 'terminal' &&
-    (column.behavior !== 'active' || canResume)
+    (column.behavior !== 'active' || !sessionAlive)
   const hasPrompt = task.prompt.trim().length > 0
   const notesPreview = task.notes.trim() ? task.notes.split('\n').slice(0, 2).join(' ') : null
 

--- a/src/renderer/src/components/board/KanbanCard.tsx
+++ b/src/renderer/src/components/board/KanbanCard.tsx
@@ -1,4 +1,4 @@
-import { FolderIcon, CommandLineIcon } from '@heroicons/react/24/outline'
+import { FolderIcon, CommandLineIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
 import { cn } from '../../lib/utils'
 import type { BoardTask, BoardColumn } from '../../../../preload/index.d'
 
@@ -28,6 +28,7 @@ interface KanbanCardProps {
   onRun: (task: BoardTask) => void
   onClick: (task: BoardTask) => void
   onContextMenu: (e: React.MouseEvent, task: BoardTask) => void
+  onViewSession?: (sessionId: string) => void
   isDragging?: boolean
   onPointerDown?: (e: React.PointerEvent) => void
 }
@@ -38,6 +39,7 @@ export function KanbanCard({
   onRun,
   onClick,
   onContextMenu,
+  onViewSession,
   isDragging,
   onPointerDown
 }: KanbanCardProps) {
@@ -107,11 +109,22 @@ export function KanbanCard({
         </div>
       )}
 
-      {/* Active session indicator */}
+      {/* Active session indicator + view button */}
       {task.sessionId && column.behavior === 'active' && (
         <div className="mt-2 flex items-center gap-1.5">
           <span className="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse" />
           <span className="text-[11px] text-green-400">Running</span>
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              onViewSession?.(task.sessionId!)
+            }}
+            className="ml-auto h-6 px-2 rounded text-[11px] font-medium bg-accent/10 hover:bg-accent/20 text-accent transition-colors flex items-center gap-1"
+            title="View session"
+          >
+            <ArrowTopRightOnSquareIcon className="w-3 h-3" />
+            View
+          </button>
         </div>
       )}
     </div>

--- a/src/renderer/src/components/board/KanbanCard.tsx
+++ b/src/renderer/src/components/board/KanbanCard.tsx
@@ -67,7 +67,8 @@ export function KanbanCard({
       onPointerDown={onPointerDown}
       className={cn(
         'group rounded-lg border border-border-subtle bg-surface-100 p-3 cursor-default transition-all hover:border-border hover:shadow-sm',
-        isDragging && 'opacity-40'
+        isDragging && 'opacity-40',
+        sessionAlive && promptWaiting && 'border-amber-400/50 shadow-[0_0_8px_rgba(251,191,36,0.15)]'
       )}
     >
       {/* Title */}

--- a/src/renderer/src/components/board/KanbanCard.tsx
+++ b/src/renderer/src/components/board/KanbanCard.tsx
@@ -1,4 +1,4 @@
-import { FolderIcon, CommandLineIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
+import { FolderIcon, CommandLineIcon, ArrowTopRightOnSquareIcon, PaperClipIcon } from '@heroicons/react/24/outline'
 import { useSessionStore } from '../../store/session-store'
 import { cn } from '../../lib/utils'
 import type { BoardTask, BoardColumn } from '../../../../preload/index.d'
@@ -132,6 +132,12 @@ export function KanbanCard({
         {hasPrompt && (
           <span className="flex items-center gap-1 text-[10px] text-accent/70" title="Has prompt">
             <CommandLineIcon className="w-3 h-3" />
+          </span>
+        )}
+        {task.attachments?.length > 0 && (
+          <span className="flex items-center gap-0.5 text-[10px] text-text-tertiary" title={`${task.attachments.length} attachment${task.attachments.length > 1 ? 's' : ''}`}>
+            <PaperClipIcon className="w-3 h-3" />
+            <span>{task.attachments.length}</span>
           </span>
         )}
         <span className="flex items-center gap-1 text-[11px] text-text-tertiary">

--- a/src/renderer/src/components/board/KanbanCard.tsx
+++ b/src/renderer/src/components/board/KanbanCard.tsx
@@ -2,6 +2,8 @@ import { FolderIcon, CommandLineIcon, ArrowTopRightOnSquareIcon } from '@heroico
 import { useSessionStore } from '../../store/session-store'
 import { cn } from '../../lib/utils'
 import type { BoardTask, BoardColumn } from '../../../../preload/index.d'
+import { TagPill } from './TagPill'
+import { useBoardStore } from '../../store/board-store'
 
 function shortenCwd(cwd: string): string {
   const parts = cwd.split('/')
@@ -44,6 +46,7 @@ export function KanbanCard({
   isDragging,
   onPointerDown
 }: KanbanCardProps) {
+  const boardTags = useBoardStore((s) => s.tags)
   const linkedSession = useSessionStore((s) =>
     task.sessionId ? s.sessions.find((sess) => sess.id === task.sessionId) : undefined
   )
@@ -96,6 +99,22 @@ export function KanbanCard({
       {/* Notes preview */}
       {notesPreview && (
         <p className="mt-1 text-xs text-text-tertiary line-clamp-2">{notesPreview}</p>
+      )}
+
+      {/* Tags */}
+      {task.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1 mt-1.5">
+          {task.tags.map((tagName) => {
+            const def = boardTags.find((t) => t.name === tagName)
+            return (
+              <TagPill
+                key={tagName}
+                name={tagName}
+                color={def?.color ?? 'blue'}
+              />
+            )
+          })}
+        </div>
       )}
 
       {/* Metadata row */}

--- a/src/renderer/src/components/board/KanbanColumn.tsx
+++ b/src/renderer/src/components/board/KanbanColumn.tsx
@@ -85,7 +85,7 @@ export function KanbanColumn({
     <div
       data-column-id={column.id}
       className={cn(
-        'flex flex-col w-72 flex-shrink-0 rounded-xl bg-surface-50 border border-border-subtle',
+        'flex flex-col w-72 flex-shrink-0 max-h-full rounded-xl bg-surface-50 border border-border-subtle',
         dropTarget?.columnId === column.id && draggingTaskId && 'ring-2 ring-accent/40'
       )}
     >

--- a/src/renderer/src/components/board/KanbanColumn.tsx
+++ b/src/renderer/src/components/board/KanbanColumn.tsx
@@ -8,6 +8,7 @@ import {
 } from '@heroicons/react/24/outline'
 import { KanbanCard } from './KanbanCard'
 import { ContextMenu } from '../ui/ContextMenu'
+import { ConfirmDialog } from '../ui/ConfirmDialog'
 import { cn } from '../../lib/utils'
 import type { BoardTask, BoardColumn as BoardColumnType } from '../../../../preload/index.d'
 
@@ -28,6 +29,9 @@ interface KanbanColumnProps {
   onRenameColumn: (columnId: string, title: string) => void
   onDeleteColumn: (columnId: string) => void
   onAddColumnAfter: (columnId: string) => void
+  onMoveColumn: (columnId: string, direction: 'left' | 'right') => void
+  isFirst: boolean
+  isLast: boolean
   isOnlyInbox: boolean
   draggingTaskId?: string | null
   dropTarget?: { columnId: string; order: number } | null
@@ -45,6 +49,9 @@ export function KanbanColumn({
   onRenameColumn,
   onDeleteColumn,
   onAddColumnAfter,
+  onMoveColumn,
+  isFirst,
+  isLast,
   isOnlyInbox,
   draggingTaskId,
   dropTarget,
@@ -53,6 +60,7 @@ export function KanbanColumn({
   const [isEditingTitle, setIsEditingTitle] = useState(false)
   const [editTitle, setEditTitle] = useState(column.title)
   const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null)
+  const [deleteConfirm, setDeleteConfirm] = useState(false)
 
   const sortedTasks = [...tasks].sort((a, b) => a.order - b.order)
   const BehaviorIcon = BEHAVIOR_ICONS[column.behavior]
@@ -165,12 +173,18 @@ export function KanbanColumn({
                 setIsEditingTitle(true)
               }
             },
+            ...(!isFirst
+              ? [{ label: 'Move left', onClick: () => onMoveColumn(column.id, 'left') }]
+              : []),
+            ...(!isLast
+              ? [{ label: 'Move right', onClick: () => onMoveColumn(column.id, 'right') }]
+              : []),
             {
               label: 'Add column after',
               onClick: () => onAddColumnAfter(column.id)
             },
             ...(canDelete
-              ? [{ label: 'Delete column', onClick: () => onDeleteColumn(column.id), danger: true }]
+              ? [{ label: 'Delete column', onClick: () => setDeleteConfirm(true), danger: true }]
               : [])
           ]}
           x={menuPos.x}
@@ -178,6 +192,27 @@ export function KanbanColumn({
           onClose={() => setMenuPos(null)}
         />
       )}
+
+      {/* Delete column confirmation */}
+      <ConfirmDialog
+        isOpen={deleteConfirm}
+        title={`Delete "${column.title}"?`}
+        message={
+          tasks.length > 0
+            ? `This column has ${tasks.length} task${tasks.length > 1 ? 's' : ''}. Move all tasks to another column before deleting.`
+            : 'This column will be permanently removed.'
+        }
+        confirmLabel={tasks.length > 0 ? 'Got it' : 'Delete'}
+        onConfirm={() => {
+          if (tasks.length > 0) {
+            setDeleteConfirm(false)
+          } else {
+            setDeleteConfirm(false)
+            onDeleteColumn(column.id)
+          }
+        }}
+        onCancel={() => setDeleteConfirm(false)}
+      />
     </div>
   )
 }

--- a/src/renderer/src/components/board/KanbanColumn.tsx
+++ b/src/renderer/src/components/board/KanbanColumn.tsx
@@ -1,5 +1,11 @@
 import { useState, useCallback } from 'react'
-import { PlusIcon, EllipsisHorizontalIcon, InboxIcon, PlayIcon, CheckCircleIcon } from '@heroicons/react/24/outline'
+import {
+  PlusIcon,
+  EllipsisHorizontalIcon,
+  InboxIcon,
+  PlayIcon,
+  CheckCircleIcon
+} from '@heroicons/react/24/outline'
 import { KanbanCard } from './KanbanCard'
 import { ContextMenu } from '../ui/ContextMenu'
 import { cn } from '../../lib/utils'
@@ -7,8 +13,8 @@ import type { BoardTask, BoardColumn as BoardColumnType } from '../../../../prel
 
 const BEHAVIOR_ICONS: Record<string, typeof InboxIcon> = {
   'default-inbox': InboxIcon,
-  'active': PlayIcon,
-  'terminal': CheckCircleIcon
+  active: PlayIcon,
+  terminal: CheckCircleIcon
 }
 
 interface KanbanColumnProps {
@@ -75,9 +81,7 @@ export function KanbanColumn({
     >
       {/* Column header */}
       <div className="flex items-center gap-2 px-3 py-2.5 border-b border-border-subtle">
-        {BehaviorIcon && (
-          <BehaviorIcon className="w-3.5 h-3.5 text-text-tertiary flex-shrink-0" />
-        )}
+        {BehaviorIcon && <BehaviorIcon className="w-3.5 h-3.5 text-text-tertiary flex-shrink-0" />}
 
         {isEditingTitle ? (
           <input

--- a/src/renderer/src/components/board/KanbanColumn.tsx
+++ b/src/renderer/src/components/board/KanbanColumn.tsx
@@ -1,0 +1,176 @@
+import { useState, useCallback } from 'react'
+import { PlusIcon, EllipsisHorizontalIcon, InboxIcon, PlayIcon, CheckCircleIcon } from '@heroicons/react/24/outline'
+import { KanbanCard } from './KanbanCard'
+import { ContextMenu } from '../ui/ContextMenu'
+import { cn } from '../../lib/utils'
+import type { BoardTask, BoardColumn as BoardColumnType } from '../../../../preload/index.d'
+
+const BEHAVIOR_ICONS: Record<string, typeof InboxIcon> = {
+  'default-inbox': InboxIcon,
+  'active': PlayIcon,
+  'terminal': CheckCircleIcon
+}
+
+interface KanbanColumnProps {
+  column: BoardColumnType
+  tasks: BoardTask[]
+  onAddTask: (columnId: string) => void
+  onRunTask: (task: BoardTask) => void
+  onClickTask: (task: BoardTask) => void
+  onContextMenuTask: (e: React.MouseEvent, task: BoardTask) => void
+  onRenameColumn: (columnId: string, title: string) => void
+  onDeleteColumn: (columnId: string) => void
+  onAddColumnAfter: (columnId: string) => void
+  isOnlyInbox: boolean
+  draggingTaskId?: string | null
+  dropTarget?: { columnId: string; order: number } | null
+  onPointerDown?: (e: React.PointerEvent, taskId: string, columnId: string) => void
+}
+
+export function KanbanColumn({
+  column,
+  tasks,
+  onAddTask,
+  onRunTask,
+  onClickTask,
+  onContextMenuTask,
+  onRenameColumn,
+  onDeleteColumn,
+  onAddColumnAfter,
+  isOnlyInbox,
+  draggingTaskId,
+  dropTarget,
+  onPointerDown
+}: KanbanColumnProps) {
+  const [isEditingTitle, setIsEditingTitle] = useState(false)
+  const [editTitle, setEditTitle] = useState(column.title)
+  const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null)
+
+  const sortedTasks = [...tasks].sort((a, b) => a.order - b.order)
+  const BehaviorIcon = BEHAVIOR_ICONS[column.behavior]
+  const canDelete = !column.locked && !(column.behavior === 'default-inbox' && isOnlyInbox)
+
+  const commitRename = useCallback(() => {
+    const trimmed = editTitle.trim()
+    if (trimmed && trimmed !== column.title) {
+      onRenameColumn(column.id, trimmed)
+    } else {
+      setEditTitle(column.title)
+    }
+    setIsEditingTitle(false)
+  }, [editTitle, column.id, column.title, onRenameColumn])
+
+  const handleMenuClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+    setMenuPos({ x: e.clientX, y: e.clientY })
+  }, [])
+
+  return (
+    <div
+      data-column-id={column.id}
+      className={cn(
+        'flex flex-col w-72 flex-shrink-0 rounded-xl bg-surface-50 border border-border-subtle',
+        dropTarget?.columnId === column.id && draggingTaskId && 'ring-2 ring-accent/40'
+      )}
+    >
+      {/* Column header */}
+      <div className="flex items-center gap-2 px-3 py-2.5 border-b border-border-subtle">
+        {BehaviorIcon && (
+          <BehaviorIcon className="w-3.5 h-3.5 text-text-tertiary flex-shrink-0" />
+        )}
+
+        {isEditingTitle ? (
+          <input
+            autoFocus
+            value={editTitle}
+            onChange={(e) => setEditTitle(e.target.value)}
+            onBlur={commitRename}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') commitRename()
+              if (e.key === 'Escape') {
+                setEditTitle(column.title)
+                setIsEditingTitle(false)
+              }
+            }}
+            className="flex-1 text-sm font-semibold text-text-primary bg-transparent outline-none border-b border-accent"
+          />
+        ) : (
+          <span
+            className="flex-1 text-sm font-semibold text-text-primary cursor-text truncate"
+            onClick={() => {
+              setEditTitle(column.title)
+              setIsEditingTitle(true)
+            }}
+          >
+            {column.title}
+          </span>
+        )}
+
+        <span className="text-xs text-text-tertiary tabular-nums">{sortedTasks.length}</span>
+
+        <button
+          onClick={handleMenuClick}
+          className="p-0.5 rounded hover:bg-surface-200 text-text-tertiary hover:text-text-secondary transition-colors"
+        >
+          <EllipsisHorizontalIcon className="w-4 h-4" />
+        </button>
+      </div>
+
+      {/* Card list */}
+      <div className="flex-1 overflow-y-auto p-2 space-y-2 min-h-[80px]">
+        {sortedTasks.map((task) => (
+          <KanbanCard
+            key={task.id}
+            task={task}
+            column={column}
+            onRun={onRunTask}
+            onClick={onClickTask}
+            onContextMenu={onContextMenuTask}
+            isDragging={draggingTaskId === task.id}
+            onPointerDown={onPointerDown ? (e) => onPointerDown(e, task.id, column.id) : undefined}
+          />
+        ))}
+
+        {sortedTasks.length === 0 && (
+          <div className="flex items-center justify-center h-20 text-xs text-text-tertiary">
+            No tasks
+          </div>
+        )}
+      </div>
+
+      {/* Add task button */}
+      <button
+        onClick={() => onAddTask(column.id)}
+        className="flex items-center gap-1.5 mx-2 mb-2 px-2 py-1.5 rounded-lg text-xs text-text-tertiary hover:text-text-secondary hover:bg-surface-100 transition-colors"
+      >
+        <PlusIcon className="w-3.5 h-3.5" />
+        Add task
+      </button>
+
+      {/* Column context menu */}
+      {menuPos && (
+        <ContextMenu
+          items={[
+            {
+              label: 'Rename',
+              onClick: () => {
+                setEditTitle(column.title)
+                setIsEditingTitle(true)
+              }
+            },
+            {
+              label: 'Add column after',
+              onClick: () => onAddColumnAfter(column.id)
+            },
+            ...(canDelete
+              ? [{ label: 'Delete column', onClick: () => onDeleteColumn(column.id), danger: true }]
+              : [])
+          ]}
+          x={menuPos.x}
+          y={menuPos.y}
+          onClose={() => setMenuPos(null)}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/board/KanbanColumn.tsx
+++ b/src/renderer/src/components/board/KanbanColumn.tsx
@@ -24,6 +24,7 @@ interface KanbanColumnProps {
   onRunTask: (task: BoardTask) => void
   onClickTask: (task: BoardTask) => void
   onContextMenuTask: (e: React.MouseEvent, task: BoardTask) => void
+  onViewSession?: (sessionId: string) => void
   onRenameColumn: (columnId: string, title: string) => void
   onDeleteColumn: (columnId: string) => void
   onAddColumnAfter: (columnId: string) => void
@@ -40,6 +41,7 @@ export function KanbanColumn({
   onRunTask,
   onClickTask,
   onContextMenuTask,
+  onViewSession,
   onRenameColumn,
   onDeleteColumn,
   onAddColumnAfter,
@@ -130,6 +132,7 @@ export function KanbanColumn({
             onRun={onRunTask}
             onClick={onClickTask}
             onContextMenu={onContextMenuTask}
+            onViewSession={onViewSession}
             isDragging={draggingTaskId === task.id}
             onPointerDown={onPointerDown ? (e) => onPointerDown(e, task.id, column.id) : undefined}
           />

--- a/src/renderer/src/components/board/TagInput.tsx
+++ b/src/renderer/src/components/board/TagInput.tsx
@@ -1,0 +1,172 @@
+import { useState, useRef, useCallback, useEffect } from 'react'
+import { useBoardStore } from '../../store/board-store'
+import { TagPill } from './TagPill'
+import { cn } from '../../lib/utils'
+
+interface TagInputProps {
+  tags: string[]
+  onChange: (tags: string[]) => void
+}
+
+export function TagInput({ tags, onChange }: TagInputProps) {
+  const boardTags = useBoardStore((s) => s.tags)
+  const addTag = useBoardStore((s) => s.addTag)
+
+  const [input, setInput] = useState('')
+  const [showDropdown, setShowDropdown] = useState(false)
+  const [highlightIdx, setHighlightIdx] = useState(0)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const normalized = input.trim().toLowerCase().replace(/^#/, '')
+
+  const suggestions = boardTags.filter(
+    (t) => t.name.includes(normalized) && !tags.includes(t.name)
+  )
+
+  const showCreate = normalized && !boardTags.some((t) => t.name === normalized) && !tags.includes(normalized)
+  const totalOptions = suggestions.length + (showCreate ? 1 : 0)
+
+  useEffect(() => {
+    setHighlightIdx(0)
+  }, [input])
+
+  const addTagToTask = useCallback(
+    (name: string) => {
+      const norm = name.trim().toLowerCase().replace(/^#/, '')
+      if (!norm) return
+      if (tags.includes(norm)) return
+
+      // Ensure tag definition exists at board level
+      if (!boardTags.some((t) => t.name === norm)) {
+        addTag(norm)
+      }
+
+      onChange([...tags, norm])
+      setInput('')
+      setShowDropdown(false)
+      inputRef.current?.focus()
+    },
+    [tags, boardTags, addTag, onChange]
+  )
+
+  const removeTagFromTask = useCallback(
+    (name: string) => {
+      onChange(tags.filter((t) => t !== name))
+    },
+    [tags, onChange]
+  )
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        if (totalOptions > 0 && showDropdown) {
+          if (highlightIdx < suggestions.length) {
+            addTagToTask(suggestions[highlightIdx].name)
+          } else if (showCreate) {
+            addTagToTask(normalized)
+          }
+        } else if (normalized) {
+          addTagToTask(normalized)
+        }
+      } else if (e.key === 'Backspace' && !input && tags.length > 0) {
+        removeTagFromTask(tags[tags.length - 1])
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setHighlightIdx((i) => Math.min(i + 1, totalOptions - 1))
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setHighlightIdx((i) => Math.max(i - 1, 0))
+      } else if (e.key === 'Escape') {
+        setShowDropdown(false)
+      }
+    },
+    [input, tags, normalized, suggestions, showCreate, highlightIdx, totalOptions, addTagToTask, removeTagFromTask, showDropdown]
+  )
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setShowDropdown(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [])
+
+  const getTagColor = (name: string): string => {
+    return boardTags.find((t) => t.name === name)?.color ?? 'blue'
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <div className="flex flex-wrap items-center gap-1 px-2 py-1.5 rounded-lg bg-surface-200 min-h-[32px]">
+        {tags.map((tag) => (
+          <TagPill
+            key={tag}
+            name={tag}
+            color={getTagColor(tag)}
+            size="md"
+            onRemove={() => removeTagFromTask(tag)}
+          />
+        ))}
+        <input
+          ref={inputRef}
+          type="text"
+          value={input}
+          onChange={(e) => {
+            setInput(e.target.value)
+            setShowDropdown(true)
+          }}
+          onFocus={() => setShowDropdown(true)}
+          onKeyDown={handleKeyDown}
+          placeholder={tags.length === 0 ? 'Add tags...' : ''}
+          className="flex-1 min-w-[60px] bg-transparent text-sm text-text-primary placeholder:text-text-tertiary outline-none"
+        />
+      </div>
+
+      {/* Autocomplete dropdown */}
+      {showDropdown && totalOptions > 0 && (
+        <div className="absolute z-10 mt-1 w-full rounded-lg bg-surface-100 border border-border shadow-lg overflow-hidden">
+          {suggestions.map((tag, idx) => (
+            <button
+              key={tag.name}
+              onClick={() => addTagToTask(tag.name)}
+              className={cn(
+                'w-full flex items-center gap-2 px-3 py-1.5 text-sm text-text-primary hover:bg-surface-200 transition-colors text-left',
+                idx === highlightIdx && 'bg-surface-200'
+              )}
+            >
+              <span
+                className="w-2 h-2 rounded-full flex-shrink-0"
+                style={{ backgroundColor: getComputedDotColor(tag.color) }}
+              />
+              {tag.name}
+            </button>
+          ))}
+          {showCreate && (
+            <button
+              onClick={() => addTagToTask(normalized)}
+              className={cn(
+                'w-full flex items-center gap-2 px-3 py-1.5 text-sm text-text-secondary hover:bg-surface-200 transition-colors text-left',
+                highlightIdx === suggestions.length && 'bg-surface-200'
+              )}
+            >
+              Create &ldquo;<span className="text-text-primary">{normalized}</span>&rdquo;
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function getComputedDotColor(colorId: string): string {
+  const colorMap: Record<string, string> = {
+    blue: '#60a5fa', green: '#4ade80', amber: '#fbbf24', red: '#f87171',
+    purple: '#c084fc', pink: '#f472b6', cyan: '#22d3ee', orange: '#fb923c'
+  }
+  return colorMap[colorId] ?? '#6b7280'
+}

--- a/src/renderer/src/components/board/TagPill.tsx
+++ b/src/renderer/src/components/board/TagPill.tsx
@@ -1,0 +1,57 @@
+import { XMarkIcon } from '@heroicons/react/24/outline'
+import { cn } from '../../lib/utils'
+
+const TAG_COLOR_MAP: Record<string, { bg: string; text: string }> = {
+  blue:   { bg: 'bg-blue-500/15',   text: 'text-blue-400'   },
+  green:  { bg: 'bg-green-500/15',  text: 'text-green-400'  },
+  amber:  { bg: 'bg-amber-500/15',  text: 'text-amber-400'  },
+  red:    { bg: 'bg-red-500/15',    text: 'text-red-400'    },
+  purple: { bg: 'bg-purple-500/15', text: 'text-purple-400' },
+  pink:   { bg: 'bg-pink-500/15',   text: 'text-pink-400'   },
+  cyan:   { bg: 'bg-cyan-500/15',   text: 'text-cyan-400'   },
+  orange: { bg: 'bg-orange-500/15', text: 'text-orange-400' },
+}
+
+const DEFAULT_COLOR = { bg: 'bg-surface-200', text: 'text-text-secondary' }
+
+interface TagPillProps {
+  name: string
+  color: string
+  size?: 'sm' | 'md'
+  onRemove?: () => void
+  onClick?: () => void
+  active?: boolean
+}
+
+export function TagPill({ name, color, size = 'sm', onRemove, onClick, active }: TagPillProps) {
+  const colors = TAG_COLOR_MAP[color] ?? DEFAULT_COLOR
+
+  return (
+    <span
+      onClick={onClick}
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full font-medium transition-colors',
+        size === 'sm' ? 'px-1.5 py-0.5 text-[10px]' : 'px-2 py-0.5 text-[11px]',
+        colors.bg,
+        colors.text,
+        onClick && 'cursor-pointer hover:opacity-80',
+        active && 'ring-1 ring-current'
+      )}
+    >
+      {name}
+      {onRemove && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation()
+            onRemove()
+          }}
+          className="hover:opacity-60 transition-opacity"
+        >
+          <XMarkIcon className={size === 'sm' ? 'w-2.5 h-2.5' : 'w-3 h-3'} />
+        </button>
+      )}
+    </span>
+  )
+}
+
+export { TAG_COLOR_MAP }

--- a/src/renderer/src/components/board/TaskDetailPanel.tsx
+++ b/src/renderer/src/components/board/TaskDetailPanel.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
 import { useBoardStore } from '../../store/board-store'
+import { useSessionStore } from '../../store/session-store'
 import type { BoardTask } from '../../../../preload/index.d'
 
 function formatFullDate(ts: number): string {
@@ -16,10 +18,19 @@ function formatFullDate(ts: number): string {
 interface TaskDetailPanelProps {
   task: BoardTask | null
   onClose: () => void
+  onRunTask?: (task: BoardTask) => void
+  onViewSession?: (sessionId: string) => void
 }
 
-export function TaskDetailPanel({ task, onClose }: TaskDetailPanelProps) {
+export function TaskDetailPanel({ task, onClose, onRunTask, onViewSession }: TaskDetailPanelProps) {
   const updateTask = useBoardStore((s) => s.updateTask)
+  const linkedSession = useSessionStore((s) =>
+    task?.sessionId ? s.sessions.find((sess) => sess.id === task.sessionId) : undefined
+  )
+  const sessionAlive = linkedSession?.alive === true
+  const activityStatus = linkedSession?.activityStatus ?? null
+  const promptWaiting = linkedSession?.promptWaiting ?? null
+  const canResume = linkedSession != null && !sessionAlive
 
   const [title, setTitle] = useState('')
   const [notes, setNotes] = useState('')
@@ -187,6 +198,92 @@ export function TaskDetailPanel({ task, onClose }: TaskDetailPanelProps) {
                     Skip permissions
                   </span>
                 </label>
+
+                {/* Session status & actions */}
+                {task.sessionId && (
+                  <div className="pt-3 border-t border-border-subtle">
+                    <div className="flex items-center gap-2">
+                      {sessionAlive && promptWaiting ? (
+                        <>
+                          <span className="w-2 h-2 rounded-full bg-amber-400 animate-pulse" />
+                          <span className="text-xs text-amber-400">
+                            {promptWaiting === 'is asking for permission'
+                              ? 'Needs permission'
+                              : 'Waiting for input'}
+                          </span>
+                        </>
+                      ) : sessionAlive && activityStatus === 'active' ? (
+                        <>
+                          <span className="w-2 h-2 rounded-full bg-green-400 animate-pulse" />
+                          <span className="text-xs text-green-400">Working</span>
+                        </>
+                      ) : sessionAlive && activityStatus === 'idle' ? (
+                        <>
+                          <span className="w-2 h-2 rounded-full bg-blue-400" />
+                          <span className="text-xs text-blue-400">Idle</span>
+                        </>
+                      ) : (
+                        <>
+                          <span className="w-2 h-2 rounded-full bg-text-tertiary" />
+                          <span className="text-xs text-text-tertiary">Session ended</span>
+                        </>
+                      )}
+
+                      <div className="ml-auto flex items-center gap-2">
+                        {linkedSession && (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              save()
+                              onClose()
+                              onViewSession?.(task.sessionId!)
+                            }}
+                            className="h-7 px-3 rounded-lg text-xs font-medium bg-accent/10 hover:bg-accent/20 text-accent transition-colors flex items-center gap-1"
+                          >
+                            <ArrowTopRightOnSquareIcon className="w-3.5 h-3.5" />
+                            View
+                          </button>
+                        )}
+                        {canResume && onRunTask && (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              save()
+                              onClose()
+                              onRunTask(task)
+                            }}
+                            className="h-7 px-3 rounded-lg text-xs font-medium bg-green-500/10 hover:bg-green-500/20 text-green-500 transition-colors flex items-center gap-1"
+                          >
+                            <svg width="8" height="8" viewBox="0 0 12 12" fill="none">
+                              <path d="M3 1.5L10 6L3 10.5V1.5Z" fill="currentColor" />
+                            </svg>
+                            Resume
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                {/* Run button for tasks without a session */}
+                {!task.sessionId && task.prompt.trim() && onRunTask && (
+                  <div className="pt-3 border-t border-border-subtle">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        save()
+                        onClose()
+                        onRunTask(task)
+                      }}
+                      className="h-7 px-3 rounded-lg text-xs font-medium bg-green-500/10 hover:bg-green-500/20 text-green-500 transition-colors flex items-center gap-1"
+                    >
+                      <svg width="8" height="8" viewBox="0 0 12 12" fill="none">
+                        <path d="M3 1.5L10 6L3 10.5V1.5Z" fill="currentColor" />
+                      </svg>
+                      Run
+                    </button>
+                  </div>
+                )}
 
                 {/* Metadata */}
                 <div className="pt-2 border-t border-border-subtle text-[11px] text-text-tertiary space-y-0.5">

--- a/src/renderer/src/components/board/TaskDetailPanel.tsx
+++ b/src/renderer/src/components/board/TaskDetailPanel.tsx
@@ -3,8 +3,9 @@ import { motion, AnimatePresence } from 'framer-motion'
 import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
 import { useBoardStore } from '../../store/board-store'
 import { TagInput } from './TagInput'
+import { AttachmentList } from './AttachmentList'
 import { useSessionStore } from '../../store/session-store'
-import type { BoardTask } from '../../../../preload/index.d'
+import type { BoardTask, TaskAttachment } from '../../../../preload/index.d'
 import { TaskHistorySection } from './TaskHistorySection'
 import { useHistoryStore } from '../../store/history-store'
 
@@ -41,6 +42,7 @@ export function TaskDetailPanel({ task, onClose, onRunTask, onViewSession }: Tas
   const [cwd, setCwd] = useState('')
   const [dangerousMode, setDangerousMode] = useState(false)
   const [tags, setTags] = useState<string[]>([])
+  const [attachments, setAttachments] = useState<TaskAttachment[]>([])
   const notesRef = useRef<HTMLTextAreaElement>(null)
 
   useEffect(() => {
@@ -51,6 +53,7 @@ export function TaskDetailPanel({ task, onClose, onRunTask, onViewSession }: Tas
       setCwd(task.cwd)
       setDangerousMode(task.dangerousMode)
       setTags(task.tags ?? [])
+      setAttachments(task.attachments ?? [])
     }
   }, [task])
 
@@ -62,9 +65,10 @@ export function TaskDetailPanel({ task, onClose, onRunTask, onViewSession }: Tas
       prompt: prompt.trim(),
       cwd: cwd.trim(),
       dangerousMode,
-      tags
+      tags,
+      attachments
     })
-  }, [task, title, notes, prompt, cwd, dangerousMode, tags, updateTask])
+  }, [task, title, notes, prompt, cwd, dangerousMode, tags, attachments, updateTask])
 
   const selectHistorySession = useHistoryStore((s) => s.selectSession)
 
@@ -169,6 +173,15 @@ export function TaskDetailPanel({ task, onClose, onRunTask, onViewSession }: Tas
                     className="w-full px-3 py-2 rounded-lg bg-surface-200 border-none text-sm text-text-primary placeholder:text-text-tertiary outline-none focus:ring-1 focus:ring-border transition-colors resize-y font-mono"
                   />
                 </div>
+
+                {/* Attachments */}
+                <AttachmentList
+                  attachments={attachments}
+                  onChange={(newAttachments) => {
+                    setAttachments(newAttachments)
+                    if (task) updateTask(task.id, { attachments: newAttachments })
+                  }}
+                />
 
                 {/* Folder */}
                 <div>

--- a/src/renderer/src/components/board/TaskDetailPanel.tsx
+++ b/src/renderer/src/components/board/TaskDetailPanel.tsx
@@ -1,0 +1,206 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { useBoardStore } from '../../store/board-store'
+import type { BoardTask } from '../../../../preload/index.d'
+
+function formatFullDate(ts: number): string {
+  return new Date(ts).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  })
+}
+
+interface TaskDetailPanelProps {
+  task: BoardTask | null
+  onClose: () => void
+}
+
+export function TaskDetailPanel({ task, onClose }: TaskDetailPanelProps) {
+  const updateTask = useBoardStore((s) => s.updateTask)
+
+  const [title, setTitle] = useState('')
+  const [notes, setNotes] = useState('')
+  const [prompt, setPrompt] = useState('')
+  const [cwd, setCwd] = useState('')
+  const [dangerousMode, setDangerousMode] = useState(false)
+  const notesRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    if (task) {
+      setTitle(task.title)
+      setNotes(task.notes)
+      setPrompt(task.prompt)
+      setCwd(task.cwd)
+      setDangerousMode(task.dangerousMode)
+    }
+  }, [task])
+
+  const save = useCallback(() => {
+    if (!task) return
+    updateTask(task.id, {
+      title: title.trim(),
+      notes: notes.trim(),
+      prompt: prompt.trim(),
+      cwd: cwd.trim(),
+      dangerousMode
+    })
+  }, [task, title, notes, prompt, cwd, dangerousMode, updateTask])
+
+  const handleBlur = useCallback(() => {
+    save()
+  }, [save])
+
+  const handlePickFolder = useCallback(async () => {
+    const folder = await window.electronAPI?.openFolderDialog()
+    if (folder) {
+      setCwd(folder)
+      if (task) updateTask(task.id, { cwd: folder })
+    }
+  }, [task, updateTask])
+
+  useEffect(() => {
+    if (!task) return
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        save()
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', handleEscape)
+    return () => window.removeEventListener('keydown', handleEscape)
+  }, [task, save, onClose])
+
+  return (
+    <AnimatePresence>
+      {task && (
+        <>
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            className="fixed inset-0 bg-black/40 z-50"
+            onClick={() => {
+              save()
+              onClose()
+            }}
+          />
+          <motion.div
+            initial={{ opacity: 0, scale: 0.96, y: -8 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.96, y: -8 }}
+            transition={{ duration: 0.15, ease: [0.2, 0, 0, 1] }}
+            className="fixed z-50 left-1/2 -translate-x-1/2 w-[560px] max-h-[80vh] overflow-y-auto"
+            style={{ top: '10%' }}
+          >
+            <div className="bg-surface-100 rounded-xl border border-border shadow-2xl overflow-hidden">
+              <div className="px-5 pt-4 pb-3">
+                <input
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  onBlur={handleBlur}
+                  placeholder="Task title"
+                  className="w-full text-base font-semibold text-text-primary bg-transparent outline-none placeholder:text-text-tertiary"
+                />
+              </div>
+
+              <div className="px-5 space-y-4 pb-5">
+                {/* Notes */}
+                <div>
+                  <label className="block text-xs font-medium text-text-secondary mb-1">Notes</label>
+                  <textarea
+                    ref={notesRef}
+                    value={notes}
+                    onChange={(e) => setNotes(e.target.value)}
+                    onBlur={handleBlur}
+                    placeholder="Context, reasoning, acceptance criteria, links..."
+                    rows={5}
+                    className="w-full px-3 py-2 rounded-lg bg-surface-200 border-none text-sm text-text-primary placeholder:text-text-tertiary outline-none focus:ring-1 focus:ring-border transition-colors resize-y"
+                  />
+                </div>
+
+                {/* Prompt */}
+                <div>
+                  <label className="block text-xs font-medium text-text-secondary mb-1">
+                    Prompt <span className="font-normal text-text-tertiary">(sent to Claude Code on run)</span>
+                  </label>
+                  <textarea
+                    value={prompt}
+                    onChange={(e) => setPrompt(e.target.value)}
+                    onBlur={handleBlur}
+                    placeholder="Instructions for Claude Code..."
+                    rows={4}
+                    className="w-full px-3 py-2 rounded-lg bg-surface-200 border-none text-sm text-text-primary placeholder:text-text-tertiary outline-none focus:ring-1 focus:ring-border transition-colors resize-y font-mono"
+                  />
+                </div>
+
+                {/* Folder */}
+                <div>
+                  <label className="block text-xs font-medium text-text-secondary mb-1">Folder</label>
+                  <div className="flex gap-2">
+                    <input
+                      type="text"
+                      value={cwd}
+                      readOnly
+                      placeholder="Select a folder..."
+                      className="flex-1 h-8 px-3 rounded-lg bg-surface-200 border-none text-sm text-text-primary placeholder:text-text-tertiary outline-none cursor-default truncate"
+                    />
+                    <button
+                      type="button"
+                      onClick={handlePickFolder}
+                      className="h-8 px-3 rounded-lg bg-surface-200 hover:bg-surface-300 text-text-secondary hover:text-text-primary text-xs font-medium transition-colors flex-shrink-0"
+                    >
+                      Browse
+                    </button>
+                  </div>
+                </div>
+
+                {/* Danger mode */}
+                <label className="flex items-center gap-2 cursor-pointer group">
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={dangerousMode}
+                    onClick={() => {
+                      setDangerousMode(!dangerousMode)
+                      if (task) updateTask(task.id, { dangerousMode: !dangerousMode })
+                    }}
+                    className={`relative w-8 h-[18px] rounded-full transition-colors flex-shrink-0 ${dangerousMode ? 'bg-red-500' : 'bg-surface-300'}`}
+                  >
+                    <span className={`absolute top-[2px] left-[2px] w-[14px] h-[14px] rounded-full bg-white transition-transform ${dangerousMode ? 'translate-x-[14px]' : ''}`} />
+                  </button>
+                  <span className={`text-xs transition-colors ${dangerousMode ? 'text-red-400' : 'text-text-secondary group-hover:text-text-primary'}`}>
+                    Skip permissions
+                  </span>
+                </label>
+
+                {/* Metadata */}
+                <div className="pt-2 border-t border-border-subtle text-[11px] text-text-tertiary space-y-0.5">
+                  <div>Created {formatFullDate(task.createdAt)}</div>
+                  <div>Updated {formatFullDate(task.updatedAt)}</div>
+                  {task.sessionId && <div>Linked session: {task.sessionId.slice(0, 8)}...</div>}
+                </div>
+              </div>
+
+              {/* Footer */}
+              <div className="px-5 py-3 border-t border-border-subtle flex justify-end">
+                <button
+                  onClick={() => {
+                    save()
+                    onClose()
+                  }}
+                  className="h-7 px-4 rounded-lg text-xs font-medium bg-accent text-white hover:bg-accent/90 transition-colors"
+                >
+                  Done
+                </button>
+              </div>
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/src/renderer/src/components/board/TaskDetailPanel.tsx
+++ b/src/renderer/src/components/board/TaskDetailPanel.tsx
@@ -110,7 +110,9 @@ export function TaskDetailPanel({ task, onClose }: TaskDetailPanelProps) {
               <div className="px-5 space-y-4 pb-5">
                 {/* Notes */}
                 <div>
-                  <label className="block text-xs font-medium text-text-secondary mb-1">Notes</label>
+                  <label className="block text-xs font-medium text-text-secondary mb-1">
+                    Notes
+                  </label>
                   <textarea
                     ref={notesRef}
                     value={notes}
@@ -125,7 +127,10 @@ export function TaskDetailPanel({ task, onClose }: TaskDetailPanelProps) {
                 {/* Prompt */}
                 <div>
                   <label className="block text-xs font-medium text-text-secondary mb-1">
-                    Prompt <span className="font-normal text-text-tertiary">(sent to Claude Code on run)</span>
+                    Prompt{' '}
+                    <span className="font-normal text-text-tertiary">
+                      (sent to Claude Code on run)
+                    </span>
                   </label>
                   <textarea
                     value={prompt}
@@ -139,7 +144,9 @@ export function TaskDetailPanel({ task, onClose }: TaskDetailPanelProps) {
 
                 {/* Folder */}
                 <div>
-                  <label className="block text-xs font-medium text-text-secondary mb-1">Folder</label>
+                  <label className="block text-xs font-medium text-text-secondary mb-1">
+                    Folder
+                  </label>
                   <div className="flex gap-2">
                     <input
                       type="text"
@@ -170,9 +177,13 @@ export function TaskDetailPanel({ task, onClose }: TaskDetailPanelProps) {
                     }}
                     className={`relative w-8 h-[18px] rounded-full transition-colors flex-shrink-0 ${dangerousMode ? 'bg-red-500' : 'bg-surface-300'}`}
                   >
-                    <span className={`absolute top-[2px] left-[2px] w-[14px] h-[14px] rounded-full bg-white transition-transform ${dangerousMode ? 'translate-x-[14px]' : ''}`} />
+                    <span
+                      className={`absolute top-[2px] left-[2px] w-[14px] h-[14px] rounded-full bg-white transition-transform ${dangerousMode ? 'translate-x-[14px]' : ''}`}
+                    />
                   </button>
-                  <span className={`text-xs transition-colors ${dangerousMode ? 'text-red-400' : 'text-text-secondary group-hover:text-text-primary'}`}>
+                  <span
+                    className={`text-xs transition-colors ${dangerousMode ? 'text-red-400' : 'text-text-secondary group-hover:text-text-primary'}`}
+                  >
                     Skip permissions
                   </span>
                 </label>

--- a/src/renderer/src/components/board/TaskDetailPanel.tsx
+++ b/src/renderer/src/components/board/TaskDetailPanel.tsx
@@ -5,6 +5,8 @@ import { useBoardStore } from '../../store/board-store'
 import { TagInput } from './TagInput'
 import { useSessionStore } from '../../store/session-store'
 import type { BoardTask } from '../../../../preload/index.d'
+import { TaskHistorySection } from './TaskHistorySection'
+import { useHistoryStore } from '../../store/history-store'
 
 function formatFullDate(ts: number): string {
   return new Date(ts).toLocaleString(undefined, {
@@ -63,6 +65,17 @@ export function TaskDetailPanel({ task, onClose, onRunTask, onViewSession }: Tas
       tags
     })
   }, [task, title, notes, prompt, cwd, dangerousMode, tags, updateTask])
+
+  const selectHistorySession = useHistoryStore((s) => s.selectSession)
+
+  const handleBrowseHistory = useCallback(
+    (historySession: import('../../store/history-store').HistorySession) => {
+      save()
+      onClose()
+      selectHistorySession(historySession)
+    },
+    [save, onClose, selectHistorySession]
+  )
 
   const handleBlur = useCallback(() => {
     save()
@@ -300,6 +313,19 @@ export function TaskDetailPanel({ task, onClose, onRunTask, onViewSession }: Tas
                       </svg>
                       Run
                     </button>
+                  </div>
+                )}
+
+                {/* History */}
+                {task.claudeSessionId && (
+                  <div className="pt-3 border-t border-border-subtle">
+                    <label className="block text-xs font-medium text-text-secondary mb-1.5">
+                      History
+                    </label>
+                    <TaskHistorySection
+                      claudeSessionId={task.claudeSessionId}
+                      onBrowseHistory={handleBrowseHistory}
+                    />
                   </div>
                 )}
 

--- a/src/renderer/src/components/board/TaskDetailPanel.tsx
+++ b/src/renderer/src/components/board/TaskDetailPanel.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
 import { useBoardStore } from '../../store/board-store'
+import { TagInput } from './TagInput'
 import { useSessionStore } from '../../store/session-store'
 import type { BoardTask } from '../../../../preload/index.d'
 
@@ -37,6 +38,7 @@ export function TaskDetailPanel({ task, onClose, onRunTask, onViewSession }: Tas
   const [prompt, setPrompt] = useState('')
   const [cwd, setCwd] = useState('')
   const [dangerousMode, setDangerousMode] = useState(false)
+  const [tags, setTags] = useState<string[]>([])
   const notesRef = useRef<HTMLTextAreaElement>(null)
 
   useEffect(() => {
@@ -46,6 +48,7 @@ export function TaskDetailPanel({ task, onClose, onRunTask, onViewSession }: Tas
       setPrompt(task.prompt)
       setCwd(task.cwd)
       setDangerousMode(task.dangerousMode)
+      setTags(task.tags ?? [])
     }
   }, [task])
 
@@ -56,9 +59,10 @@ export function TaskDetailPanel({ task, onClose, onRunTask, onViewSession }: Tas
       notes: notes.trim(),
       prompt: prompt.trim(),
       cwd: cwd.trim(),
-      dangerousMode
+      dangerousMode,
+      tags
     })
-  }, [task, title, notes, prompt, cwd, dangerousMode, updateTask])
+  }, [task, title, notes, prompt, cwd, dangerousMode, tags, updateTask])
 
   const handleBlur = useCallback(() => {
     save()
@@ -198,6 +202,20 @@ export function TaskDetailPanel({ task, onClose, onRunTask, onViewSession }: Tas
                     Skip permissions
                   </span>
                 </label>
+
+                {/* Tags */}
+                <div>
+                  <label className="block text-xs font-medium text-text-secondary mb-1">
+                    Tags
+                  </label>
+                  <TagInput
+                    tags={tags}
+                    onChange={(newTags) => {
+                      setTags(newTags)
+                      if (task) updateTask(task.id, { tags: newTags })
+                    }}
+                  />
+                </div>
 
                 {/* Session status & actions */}
                 {task.sessionId && (

--- a/src/renderer/src/components/board/TaskDetailPanel.tsx
+++ b/src/renderer/src/components/board/TaskDetailPanel.tsx
@@ -31,7 +31,7 @@ export function TaskDetailPanel({ task, onClose, onRunTask, onViewSession }: Tas
   const sessionAlive = linkedSession?.alive === true
   const activityStatus = linkedSession?.activityStatus ?? null
   const promptWaiting = linkedSession?.promptWaiting ?? null
-  const canResume = linkedSession != null && !sessionAlive
+  const canResume = (linkedSession != null && !sessionAlive) || (!linkedSession && !!task?.claudeSessionId)
 
   const [title, setTitle] = useState('')
   const [notes, setNotes] = useState('')

--- a/src/renderer/src/components/board/TaskForm.tsx
+++ b/src/renderer/src/components/board/TaskForm.tsx
@@ -133,8 +133,8 @@ export function TaskForm({ isOpen, onClose, columnId, editTask }: TaskFormProps)
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.96, y: -8 }}
             transition={{ duration: 0.15, ease: [0.2, 0, 0, 1] }}
-            className="fixed z-50 left-1/2 -translate-x-1/2 w-[480px]"
-            style={{ top: '15%' }}
+            className="fixed z-50 left-1/2 -translate-x-1/2 w-[480px] max-h-[80vh] overflow-y-auto"
+            style={{ top: '10%' }}
           >
             <form
               onSubmit={handleSubmit}

--- a/src/renderer/src/components/board/TaskForm.tsx
+++ b/src/renderer/src/components/board/TaskForm.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useBoardStore } from '../../store/board-store'
+import { TagInput } from './TagInput'
 
 interface TaskFormProps {
   isOpen: boolean
@@ -13,6 +14,7 @@ interface TaskFormProps {
     notes: string
     cwd: string
     dangerousMode: boolean
+    tags?: string[]
   } | null
 }
 
@@ -25,6 +27,7 @@ export function TaskForm({ isOpen, onClose, columnId, editTask }: TaskFormProps)
   const [prompt, setPrompt] = useState('')
   const [cwd, setCwd] = useState('')
   const [dangerousMode, setDangerousMode] = useState(false)
+  const [tags, setTags] = useState<string[]>([])
   const titleRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
@@ -35,12 +38,14 @@ export function TaskForm({ isOpen, onClose, columnId, editTask }: TaskFormProps)
         setPrompt(editTask.prompt)
         setCwd(editTask.cwd)
         setDangerousMode(editTask.dangerousMode)
+        setTags(editTask.tags ?? [])
       } else {
         setTitle('')
         setNotes('')
         setPrompt('')
         setCwd('')
         setDangerousMode(false)
+        setTags([])
       }
       setTimeout(() => titleRef.current?.focus(), 50)
     }
@@ -74,7 +79,8 @@ export function TaskForm({ isOpen, onClose, columnId, editTask }: TaskFormProps)
           notes: notes.trim(),
           prompt: prompt.trim(),
           cwd: cwd.trim(),
-          dangerousMode
+          dangerousMode,
+          tags
         })
       } else {
         addTask({
@@ -83,13 +89,13 @@ export function TaskForm({ isOpen, onClose, columnId, editTask }: TaskFormProps)
           prompt: prompt.trim(),
           cwd: cwd.trim(),
           dangerousMode,
-          tags: [],
+          tags,
           columnId
         })
       }
       onClose()
     },
-    [title, notes, prompt, cwd, dangerousMode, columnId, editTask, addTask, updateTask, onClose]
+    [title, notes, prompt, cwd, dangerousMode, tags, columnId, editTask, addTask, updateTask, onClose]
   )
 
   const handleKeyDown = useCallback(
@@ -213,6 +219,12 @@ export function TaskForm({ isOpen, onClose, columnId, editTask }: TaskFormProps)
                     Skip permissions
                   </span>
                 </label>
+
+                {/* Tags */}
+                <div>
+                  <label className="block text-xs text-text-secondary mb-1">Tags</label>
+                  <TagInput tags={tags} onChange={setTags} />
+                </div>
               </div>
 
               <div className="px-5 py-3 border-t border-border-subtle flex items-center justify-between">

--- a/src/renderer/src/components/board/TaskForm.tsx
+++ b/src/renderer/src/components/board/TaskForm.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useBoardStore } from '../../store/board-store'
 import { TagInput } from './TagInput'
+import { AttachmentList } from './AttachmentList'
+import type { TaskAttachment } from '../../../../preload/index.d'
 
 interface TaskFormProps {
   isOpen: boolean
@@ -15,6 +17,7 @@ interface TaskFormProps {
     cwd: string
     dangerousMode: boolean
     tags?: string[]
+    attachments?: TaskAttachment[]
   } | null
 }
 
@@ -28,6 +31,7 @@ export function TaskForm({ isOpen, onClose, columnId, editTask }: TaskFormProps)
   const [cwd, setCwd] = useState('')
   const [dangerousMode, setDangerousMode] = useState(false)
   const [tags, setTags] = useState<string[]>([])
+  const [attachments, setAttachments] = useState<TaskAttachment[]>([])
   const titleRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
@@ -39,6 +43,7 @@ export function TaskForm({ isOpen, onClose, columnId, editTask }: TaskFormProps)
         setCwd(editTask.cwd)
         setDangerousMode(editTask.dangerousMode)
         setTags(editTask.tags ?? [])
+        setAttachments(editTask.attachments ?? [])
       } else {
         setTitle('')
         setNotes('')
@@ -46,6 +51,7 @@ export function TaskForm({ isOpen, onClose, columnId, editTask }: TaskFormProps)
         setCwd('')
         setDangerousMode(false)
         setTags([])
+        setAttachments([])
       }
       setTimeout(() => titleRef.current?.focus(), 50)
     }
@@ -80,7 +86,8 @@ export function TaskForm({ isOpen, onClose, columnId, editTask }: TaskFormProps)
           prompt: prompt.trim(),
           cwd: cwd.trim(),
           dangerousMode,
-          tags
+          tags,
+          attachments
         })
       } else {
         addTask({
@@ -90,12 +97,13 @@ export function TaskForm({ isOpen, onClose, columnId, editTask }: TaskFormProps)
           cwd: cwd.trim(),
           dangerousMode,
           tags,
+          attachments,
           columnId
         })
       }
       onClose()
     },
-    [title, notes, prompt, cwd, dangerousMode, tags, columnId, editTask, addTask, updateTask, onClose]
+    [title, notes, prompt, cwd, dangerousMode, tags, attachments, columnId, editTask, addTask, updateTask, onClose]
   )
 
   const handleKeyDown = useCallback(
@@ -178,6 +186,9 @@ export function TaskForm({ isOpen, onClose, columnId, editTask }: TaskFormProps)
                     className="w-full px-3 py-2 rounded-lg bg-surface-200 border-none text-sm text-text-primary placeholder:text-text-tertiary outline-none focus:ring-1 focus:ring-border transition-colors resize-none font-mono"
                   />
                 </div>
+
+                {/* Attachments */}
+                <AttachmentList attachments={attachments} onChange={setAttachments} />
 
                 {/* Folder */}
                 <div>

--- a/src/renderer/src/components/board/TaskForm.tsx
+++ b/src/renderer/src/components/board/TaskForm.tsx
@@ -5,33 +5,37 @@ import { useBoardStore } from '../../store/board-store'
 interface TaskFormProps {
   isOpen: boolean
   onClose: () => void
-  editTask?: { id: string; title: string; prompt: string; cwd: string; dangerousMode: boolean } | null
+  columnId?: string
+  editTask?: { id: string; title: string; prompt: string; notes: string; cwd: string; dangerousMode: boolean } | null
 }
 
-export function TaskForm({ isOpen, onClose, editTask }: TaskFormProps) {
+export function TaskForm({ isOpen, onClose, columnId, editTask }: TaskFormProps) {
   const addTask = useBoardStore((s) => s.addTask)
   const updateTask = useBoardStore((s) => s.updateTask)
 
+  const [title, setTitle] = useState('')
+  const [notes, setNotes] = useState('')
   const [prompt, setPrompt] = useState('')
   const [cwd, setCwd] = useState('')
   const [dangerousMode, setDangerousMode] = useState(false)
-  const [title, setTitle] = useState('')
-  const promptRef = useRef<HTMLTextAreaElement>(null)
+  const titleRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     if (isOpen) {
       if (editTask) {
+        setTitle(editTask.title)
+        setNotes(editTask.notes)
         setPrompt(editTask.prompt)
         setCwd(editTask.cwd)
         setDangerousMode(editTask.dangerousMode)
-        setTitle(editTask.title)
       } else {
+        setTitle('')
+        setNotes('')
         setPrompt('')
         setCwd('')
         setDangerousMode(false)
-        setTitle('')
       }
-      setTimeout(() => promptRef.current?.focus(), 50)
+      setTimeout(() => titleRef.current?.focus(), 50)
     }
   }, [isOpen, editTask])
 
@@ -55,16 +59,29 @@ export function TaskForm({ isOpen, onClose, editTask }: TaskFormProps) {
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
       e.preventDefault()
-      if (!prompt.trim() || !cwd.trim()) return
+      if (!cwd.trim()) return
 
       if (editTask) {
-        updateTask(editTask.id, { title: title.trim(), prompt: prompt.trim(), cwd: cwd.trim(), dangerousMode })
+        updateTask(editTask.id, {
+          title: title.trim(),
+          notes: notes.trim(),
+          prompt: prompt.trim(),
+          cwd: cwd.trim(),
+          dangerousMode
+        })
       } else {
-        addTask({ title: title.trim(), prompt: prompt.trim(), cwd: cwd.trim(), dangerousMode })
+        addTask({
+          title: title.trim(),
+          notes: notes.trim(),
+          prompt: prompt.trim(),
+          cwd: cwd.trim(),
+          dangerousMode,
+          columnId
+        })
       }
       onClose()
     },
-    [title, prompt, cwd, dangerousMode, editTask, addTask, updateTask, onClose]
+    [title, notes, prompt, cwd, dangerousMode, columnId, editTask, addTask, updateTask, onClose]
   )
 
   const handleKeyDown = useCallback(
@@ -78,121 +95,139 @@ export function TaskForm({ isOpen, onClose, editTask }: TaskFormProps) {
   )
 
   return (
-      <AnimatePresence>
-        {isOpen && (
-          <>
-            <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.15 }}
-              className="fixed inset-0 bg-black/40 z-50"
-              onClick={onClose}
-            />
-            <motion.div
-              initial={{ opacity: 0, scale: 0.96, y: -8 }}
-              animate={{ opacity: 1, scale: 1, y: 0 }}
-              exit={{ opacity: 0, scale: 0.96, y: -8 }}
-              transition={{ duration: 0.15, ease: [0.2, 0, 0, 1] }}
-              className="fixed z-50 left-1/2 -translate-x-1/2 w-[480px]"
-              style={{ top: '20%' }}
+    <AnimatePresence>
+      {isOpen && (
+        <>
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            className="fixed inset-0 bg-black/40 z-50"
+            onClick={onClose}
+          />
+          <motion.div
+            initial={{ opacity: 0, scale: 0.96, y: -8 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.96, y: -8 }}
+            transition={{ duration: 0.15, ease: [0.2, 0, 0, 1] }}
+            className="fixed z-50 left-1/2 -translate-x-1/2 w-[480px]"
+            style={{ top: '15%' }}
+          >
+            <form
+              onSubmit={handleSubmit}
+              onKeyDown={handleKeyDown}
+              className="bg-surface-100 rounded-xl border border-border shadow-2xl overflow-hidden"
             >
-              <form
-                onSubmit={handleSubmit}
-                onKeyDown={handleKeyDown}
-                className="bg-surface-100 rounded-xl border border-border shadow-2xl overflow-hidden"
-              >
-                <div className="px-5 pt-4 pb-3">
-                  <h2 className="text-sm font-semibold text-text-primary">
-                    {editTask ? 'Edit Task' : 'New Task'}
-                  </h2>
+              <div className="px-5 pt-4 pb-3">
+                <h2 className="text-sm font-semibold text-text-primary">
+                  {editTask ? 'Edit Task' : 'New Task'}
+                </h2>
+              </div>
+
+              <div className="px-5 space-y-3 pb-4">
+                {/* Title */}
+                <div>
+                  <label className="block text-xs text-text-secondary mb-1">Title</label>
+                  <input
+                    ref={titleRef}
+                    type="text"
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                    placeholder="Short label for the task"
+                    className="w-full h-8 px-3 rounded-lg bg-surface-200 border-none text-sm text-text-primary placeholder:text-text-tertiary outline-none focus:ring-1 focus:ring-border transition-colors"
+                  />
                 </div>
 
-                <div className="px-5 space-y-3 pb-4">
-                  <div>
-                    <label className="block text-xs text-text-secondary mb-1">Prompt</label>
-                    <textarea
-                      ref={promptRef}
-                      value={prompt}
-                      onChange={(e) => setPrompt(e.target.value)}
-                      placeholder="Instructions for Claude Code..."
-                      rows={4}
-                      className="w-full px-3 py-2 rounded-lg bg-surface-200 border-none text-sm text-text-primary placeholder:text-text-tertiary outline-none focus:ring-1 focus:ring-border transition-colors resize-none font-mono"
-                    />
-                  </div>
+                {/* Notes */}
+                <div>
+                  <label className="block text-xs text-text-secondary mb-1">Notes</label>
+                  <textarea
+                    value={notes}
+                    onChange={(e) => setNotes(e.target.value)}
+                    placeholder="Context, reasoning, acceptance criteria..."
+                    rows={3}
+                    className="w-full px-3 py-2 rounded-lg bg-surface-200 border-none text-sm text-text-primary placeholder:text-text-tertiary outline-none focus:ring-1 focus:ring-border transition-colors resize-none"
+                  />
+                </div>
 
-                  <div>
-                    <label className="block text-xs text-text-secondary mb-1">Folder</label>
-                    <div className="flex gap-2">
-                      <input
-                        type="text"
-                        value={cwd}
-                        readOnly
-                        placeholder="Select a folder..."
-                        className="flex-1 h-8 px-3 rounded-lg bg-surface-200 border-none text-sm text-text-primary placeholder:text-text-tertiary outline-none cursor-default truncate"
-                      />
-                      <button
-                        type="button"
-                        onClick={handlePickFolder}
-                        className="h-8 px-3 rounded-lg bg-surface-200 hover:bg-surface-300 text-text-secondary hover:text-text-primary text-xs font-medium transition-colors flex-shrink-0"
-                      >
-                        Browse
-                      </button>
-                    </div>
-                  </div>
-
-                  <label className="flex items-center gap-2 cursor-pointer group">
-                    <button
-                      type="button"
-                      role="switch"
-                      aria-checked={dangerousMode}
-                      onClick={() => setDangerousMode(!dangerousMode)}
-                      className={`relative w-8 h-[18px] rounded-full transition-colors flex-shrink-0 ${dangerousMode ? 'bg-red-500' : 'bg-surface-300'}`}
-                    >
-                      <span className={`absolute top-[2px] left-[2px] w-[14px] h-[14px] rounded-full bg-white transition-transform ${dangerousMode ? 'translate-x-[14px]' : ''}`} />
-                    </button>
-                    <span className={`text-xs transition-colors ${dangerousMode ? 'text-red-400' : 'text-text-secondary group-hover:text-text-primary'}`}>
-                      Skip permissions
-                    </span>
+                {/* Prompt */}
+                <div>
+                  <label className="block text-xs text-text-secondary mb-1">
+                    Prompt <span className="text-text-tertiary">(optional — required to run)</span>
                   </label>
+                  <textarea
+                    value={prompt}
+                    onChange={(e) => setPrompt(e.target.value)}
+                    placeholder="Instructions for Claude Code..."
+                    rows={3}
+                    className="w-full px-3 py-2 rounded-lg bg-surface-200 border-none text-sm text-text-primary placeholder:text-text-tertiary outline-none focus:ring-1 focus:ring-border transition-colors resize-none font-mono"
+                  />
+                </div>
 
-                  <div>
-                    <label className="block text-xs text-text-tertiary mb-1">Title (optional)</label>
+                {/* Folder */}
+                <div>
+                  <label className="block text-xs text-text-secondary mb-1">Folder</label>
+                  <div className="flex gap-2">
                     <input
                       type="text"
-                      value={title}
-                      onChange={(e) => setTitle(e.target.value)}
-                      placeholder="Short label for the task"
-                      className="w-full h-8 px-3 rounded-lg bg-surface-200 border-none text-sm text-text-primary placeholder:text-text-tertiary outline-none focus:ring-1 focus:ring-border transition-colors"
+                      value={cwd}
+                      readOnly
+                      placeholder="Select a folder..."
+                      className="flex-1 h-8 px-3 rounded-lg bg-surface-200 border-none text-sm text-text-primary placeholder:text-text-tertiary outline-none cursor-default truncate"
                     />
+                    <button
+                      type="button"
+                      onClick={handlePickFolder}
+                      className="h-8 px-3 rounded-lg bg-surface-200 hover:bg-surface-300 text-text-secondary hover:text-text-primary text-xs font-medium transition-colors flex-shrink-0"
+                    >
+                      Browse
+                    </button>
                   </div>
                 </div>
 
-                <div className="px-5 py-3 border-t border-border-subtle flex items-center justify-between">
-                  <span className="text-[11px] text-text-tertiary">
-                    <kbd className="px-1 py-0.5 rounded bg-surface-200 text-text-secondary">Cmd+Enter</kbd> submit
+                {/* Danger mode */}
+                <label className="flex items-center gap-2 cursor-pointer group">
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={dangerousMode}
+                    onClick={() => setDangerousMode(!dangerousMode)}
+                    className={`relative w-8 h-[18px] rounded-full transition-colors flex-shrink-0 ${dangerousMode ? 'bg-red-500' : 'bg-surface-300'}`}
+                  >
+                    <span className={`absolute top-[2px] left-[2px] w-[14px] h-[14px] rounded-full bg-white transition-transform ${dangerousMode ? 'translate-x-[14px]' : ''}`} />
+                  </button>
+                  <span className={`text-xs transition-colors ${dangerousMode ? 'text-red-400' : 'text-text-secondary group-hover:text-text-primary'}`}>
+                    Skip permissions
                   </span>
-                  <div className="flex gap-2">
-                    <button
-                      type="button"
-                      onClick={onClose}
-                      className="h-7 px-3 rounded-lg text-xs text-text-secondary hover:text-text-primary hover:bg-surface-200 transition-colors"
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      type="submit"
-                      disabled={!prompt.trim() || !cwd.trim()}
-                      className="h-7 px-4 rounded-lg text-xs font-medium bg-accent text-white hover:bg-accent/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-                    >
-                      {editTask ? 'Save' : 'Create'}
-                    </button>
-                  </div>
+                </label>
+              </div>
+
+              <div className="px-5 py-3 border-t border-border-subtle flex items-center justify-between">
+                <span className="text-[11px] text-text-tertiary">
+                  <kbd className="px-1 py-0.5 rounded bg-surface-200 text-text-secondary">Cmd+Enter</kbd> submit
+                </span>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={onClose}
+                    className="h-7 px-3 rounded-lg text-xs text-text-secondary hover:text-text-primary hover:bg-surface-200 transition-colors"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="submit"
+                    disabled={!cwd.trim()}
+                    className="h-7 px-4 rounded-lg text-xs font-medium bg-accent text-white hover:bg-accent/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    {editTask ? 'Save' : 'Create'}
+                  </button>
                 </div>
-              </form>
-            </motion.div>
-          </>
-        )}
-      </AnimatePresence>
+              </div>
+            </form>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
   )
 }

--- a/src/renderer/src/components/board/TaskForm.tsx
+++ b/src/renderer/src/components/board/TaskForm.tsx
@@ -6,7 +6,14 @@ interface TaskFormProps {
   isOpen: boolean
   onClose: () => void
   columnId?: string
-  editTask?: { id: string; title: string; prompt: string; notes: string; cwd: string; dangerousMode: boolean } | null
+  editTask?: {
+    id: string
+    title: string
+    prompt: string
+    notes: string
+    cwd: string
+    dangerousMode: boolean
+  } | null
 }
 
 export function TaskForm({ isOpen, onClose, columnId, editTask }: TaskFormProps) {
@@ -195,9 +202,13 @@ export function TaskForm({ isOpen, onClose, columnId, editTask }: TaskFormProps)
                     onClick={() => setDangerousMode(!dangerousMode)}
                     className={`relative w-8 h-[18px] rounded-full transition-colors flex-shrink-0 ${dangerousMode ? 'bg-red-500' : 'bg-surface-300'}`}
                   >
-                    <span className={`absolute top-[2px] left-[2px] w-[14px] h-[14px] rounded-full bg-white transition-transform ${dangerousMode ? 'translate-x-[14px]' : ''}`} />
+                    <span
+                      className={`absolute top-[2px] left-[2px] w-[14px] h-[14px] rounded-full bg-white transition-transform ${dangerousMode ? 'translate-x-[14px]' : ''}`}
+                    />
                   </button>
-                  <span className={`text-xs transition-colors ${dangerousMode ? 'text-red-400' : 'text-text-secondary group-hover:text-text-primary'}`}>
+                  <span
+                    className={`text-xs transition-colors ${dangerousMode ? 'text-red-400' : 'text-text-secondary group-hover:text-text-primary'}`}
+                  >
                     Skip permissions
                   </span>
                 </label>
@@ -205,7 +216,10 @@ export function TaskForm({ isOpen, onClose, columnId, editTask }: TaskFormProps)
 
               <div className="px-5 py-3 border-t border-border-subtle flex items-center justify-between">
                 <span className="text-[11px] text-text-tertiary">
-                  <kbd className="px-1 py-0.5 rounded bg-surface-200 text-text-secondary">Cmd+Enter</kbd> submit
+                  <kbd className="px-1 py-0.5 rounded bg-surface-200 text-text-secondary">
+                    Cmd+Enter
+                  </kbd>{' '}
+                  submit
                 </span>
                 <div className="flex gap-2">
                   <button

--- a/src/renderer/src/components/board/TaskForm.tsx
+++ b/src/renderer/src/components/board/TaskForm.tsx
@@ -83,6 +83,7 @@ export function TaskForm({ isOpen, onClose, columnId, editTask }: TaskFormProps)
           prompt: prompt.trim(),
           cwd: cwd.trim(),
           dangerousMode,
+          tags: [],
           columnId
         })
       }

--- a/src/renderer/src/components/board/TaskHistorySection.tsx
+++ b/src/renderer/src/components/board/TaskHistorySection.tsx
@@ -1,0 +1,102 @@
+import { useState, useEffect, useMemo } from 'react'
+import { ClockIcon, ChatBubbleLeftRightIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
+import { useHistoryStore, type HistorySession } from '../../store/history-store'
+
+function formatRelativeDate(dateStr: string): string {
+  const date = new Date(dateStr)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffMin = Math.floor(diffMs / 60000)
+  if (diffMin < 1) return 'just now'
+  if (diffMin < 60) return `${diffMin}m ago`
+  const diffHr = Math.floor(diffMin / 60)
+  if (diffHr < 24) return `${diffHr}h ago`
+  const diffDay = Math.floor(diffHr / 24)
+  if (diffDay < 7) return `${diffDay}d ago`
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}
+
+function formatDuration(startStr: string, endStr: string): string {
+  const start = new Date(startStr).getTime()
+  const end = new Date(endStr).getTime()
+  const diffMin = Math.floor((end - start) / 60000)
+  if (diffMin < 1) return '<1m'
+  if (diffMin < 60) return `${diffMin}m`
+  const hours = Math.floor(diffMin / 60)
+  const mins = diffMin % 60
+  return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`
+}
+
+interface TaskHistorySectionProps {
+  claudeSessionId: string
+  onBrowseHistory: (session: HistorySession) => void
+}
+
+export function TaskHistorySection({ claudeSessionId, onBrowseHistory }: TaskHistorySectionProps) {
+  const sessionsByProject = useHistoryStore((s) => s.sessionsByProject)
+  const refresh = useHistoryStore((s) => s.refresh)
+  const [loading, setLoading] = useState(false)
+  const [refreshed, setRefreshed] = useState(false)
+
+  const historySession = useMemo(() => {
+    for (const sessions of Object.values(sessionsByProject)) {
+      const match = sessions.find((s) => s.sessionId === claudeSessionId)
+      if (match) return match
+    }
+    return null
+  }, [sessionsByProject, claudeSessionId])
+
+  useEffect(() => {
+    if (!historySession && !refreshed && !loading) {
+      setLoading(true)
+      setRefreshed(true)
+      refresh().finally(() => setLoading(false))
+    }
+  }, [historySession, refreshed, loading, refresh])
+
+  if (loading) {
+    return (
+      <div className="text-xs text-text-tertiary py-2">
+        Loading history...
+      </div>
+    )
+  }
+
+  if (!historySession) {
+    return (
+      <div className="text-xs text-text-tertiary py-2">
+        Session history not found
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      {historySession.summary && (
+        <p className="text-xs text-text-secondary line-clamp-3">
+          {historySession.summary}
+        </p>
+      )}
+
+      <div className="flex items-center gap-3 text-[11px] text-text-tertiary">
+        <span className="flex items-center gap-1">
+          <ChatBubbleLeftRightIcon className="w-3 h-3" />
+          {historySession.messageCount} messages
+        </span>
+        <span className="flex items-center gap-1">
+          <ClockIcon className="w-3 h-3" />
+          {formatDuration(historySession.createdAt, historySession.lastModified)}
+        </span>
+        <span>{formatRelativeDate(historySession.lastModified)}</span>
+      </div>
+
+      <button
+        onClick={() => onBrowseHistory(historySession)}
+        className="h-6 px-2.5 rounded text-[11px] font-medium bg-accent/10 hover:bg-accent/20 text-accent transition-colors flex items-center gap-1"
+      >
+        <ArrowTopRightOnSquareIcon className="w-3 h-3" />
+        Browse History
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/src/components/layout/AppShell.tsx
+++ b/src/renderer/src/components/layout/AppShell.tsx
@@ -497,7 +497,7 @@ export function AppShell() {
           'flex-1 min-h-0 floating-card',
           activeView === 'terminals' ? 'hidden' : 'flex'
         )}>
-          <div className={activeView === 'board' ? 'flex-1 flex min-h-0' : 'hidden'}>
+          <div className={activeView === 'board' ? 'flex-1 flex min-h-0 min-w-0' : 'hidden'}>
             <TaskQueue />
           </div>
           <div className={activeView === 'usage' ? 'flex-1 flex min-h-0' : 'hidden'}>

--- a/src/renderer/src/components/layout/SidebarSections.tsx
+++ b/src/renderer/src/components/layout/SidebarSections.tsx
@@ -1,5 +1,10 @@
 import { useCallback, useMemo, useState } from 'react'
-import { ChevronRightIcon, ClockIcon, QueueListIcon, SparklesIcon } from '@heroicons/react/24/outline'
+import {
+  ChevronRightIcon,
+  ClockIcon,
+  QueueListIcon,
+  SparklesIcon
+} from '@heroicons/react/24/outline'
 import { useSessionStore } from '../../store/session-store'
 import { useBoardStore } from '../../store/board-store'
 import { useHistoryStore, type HistorySession } from '../../store/history-store'
@@ -97,7 +102,8 @@ export function TaskQueueSection({ collapsed }: { collapsed: boolean }) {
               <div className="absolute left-0 top-0 bottom-0 w-px bg-border-subtle" />
 
               {activeTasks.map((task) => {
-                const label = task.title || task.notes.split('\n')[0] || task.prompt.slice(0, 40) || 'Untitled'
+                const label =
+                  task.title || task.notes.split('\n')[0] || task.prompt.slice(0, 40) || 'Untitled'
                 return (
                   <button
                     key={task.id}
@@ -108,7 +114,9 @@ export function TaskQueueSection({ collapsed }: { collapsed: boolean }) {
                     <div className="absolute left-0 top-1/2 w-2.5 h-px bg-border-subtle" />
                     <span className="text-[12px] text-text-secondary truncate">{label}</span>
                     {task.dangerousMode && (
-                      <span className="flex-shrink-0 text-[9px] text-red-400 font-medium">skip</span>
+                      <span className="flex-shrink-0 text-[9px] text-red-400 font-medium">
+                        skip
+                      </span>
                     )}
                   </button>
                 )

--- a/src/renderer/src/components/layout/SidebarSections.tsx
+++ b/src/renderer/src/components/layout/SidebarSections.tsx
@@ -36,7 +36,18 @@ export function TaskQueueSection({ collapsed }: { collapsed: boolean }) {
   const activeView = useSessionStore((s) => s.activeView)
   const setActiveView = useSessionStore((s) => s.setActiveView)
   const tasks = useBoardStore((s) => s.tasks)
+  const columns = useBoardStore((s) => s.columns)
   const [expanded, setExpanded] = useState(false)
+
+  // Hide tasks in terminal columns (e.g., "Done") from sidebar count
+  const terminalColumnIds = useMemo(
+    () => new Set(columns.filter((c) => c.behavior === 'terminal').map((c) => c.id)),
+    [columns]
+  )
+  const activeTasks = useMemo(
+    () => tasks.filter((t) => !terminalColumnIds.has(t.columnId)),
+    [tasks, terminalColumnIds]
+  )
 
   return (
     <div
@@ -56,10 +67,10 @@ export function TaskQueueSection({ collapsed }: { collapsed: boolean }) {
             )}
           >
             <QueueListIcon className="flex-shrink-0 w-4 h-4 text-text-tertiary" />
-            <span className="truncate">Queue</span>
-            {tasks.length > 0 && (
+            <span className="truncate">Board</span>
+            {activeTasks.length > 0 && (
               <span className="ml-auto flex items-center gap-1.5">
-                <span className="text-[12px] text-text-tertiary">{tasks.length}</span>
+                <span className="text-[12px] text-text-tertiary">{activeTasks.length}</span>
                 <span
                   role="button"
                   onClick={(e) => {
@@ -79,14 +90,14 @@ export function TaskQueueSection({ collapsed }: { collapsed: boolean }) {
             )}
           </button>
 
-          {/* Expanded sub-items: task list with vertical connecting line */}
-          {expanded && tasks.length > 0 && (
+          {/* Expanded sub-items: non-terminal tasks with vertical connecting line */}
+          {expanded && activeTasks.length > 0 && (
             <div className="relative ml-[18px] mt-0.5">
               {/* Vertical connecting line */}
               <div className="absolute left-0 top-0 bottom-0 w-px bg-border-subtle" />
 
-              {tasks.map((task) => {
-                const label = task.title || task.prompt
+              {activeTasks.map((task) => {
+                const label = task.title || task.notes.split('\n')[0] || task.prompt.slice(0, 40) || 'Untitled'
                 return (
                   <button
                     key={task.id}

--- a/src/renderer/src/components/layout/SidebarSections.tsx
+++ b/src/renderer/src/components/layout/SidebarSections.tsx
@@ -102,8 +102,7 @@ export function TaskQueueSection({ collapsed }: { collapsed: boolean }) {
               <div className="absolute left-0 top-0 bottom-0 w-px bg-border-subtle" />
 
               {activeTasks.map((task) => {
-                const label =
-                  task.title || task.notes.split('\n')[0] || task.prompt.slice(0, 40) || 'Untitled'
+                const label = task.title || task.notes.split('\n')[0] || task.prompt.slice(0, 40) || 'Untitled'
                 return (
                   <button
                     key={task.id}

--- a/src/renderer/src/hooks/use-board-dnd.ts
+++ b/src/renderer/src/hooks/use-board-dnd.ts
@@ -1,0 +1,131 @@
+import { useCallback, useRef, useState } from 'react'
+import { useBoardStore } from '../store/board-store'
+
+interface DragState {
+  taskId: string
+  sourceColumnId: string
+  startX: number
+  startY: number
+  started: boolean
+}
+
+interface DropTarget {
+  columnId: string
+  order: number
+}
+
+const DRAG_THRESHOLD = 5
+
+export function useBoardDnd() {
+  const moveTask = useBoardStore((s) => s.moveTask)
+  const [draggingTaskId, setDraggingTaskId] = useState<string | null>(null)
+  const [dropTarget, setDropTarget] = useState<DropTarget | null>(null)
+  const dragRef = useRef<DragState | null>(null)
+  const ghostRef = useRef<HTMLElement | null>(null)
+
+  const createGhost = useCallback((sourceEl: HTMLElement, x: number, y: number) => {
+    const ghost = sourceEl.cloneNode(true) as HTMLElement
+    ghost.style.position = 'fixed'
+    ghost.style.zIndex = '9999'
+    ghost.style.width = `${sourceEl.offsetWidth}px`
+    ghost.style.pointerEvents = 'none'
+    ghost.style.opacity = '0.85'
+    ghost.style.transform = 'rotate(2deg) scale(1.02)'
+    ghost.style.left = `${x - sourceEl.offsetWidth / 2}px`
+    ghost.style.top = `${y - 20}px`
+    document.body.appendChild(ghost)
+    return ghost
+  }, [])
+
+  const removeGhost = useCallback(() => {
+    if (ghostRef.current) {
+      ghostRef.current.remove()
+      ghostRef.current = null
+    }
+  }, [])
+
+  const findDropTarget = useCallback((x: number, y: number): DropTarget | null => {
+    const columnEls = document.querySelectorAll<HTMLElement>('[data-column-id]')
+    for (const colEl of columnEls) {
+      const rect = colEl.getBoundingClientRect()
+      if (x >= rect.left && x <= rect.right) {
+        const columnId = colEl.dataset.columnId!
+        const cardEls = colEl.querySelectorAll<HTMLElement>('[data-task-id]')
+        let order = 0
+        for (const cardEl of cardEls) {
+          const cardRect = cardEl.getBoundingClientRect()
+          const cardMidY = cardRect.top + cardRect.height / 2
+          if (y > cardMidY) {
+            order++
+          }
+        }
+        return { columnId, order }
+      }
+    }
+    return null
+  }, [])
+
+  const onPointerDown = useCallback((e: React.PointerEvent, taskId: string, columnId: string) => {
+    if (e.button !== 0) return
+    e.preventDefault()
+
+    dragRef.current = {
+      taskId,
+      sourceColumnId: columnId,
+      startX: e.clientX,
+      startY: e.clientY,
+      started: false
+    }
+
+    const sourceEl = (e.target as HTMLElement).closest('[data-task-id]') as HTMLElement | null
+
+    const onMove = (ev: PointerEvent) => {
+      const drag = dragRef.current
+      if (!drag) return
+
+      const dx = ev.clientX - drag.startX
+      const dy = ev.clientY - drag.startY
+
+      if (!drag.started) {
+        if (Math.abs(dx) + Math.abs(dy) < DRAG_THRESHOLD) return
+        drag.started = true
+        setDraggingTaskId(drag.taskId)
+        if (sourceEl) {
+          ghostRef.current = createGhost(sourceEl, ev.clientX, ev.clientY)
+        }
+      }
+
+      if (ghostRef.current) {
+        ghostRef.current.style.left = `${ev.clientX - (sourceEl?.offsetWidth ?? 200) / 2}px`
+        ghostRef.current.style.top = `${ev.clientY - 20}px`
+      }
+
+      const target = findDropTarget(ev.clientX, ev.clientY)
+      setDropTarget(target)
+    }
+
+    const onUp = () => {
+      const drag = dragRef.current
+      const currentTarget = dropTarget
+      if (drag?.started && currentTarget) {
+        moveTask(drag.taskId, currentTarget.columnId, currentTarget.order)
+      }
+
+      dragRef.current = null
+      setDraggingTaskId(null)
+      setDropTarget(null)
+      removeGhost()
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+    }
+
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp)
+  }, [createGhost, removeGhost, findDropTarget, moveTask, dropTarget])
+
+  return {
+    draggingTaskId,
+    dropTarget,
+    onPointerDown
+  }
+}

--- a/src/renderer/src/hooks/use-board-dnd.ts
+++ b/src/renderer/src/hooks/use-board-dnd.ts
@@ -65,63 +65,66 @@ export function useBoardDnd() {
     return null
   }, [])
 
-  const onPointerDown = useCallback((e: React.PointerEvent, taskId: string, columnId: string) => {
-    if (e.button !== 0) return
-    e.preventDefault()
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent, taskId: string, columnId: string) => {
+      if (e.button !== 0) return
+      e.preventDefault()
 
-    dragRef.current = {
-      taskId,
-      sourceColumnId: columnId,
-      startX: e.clientX,
-      startY: e.clientY,
-      started: false
-    }
+      dragRef.current = {
+        taskId,
+        sourceColumnId: columnId,
+        startX: e.clientX,
+        startY: e.clientY,
+        started: false
+      }
 
-    const sourceEl = (e.target as HTMLElement).closest('[data-task-id]') as HTMLElement | null
+      const sourceEl = (e.target as HTMLElement).closest('[data-task-id]') as HTMLElement | null
 
-    const onMove = (ev: PointerEvent) => {
-      const drag = dragRef.current
-      if (!drag) return
+      const onMove = (ev: PointerEvent) => {
+        const drag = dragRef.current
+        if (!drag) return
 
-      const dx = ev.clientX - drag.startX
-      const dy = ev.clientY - drag.startY
+        const dx = ev.clientX - drag.startX
+        const dy = ev.clientY - drag.startY
 
-      if (!drag.started) {
-        if (Math.abs(dx) + Math.abs(dy) < DRAG_THRESHOLD) return
-        drag.started = true
-        setDraggingTaskId(drag.taskId)
-        if (sourceEl) {
-          ghostRef.current = createGhost(sourceEl, ev.clientX, ev.clientY)
+        if (!drag.started) {
+          if (Math.abs(dx) + Math.abs(dy) < DRAG_THRESHOLD) return
+          drag.started = true
+          setDraggingTaskId(drag.taskId)
+          if (sourceEl) {
+            ghostRef.current = createGhost(sourceEl, ev.clientX, ev.clientY)
+          }
         }
+
+        if (ghostRef.current) {
+          ghostRef.current.style.left = `${ev.clientX - (sourceEl?.offsetWidth ?? 200) / 2}px`
+          ghostRef.current.style.top = `${ev.clientY - 20}px`
+        }
+
+        const target = findDropTarget(ev.clientX, ev.clientY)
+        setDropTarget(target)
       }
 
-      if (ghostRef.current) {
-        ghostRef.current.style.left = `${ev.clientX - (sourceEl?.offsetWidth ?? 200) / 2}px`
-        ghostRef.current.style.top = `${ev.clientY - 20}px`
+      const onUp = () => {
+        const drag = dragRef.current
+        const currentTarget = dropTarget
+        if (drag?.started && currentTarget) {
+          moveTask(drag.taskId, currentTarget.columnId, currentTarget.order)
+        }
+
+        dragRef.current = null
+        setDraggingTaskId(null)
+        setDropTarget(null)
+        removeGhost()
+        window.removeEventListener('pointermove', onMove)
+        window.removeEventListener('pointerup', onUp)
       }
 
-      const target = findDropTarget(ev.clientX, ev.clientY)
-      setDropTarget(target)
-    }
-
-    const onUp = () => {
-      const drag = dragRef.current
-      const currentTarget = dropTarget
-      if (drag?.started && currentTarget) {
-        moveTask(drag.taskId, currentTarget.columnId, currentTarget.order)
-      }
-
-      dragRef.current = null
-      setDraggingTaskId(null)
-      setDropTarget(null)
-      removeGhost()
-      window.removeEventListener('pointermove', onMove)
-      window.removeEventListener('pointerup', onUp)
-    }
-
-    window.addEventListener('pointermove', onMove)
-    window.addEventListener('pointerup', onUp)
-  }, [createGhost, removeGhost, findDropTarget, moveTask, dropTarget])
+      window.addEventListener('pointermove', onMove)
+      window.addEventListener('pointerup', onUp)
+    },
+    [createGhost, removeGhost, findDropTarget, moveTask, dropTarget]
+  )
 
   return {
     draggingTaskId,

--- a/src/renderer/src/hooks/use-board-dnd.ts
+++ b/src/renderer/src/hooks/use-board-dnd.ts
@@ -22,6 +22,7 @@ export function useBoardDnd() {
   const [dropTarget, setDropTarget] = useState<DropTarget | null>(null)
   const dragRef = useRef<DragState | null>(null)
   const ghostRef = useRef<HTMLElement | null>(null)
+  const dropTargetRef = useRef<DropTarget | null>(null)
 
   const createGhost = useCallback((sourceEl: HTMLElement, x: number, y: number) => {
     const ghost = sourceEl.cloneNode(true) as HTMLElement
@@ -102,17 +103,19 @@ export function useBoardDnd() {
         }
 
         const target = findDropTarget(ev.clientX, ev.clientY)
+        dropTargetRef.current = target
         setDropTarget(target)
       }
 
       const onUp = () => {
         const drag = dragRef.current
-        const currentTarget = dropTarget
+        const currentTarget = dropTargetRef.current
         if (drag?.started && currentTarget) {
           moveTask(drag.taskId, currentTarget.columnId, currentTarget.order)
         }
 
         dragRef.current = null
+        dropTargetRef.current = null
         setDraggingTaskId(null)
         setDropTarget(null)
         removeGhost()
@@ -123,7 +126,7 @@ export function useBoardDnd() {
       window.addEventListener('pointermove', onMove)
       window.addEventListener('pointerup', onUp)
     },
-    [createGhost, removeGhost, findDropTarget, moveTask, dropTarget]
+    [createGhost, removeGhost, findDropTarget, moveTask]
   )
 
   return {

--- a/src/renderer/src/hooks/use-board-session-sync.ts
+++ b/src/renderer/src/hooks/use-board-session-sync.ts
@@ -34,19 +34,26 @@ export function useBoardSessionSync(): void {
       const prevIds = prevSessionIdsRef.current
       const prevAlive = prevAliveRef.current
 
-      // Build a set of session IDs already linked to board tasks
+      // Build sets of IDs already linked to board tasks for deduplication.
+      // Check both sessionId (runtime) AND claudeSessionId (persistent) —
+      // resumed sessions get a new runtime ID but keep the same claudeSessionId.
       const linkedSessionIds = new Set<string>()
+      const linkedClaudeSessionIds = new Set<string>()
       for (const task of boardState.tasks) {
         if (task.sessionId) linkedSessionIds.add(task.sessionId)
+        if (task.claudeSessionId) linkedClaudeSessionIds.add(task.claudeSessionId)
       }
 
       for (const session of state.sessions) {
         // --- New session detection ---
         if (!prevIds.has(session.id)) {
+          const alreadyLinked =
+            linkedSessionIds.has(session.id) ||
+            (session.claudeSessionId && linkedClaudeSessionIds.has(session.claudeSessionId))
           if (
             session.claudeMode &&
             session.sessionType === 'local' &&
-            !linkedSessionIds.has(session.id)
+            !alreadyLinked
           ) {
             const activeCol = boardState.getColumnByBehavior('active')
             if (activeCol) {
@@ -70,6 +77,23 @@ export function useBoardSessionSync(): void {
         if (wasAlive === true && session.alive === false) {
           const currentBoardState = useBoardStore.getState()
           const task = currentBoardState.tasks.find((t) => t.sessionId === session.id)
+          if (task) {
+            const terminalCol = currentBoardState.getColumnByBehavior('terminal')
+            if (terminalCol && task.columnId !== terminalCol.id) {
+              useBoardStore.getState().moveTask(task.id, terminalCol.id, 0)
+            }
+          }
+        }
+      }
+
+      // --- Session removal detection ---
+      // When a session is closed via X, removeSession() removes it from the store
+      // entirely — it never transitions alive: true → false. Detect disappearance.
+      const currentIds = new Set(state.sessions.map((s) => s.id))
+      for (const oldId of prevIds) {
+        if (!currentIds.has(oldId)) {
+          const currentBoardState = useBoardStore.getState()
+          const task = currentBoardState.tasks.find((t) => t.sessionId === oldId)
           if (task) {
             const terminalCol = currentBoardState.getColumnByBehavior('terminal')
             if (terminalCol && task.columnId !== terminalCol.id) {

--- a/src/renderer/src/hooks/use-board-session-sync.ts
+++ b/src/renderer/src/hooks/use-board-session-sync.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from 'react'
+import { useSessionStore } from '../store/session-store'
+import { useBoardStore } from '../store/board-store'
+
+/**
+ * Subscribes to session store changes and auto-moves board cards
+ * when their linked session's state transitions.
+ *
+ * Transitions handled:
+ * - Session ends (alive: false) → move card to terminal-behavior column (Done)
+ */
+export function useBoardSessionSync(): void {
+  // Track previous session states to detect transitions
+  const prevSessionsRef = useRef<Map<string, { alive: boolean }>>(new Map())
+
+  useEffect(() => {
+    // Build initial snapshot
+    const sessions = useSessionStore.getState().sessions
+    const initial = new Map<string, { alive: boolean }>()
+    for (const s of sessions) {
+      initial.set(s.id, { alive: s.alive })
+    }
+    prevSessionsRef.current = initial
+
+    const unsub = useSessionStore.subscribe((state) => {
+      const boardState = useBoardStore.getState()
+      const prevSessions = prevSessionsRef.current
+
+      // Build a map of sessionId → task for quick lookup
+      const tasksBySessionId = new Map<string, (typeof boardState.tasks)[number]>()
+      for (const task of boardState.tasks) {
+        if (task.sessionId) {
+          tasksBySessionId.set(task.sessionId, task)
+        }
+      }
+
+      for (const session of state.sessions) {
+        const prev = prevSessions.get(session.id)
+        const task = tasksBySessionId.get(session.id)
+        if (!task) continue
+
+        // Transition: alive → dead → move to terminal column
+        if (prev?.alive === true && session.alive === false) {
+          const terminalCol = boardState.getColumnByBehavior('terminal')
+          if (terminalCol && task.columnId !== terminalCol.id) {
+            useBoardStore.getState().moveTask(task.id, terminalCol.id, 0)
+          }
+        }
+      }
+
+      // Update snapshot
+      const next = new Map<string, { alive: boolean }>()
+      for (const s of state.sessions) {
+        next.set(s.id, { alive: s.alive })
+      }
+      prevSessionsRef.current = next
+    })
+
+    return unsub
+  }, [])
+}

--- a/src/renderer/src/hooks/use-board-session-sync.ts
+++ b/src/renderer/src/hooks/use-board-session-sync.ts
@@ -3,57 +3,91 @@ import { useSessionStore } from '../store/session-store'
 import { useBoardStore } from '../store/board-store'
 
 /**
- * Subscribes to session store changes and auto-moves board cards
- * when their linked session's state transitions.
+ * Subscribes to session store changes and syncs with the board:
  *
- * Transitions handled:
- * - Session ends (alive: false) → move card to terminal-behavior column (Done)
+ * 1. Session ends (alive: true → false) → move card to terminal-behavior column
+ * 2. New Claude-mode session appears → auto-create a board card in active column
+ *
+ * Startup sessions (templates, pinned groups) are skipped because they exist
+ * in the initial snapshot — only sessions appearing AFTER init trigger card creation.
  */
 export function useBoardSessionSync(): void {
-  // Track previous session states to detect transitions
-  const prevSessionsRef = useRef<Map<string, { alive: boolean }>>(new Map())
+  const prevSessionIdsRef = useRef<Set<string>>(new Set())
+  const prevAliveRef = useRef<Map<string, boolean>>(new Map())
 
   useEffect(() => {
-    // Build initial snapshot
+    // Build initial snapshot — these are startup sessions, skip them
     const sessions = useSessionStore.getState().sessions
-    const initial = new Map<string, { alive: boolean }>()
+    const initialIds = new Set<string>()
+    const initialAlive = new Map<string, boolean>()
     for (const s of sessions) {
-      initial.set(s.id, { alive: s.alive })
+      initialIds.add(s.id)
+      initialAlive.set(s.id, s.alive)
     }
-    prevSessionsRef.current = initial
+    prevSessionIdsRef.current = initialIds
+    prevAliveRef.current = initialAlive
 
     const unsub = useSessionStore.subscribe((state) => {
       const boardState = useBoardStore.getState()
-      const prevSessions = prevSessionsRef.current
+      if (!boardState.loaded) return
 
-      // Build a map of sessionId → task for quick lookup
-      const tasksBySessionId = new Map<string, (typeof boardState.tasks)[number]>()
+      const prevIds = prevSessionIdsRef.current
+      const prevAlive = prevAliveRef.current
+
+      // Build a set of session IDs already linked to board tasks
+      const linkedSessionIds = new Set<string>()
       for (const task of boardState.tasks) {
-        if (task.sessionId) {
-          tasksBySessionId.set(task.sessionId, task)
-        }
+        if (task.sessionId) linkedSessionIds.add(task.sessionId)
       }
 
       for (const session of state.sessions) {
-        const prev = prevSessions.get(session.id)
-        const task = tasksBySessionId.get(session.id)
-        if (!task) continue
+        // --- New session detection ---
+        if (!prevIds.has(session.id)) {
+          if (
+            session.claudeMode &&
+            session.sessionType === 'local' &&
+            !linkedSessionIds.has(session.id)
+          ) {
+            const activeCol = boardState.getColumnByBehavior('active')
+            if (activeCol) {
+              useBoardStore.getState().addTask({
+                title: session.name || session.folderName,
+                prompt: '',
+                notes: '',
+                cwd: session.cwd,
+                dangerousMode: session.dangerousMode,
+                tags: [],
+                sessionId: session.id,
+                claudeSessionId: session.claudeSessionId ?? undefined,
+                columnId: activeCol.id
+              })
+            }
+          }
+        }
 
-        // Transition: alive → dead → move to terminal column
-        if (prev?.alive === true && session.alive === false) {
-          const terminalCol = boardState.getColumnByBehavior('terminal')
-          if (terminalCol && task.columnId !== terminalCol.id) {
-            useBoardStore.getState().moveTask(task.id, terminalCol.id, 0)
+        // --- Session end detection ---
+        const wasAlive = prevAlive.get(session.id)
+        if (wasAlive === true && session.alive === false) {
+          const currentBoardState = useBoardStore.getState()
+          const task = currentBoardState.tasks.find((t) => t.sessionId === session.id)
+          if (task) {
+            const terminalCol = currentBoardState.getColumnByBehavior('terminal')
+            if (terminalCol && task.columnId !== terminalCol.id) {
+              useBoardStore.getState().moveTask(task.id, terminalCol.id, 0)
+            }
           }
         }
       }
 
-      // Update snapshot
-      const next = new Map<string, { alive: boolean }>()
+      // Update snapshots
+      const nextIds = new Set<string>()
+      const nextAlive = new Map<string, boolean>()
       for (const s of state.sessions) {
-        next.set(s.id, { alive: s.alive })
+        nextIds.add(s.id)
+        nextAlive.set(s.id, s.alive)
       }
-      prevSessionsRef.current = next
+      prevSessionIdsRef.current = nextIds
+      prevAliveRef.current = nextAlive
     })
 
     return unsub

--- a/src/renderer/src/hooks/use-board-session-sync.ts
+++ b/src/renderer/src/hooks/use-board-session-sync.ts
@@ -64,6 +64,7 @@ export function useBoardSessionSync(): void {
                 cwd: session.cwd,
                 dangerousMode: session.dangerousMode,
                 tags: [],
+                attachments: [],
                 sessionId: session.id,
                 claudeSessionId: session.claudeSessionId ?? undefined,
                 columnId: activeCol.id

--- a/src/renderer/src/store/board-store.ts
+++ b/src/renderer/src/store/board-store.ts
@@ -66,7 +66,27 @@ export const useBoardStore = create<BoardState>((set, get) => ({
   loadBoard: async () => {
     if (!window.electronAPI?.boardLoad) return
     const data = await window.electronAPI.boardLoad()
-    set({ tasks: data.tasks, columns: data.columns, tags: data.tags ?? [], loaded: true })
+    const columns = data.columns ?? []
+    const tags = data.tags ?? []
+    const columnIds = new Set(columns.map((c) => c.id))
+
+    // Fix orphaned tasks whose columnId doesn't match any existing column
+    const inboxCol =
+      columns.find((c) => c.behavior === 'default-inbox') ??
+      [...columns].sort((a, b) => a.order - b.order)[0]
+    let needsSave = false
+    const tasks = (data.tasks ?? []).map((t) => {
+      if (!columnIds.has(t.columnId) && inboxCol) {
+        needsSave = true
+        return { ...t, columnId: inboxCol.id, updatedAt: Date.now() }
+      }
+      return t
+    })
+
+    set({ tasks, columns, tags, loaded: true })
+    if (needsSave) {
+      debouncedSave({ tasks, columns, tags })
+    }
   },
 
   addTask: (partial) => {

--- a/src/renderer/src/store/board-store.ts
+++ b/src/renderer/src/store/board-store.ts
@@ -7,8 +7,17 @@ interface BoardState {
   loaded: boolean
 
   loadBoard: () => Promise<void>
-  addTask: (task: Omit<BoardTask, 'id' | 'createdAt' | 'updatedAt' | 'columnId' | 'order'> & { columnId?: string }) => void
-  updateTask: (id: string, updates: Partial<Pick<BoardTask, 'title' | 'prompt' | 'notes' | 'cwd' | 'dangerousMode' | 'sessionId'>>) => void
+  addTask: (
+    task: Omit<BoardTask, 'id' | 'createdAt' | 'updatedAt' | 'columnId' | 'order'> & {
+      columnId?: string
+    }
+  ) => void
+  updateTask: (
+    id: string,
+    updates: Partial<
+      Pick<BoardTask, 'title' | 'prompt' | 'notes' | 'cwd' | 'dangerousMode' | 'sessionId'>
+    >
+  ) => void
   deleteTask: (id: string) => void
   moveTask: (taskId: string, toColumnId: string, toOrder: number) => void
 
@@ -93,17 +102,13 @@ export const useBoardStore = create<BoardState>((set, get) => ({
     let newTasks = state.tasks.filter((t) => t.id !== taskId)
     if (fromColumnId !== toColumnId) {
       newTasks = newTasks.map((t) =>
-        t.columnId === fromColumnId && t.order > task.order
-          ? { ...t, order: t.order - 1 }
-          : t
+        t.columnId === fromColumnId && t.order > task.order ? { ...t, order: t.order - 1 } : t
       )
     }
 
     // Make space at target position
     newTasks = newTasks.map((t) =>
-      t.columnId === toColumnId && t.order >= toOrder
-        ? { ...t, order: t.order + 1 }
-        : t
+      t.columnId === toColumnId && t.order >= toOrder ? { ...t, order: t.order + 1 } : t
     )
 
     // Insert at new position
@@ -146,9 +151,7 @@ export const useBoardStore = create<BoardState>((set, get) => ({
 
   updateColumn: (id, updates) => {
     const state = get()
-    const newColumns = state.columns.map((c) =>
-      c.id === id ? { ...c, ...updates } : c
-    )
+    const newColumns = state.columns.map((c) => (c.id === id ? { ...c, ...updates } : c))
     set({ columns: newColumns })
     debouncedSave({ tasks: state.tasks, columns: newColumns })
   },
@@ -164,9 +167,8 @@ export const useBoardStore = create<BoardState>((set, get) => ({
     const remainingColumns = state.columns.filter((c) => c.id !== id)
     if (remainingColumns.length === 0) return
 
-    const targetColumnId = column.id === inbox.id
-      ? remainingColumns.sort((a, b) => a.order - b.order)[0].id
-      : inbox.id
+    const targetColumnId =
+      column.id === inbox.id ? remainingColumns.sort((a, b) => a.order - b.order)[0].id : inbox.id
 
     const targetTaskCount = state.tasks.filter((t) => t.columnId === targetColumnId).length
     const newTasks = state.tasks.map((t, idx) =>
@@ -199,6 +201,9 @@ export const useBoardStore = create<BoardState>((set, get) => ({
 
   getInboxColumn: () => {
     const state = get()
-    return state.columns.find((c) => c.behavior === 'default-inbox') ?? state.columns.sort((a, b) => a.order - b.order)[0]
+    return (
+      state.columns.find((c) => c.behavior === 'default-inbox') ??
+      state.columns.sort((a, b) => a.order - b.order)[0]
+    )
   }
 }))

--- a/src/renderer/src/store/board-store.ts
+++ b/src/renderer/src/store/board-store.ts
@@ -17,7 +17,7 @@ interface BoardState {
   updateTask: (
     id: string,
     updates: Partial<
-      Pick<BoardTask, 'title' | 'prompt' | 'notes' | 'cwd' | 'dangerousMode' | 'sessionId' | 'tags' | 'claudeSessionId'>
+      Pick<BoardTask, 'title' | 'prompt' | 'notes' | 'cwd' | 'dangerousMode' | 'sessionId' | 'tags' | 'claudeSessionId' | 'attachments'>
     >
   ) => void
   deleteTask: (id: string) => void
@@ -103,6 +103,7 @@ export const useBoardStore = create<BoardState>((set, get) => ({
       cwd: partial.cwd,
       dangerousMode: partial.dangerousMode,
       tags: partial.tags ?? [],
+      attachments: partial.attachments ?? [],
       createdAt: now,
       updatedAt: now,
       columnId,

--- a/src/renderer/src/store/board-store.ts
+++ b/src/renderer/src/store/board-store.ts
@@ -17,7 +17,7 @@ interface BoardState {
   updateTask: (
     id: string,
     updates: Partial<
-      Pick<BoardTask, 'title' | 'prompt' | 'notes' | 'cwd' | 'dangerousMode' | 'sessionId' | 'tags'>
+      Pick<BoardTask, 'title' | 'prompt' | 'notes' | 'cwd' | 'dangerousMode' | 'sessionId' | 'tags' | 'claudeSessionId'>
     >
   ) => void
   deleteTask: (id: string) => void

--- a/src/renderer/src/store/board-store.ts
+++ b/src/renderer/src/store/board-store.ts
@@ -1,70 +1,204 @@
 import { create } from 'zustand'
-import type { BoardTask, BoardData } from '../../../preload/index.d'
+import type { BoardTask, BoardData, BoardColumn, ColumnBehavior } from '../../../preload/index.d'
 
 interface BoardState {
   tasks: BoardTask[]
+  columns: BoardColumn[]
   loaded: boolean
 
   loadBoard: () => Promise<void>
-  addTask: (task: Omit<BoardTask, 'id' | 'createdAt' | 'updatedAt'>) => void
-  updateTask: (id: string, updates: Partial<Pick<BoardTask, 'title' | 'prompt' | 'cwd' | 'dangerousMode'>>) => void
+  addTask: (task: Omit<BoardTask, 'id' | 'createdAt' | 'updatedAt' | 'columnId' | 'order'> & { columnId?: string }) => void
+  updateTask: (id: string, updates: Partial<Pick<BoardTask, 'title' | 'prompt' | 'notes' | 'cwd' | 'dangerousMode' | 'sessionId'>>) => void
   deleteTask: (id: string) => void
-  removeTask: (id: string) => void
+  moveTask: (taskId: string, toColumnId: string, toOrder: number) => void
+
+  addColumn: (title: string, afterColumnId?: string) => void
+  updateColumn: (id: string, updates: Partial<Pick<BoardColumn, 'title' | 'color'>>) => void
+  deleteColumn: (id: string) => void
+  reorderColumns: (columnIds: string[]) => void
+
+  getColumnByBehavior: (behavior: ColumnBehavior) => BoardColumn | undefined
+  getInboxColumn: () => BoardColumn
 }
 
 let saveTimer: ReturnType<typeof setTimeout> | null = null
 
-function debouncedSave(tasks: BoardTask[]): void {
+function debouncedSave(state: { tasks: BoardTask[]; columns: BoardColumn[] }): void {
   if (saveTimer) clearTimeout(saveTimer)
   saveTimer = setTimeout(() => {
-    const data: BoardData = { tasks }
+    const data: BoardData = { tasks: state.tasks, columns: state.columns }
     window.electronAPI?.boardSave?.(data)
   }, 300)
 }
 
 export const useBoardStore = create<BoardState>((set, get) => ({
   tasks: [],
+  columns: [],
   loaded: false,
 
   loadBoard: async () => {
     if (!window.electronAPI?.boardLoad) return
     const data = await window.electronAPI.boardLoad()
-    set({ tasks: data.tasks, loaded: true })
+    set({ tasks: data.tasks, columns: data.columns, loaded: true })
   },
 
   addTask: (partial) => {
+    const state = get()
+    const inbox = state.getInboxColumn()
+    const columnId = partial.columnId ?? inbox.id
+    const tasksInColumn = state.tasks.filter((t) => t.columnId === columnId)
     const now = Date.now()
     const task: BoardTask = {
       id: crypto.randomUUID(),
       title: partial.title,
       prompt: partial.prompt,
+      notes: partial.notes,
       cwd: partial.cwd,
       dangerousMode: partial.dangerousMode,
       createdAt: now,
-      updatedAt: now
+      updatedAt: now,
+      columnId,
+      order: tasksInColumn.length,
+      sessionId: undefined
     }
-    const newTasks = [...get().tasks, task]
+    const newTasks = [...state.tasks, task]
     set({ tasks: newTasks })
-    debouncedSave(newTasks)
+    debouncedSave({ tasks: newTasks, columns: state.columns })
   },
 
   updateTask: (id, updates) => {
-    const newTasks = get().tasks.map((t) =>
+    const state = get()
+    const newTasks = state.tasks.map((t) =>
       t.id === id ? { ...t, ...updates, updatedAt: Date.now() } : t
     )
     set({ tasks: newTasks })
-    debouncedSave(newTasks)
+    debouncedSave({ tasks: newTasks, columns: state.columns })
   },
 
   deleteTask: (id) => {
-    const newTasks = get().tasks.filter((t) => t.id !== id)
+    const state = get()
+    const newTasks = state.tasks.filter((t) => t.id !== id)
     set({ tasks: newTasks })
-    debouncedSave(newTasks)
+    debouncedSave({ tasks: newTasks, columns: state.columns })
   },
 
-  removeTask: (id) => {
-    const newTasks = get().tasks.filter((t) => t.id !== id)
+  moveTask: (taskId, toColumnId, toOrder) => {
+    const state = get()
+    const task = state.tasks.find((t) => t.id === taskId)
+    if (!task) return
+
+    const fromColumnId = task.columnId
+
+    // Remove from current position and reindex source column
+    let newTasks = state.tasks.filter((t) => t.id !== taskId)
+    if (fromColumnId !== toColumnId) {
+      newTasks = newTasks.map((t) =>
+        t.columnId === fromColumnId && t.order > task.order
+          ? { ...t, order: t.order - 1 }
+          : t
+      )
+    }
+
+    // Make space at target position
+    newTasks = newTasks.map((t) =>
+      t.columnId === toColumnId && t.order >= toOrder
+        ? { ...t, order: t.order + 1 }
+        : t
+    )
+
+    // Insert at new position
+    newTasks.push({
+      ...task,
+      columnId: toColumnId,
+      order: toOrder,
+      updatedAt: Date.now()
+    })
+
     set({ tasks: newTasks })
-    debouncedSave(newTasks)
+    debouncedSave({ tasks: newTasks, columns: state.columns })
+  },
+
+  addColumn: (title, afterColumnId) => {
+    const state = get()
+    let insertOrder: number
+    if (afterColumnId) {
+      const afterCol = state.columns.find((c) => c.id === afterColumnId)
+      insertOrder = afterCol ? afterCol.order + 1 : state.columns.length
+    } else {
+      insertOrder = state.columns.length
+    }
+
+    const newColumns = state.columns.map((c) =>
+      c.order >= insertOrder ? { ...c, order: c.order + 1 } : c
+    )
+
+    newColumns.push({
+      id: crypto.randomUUID(),
+      title,
+      order: insertOrder,
+      builtIn: false,
+      behavior: 'none' as ColumnBehavior
+    })
+
+    set({ columns: newColumns })
+    debouncedSave({ tasks: state.tasks, columns: newColumns })
+  },
+
+  updateColumn: (id, updates) => {
+    const state = get()
+    const newColumns = state.columns.map((c) =>
+      c.id === id ? { ...c, ...updates } : c
+    )
+    set({ columns: newColumns })
+    debouncedSave({ tasks: state.tasks, columns: newColumns })
+  },
+
+  deleteColumn: (id) => {
+    const state = get()
+    const column = state.columns.find((c) => c.id === id)
+    if (!column) return
+    if (column.locked) return
+
+    const inbox = state.getInboxColumn()
+
+    const remainingColumns = state.columns.filter((c) => c.id !== id)
+    if (remainingColumns.length === 0) return
+
+    const targetColumnId = column.id === inbox.id
+      ? remainingColumns.sort((a, b) => a.order - b.order)[0].id
+      : inbox.id
+
+    const targetTaskCount = state.tasks.filter((t) => t.columnId === targetColumnId).length
+    const newTasks = state.tasks.map((t, idx) =>
+      t.columnId === id
+        ? { ...t, columnId: targetColumnId, order: targetTaskCount + idx, updatedAt: Date.now() }
+        : t
+    )
+
+    const newColumns = remainingColumns
+      .sort((a, b) => a.order - b.order)
+      .map((c, i) => ({ ...c, order: i }))
+
+    set({ tasks: newTasks, columns: newColumns })
+    debouncedSave({ tasks: newTasks, columns: newColumns })
+  },
+
+  reorderColumns: (columnIds) => {
+    const state = get()
+    const newColumns = state.columns.map((c) => {
+      const newOrder = columnIds.indexOf(c.id)
+      return newOrder >= 0 ? { ...c, order: newOrder } : c
+    })
+    set({ columns: newColumns })
+    debouncedSave({ tasks: state.tasks, columns: newColumns })
+  },
+
+  getColumnByBehavior: (behavior) => {
+    return get().columns.find((c) => c.behavior === behavior)
+  },
+
+  getInboxColumn: () => {
+    const state = get()
+    return state.columns.find((c) => c.behavior === 'default-inbox') ?? state.columns.sort((a, b) => a.order - b.order)[0]
   }
 }))

--- a/src/renderer/src/store/board-store.ts
+++ b/src/renderer/src/store/board-store.ts
@@ -87,7 +87,8 @@ export const useBoardStore = create<BoardState>((set, get) => ({
       updatedAt: now,
       columnId,
       order: tasksInColumn.length,
-      sessionId: undefined
+      sessionId: partial.sessionId ?? undefined,
+      claudeSessionId: partial.claudeSessionId ?? undefined
     }
     const newTasks = [...state.tasks, task]
     set({ tasks: newTasks })

--- a/src/renderer/src/store/board-store.ts
+++ b/src/renderer/src/store/board-store.ts
@@ -1,10 +1,12 @@
 import { create } from 'zustand'
-import type { BoardTask, BoardData, BoardColumn, ColumnBehavior } from '../../../preload/index.d'
+import type { BoardTask, BoardData, BoardColumn, ColumnBehavior, TagDefinition } from '../../../preload/index.d'
 
 interface BoardState {
   tasks: BoardTask[]
   columns: BoardColumn[]
   loaded: boolean
+  tags: TagDefinition[]
+  activeTagFilter: string | null
 
   loadBoard: () => Promise<void>
   addTask: (
@@ -15,7 +17,7 @@ interface BoardState {
   updateTask: (
     id: string,
     updates: Partial<
-      Pick<BoardTask, 'title' | 'prompt' | 'notes' | 'cwd' | 'dangerousMode' | 'sessionId'>
+      Pick<BoardTask, 'title' | 'prompt' | 'notes' | 'cwd' | 'dangerousMode' | 'sessionId' | 'tags'>
     >
   ) => void
   deleteTask: (id: string) => void
@@ -28,27 +30,43 @@ interface BoardState {
 
   getColumnByBehavior: (behavior: ColumnBehavior) => BoardColumn | undefined
   getInboxColumn: () => BoardColumn
+
+  addTag: (name: string, color?: string) => void
+  removeTag: (name: string) => void
+  updateTagColor: (name: string, color: string) => void
+  setActiveTagFilter: (tagName: string | null) => void
 }
 
 let saveTimer: ReturnType<typeof setTimeout> | null = null
 
-function debouncedSave(state: { tasks: BoardTask[]; columns: BoardColumn[] }): void {
+function debouncedSave(state: { tasks: BoardTask[]; columns: BoardColumn[]; tags: TagDefinition[] }): void {
   if (saveTimer) clearTimeout(saveTimer)
   saveTimer = setTimeout(() => {
-    const data: BoardData = { tasks: state.tasks, columns: state.columns }
+    const data: BoardData = { tasks: state.tasks, columns: state.columns, tags: state.tags }
     window.electronAPI?.boardSave?.(data)
   }, 300)
+}
+
+const TAG_COLORS = [
+  'blue', 'green', 'amber', 'red', 'purple', 'pink', 'cyan', 'orange'
+] as const
+
+function nextTagColor(existingTags: TagDefinition[]): string {
+  const usedColors = new Set(existingTags.map((t) => t.color))
+  return TAG_COLORS.find((c) => !usedColors.has(c)) ?? TAG_COLORS[existingTags.length % TAG_COLORS.length]
 }
 
 export const useBoardStore = create<BoardState>((set, get) => ({
   tasks: [],
   columns: [],
   loaded: false,
+  tags: [],
+  activeTagFilter: null,
 
   loadBoard: async () => {
     if (!window.electronAPI?.boardLoad) return
     const data = await window.electronAPI.boardLoad()
-    set({ tasks: data.tasks, columns: data.columns, loaded: true })
+    set({ tasks: data.tasks, columns: data.columns, tags: data.tags ?? [], loaded: true })
   },
 
   addTask: (partial) => {
@@ -64,6 +82,7 @@ export const useBoardStore = create<BoardState>((set, get) => ({
       notes: partial.notes,
       cwd: partial.cwd,
       dangerousMode: partial.dangerousMode,
+      tags: partial.tags ?? [],
       createdAt: now,
       updatedAt: now,
       columnId,
@@ -72,7 +91,7 @@ export const useBoardStore = create<BoardState>((set, get) => ({
     }
     const newTasks = [...state.tasks, task]
     set({ tasks: newTasks })
-    debouncedSave({ tasks: newTasks, columns: state.columns })
+    debouncedSave({ tasks: newTasks, columns: state.columns, tags: state.tags })
   },
 
   updateTask: (id, updates) => {
@@ -81,14 +100,14 @@ export const useBoardStore = create<BoardState>((set, get) => ({
       t.id === id ? { ...t, ...updates, updatedAt: Date.now() } : t
     )
     set({ tasks: newTasks })
-    debouncedSave({ tasks: newTasks, columns: state.columns })
+    debouncedSave({ tasks: newTasks, columns: state.columns, tags: state.tags })
   },
 
   deleteTask: (id) => {
     const state = get()
     const newTasks = state.tasks.filter((t) => t.id !== id)
     set({ tasks: newTasks })
-    debouncedSave({ tasks: newTasks, columns: state.columns })
+    debouncedSave({ tasks: newTasks, columns: state.columns, tags: state.tags })
   },
 
   moveTask: (taskId, toColumnId, toOrder) => {
@@ -120,7 +139,7 @@ export const useBoardStore = create<BoardState>((set, get) => ({
     })
 
     set({ tasks: newTasks })
-    debouncedSave({ tasks: newTasks, columns: state.columns })
+    debouncedSave({ tasks: newTasks, columns: state.columns, tags: state.tags })
   },
 
   addColumn: (title, afterColumnId) => {
@@ -146,14 +165,14 @@ export const useBoardStore = create<BoardState>((set, get) => ({
     })
 
     set({ columns: newColumns })
-    debouncedSave({ tasks: state.tasks, columns: newColumns })
+    debouncedSave({ tasks: state.tasks, columns: newColumns, tags: state.tags })
   },
 
   updateColumn: (id, updates) => {
     const state = get()
     const newColumns = state.columns.map((c) => (c.id === id ? { ...c, ...updates } : c))
     set({ columns: newColumns })
-    debouncedSave({ tasks: state.tasks, columns: newColumns })
+    debouncedSave({ tasks: state.tasks, columns: newColumns, tags: state.tags })
   },
 
   deleteColumn: (id) => {
@@ -182,7 +201,7 @@ export const useBoardStore = create<BoardState>((set, get) => ({
       .map((c, i) => ({ ...c, order: i }))
 
     set({ tasks: newTasks, columns: newColumns })
-    debouncedSave({ tasks: newTasks, columns: newColumns })
+    debouncedSave({ tasks: newTasks, columns: newColumns, tags: state.tags })
   },
 
   reorderColumns: (columnIds) => {
@@ -192,7 +211,7 @@ export const useBoardStore = create<BoardState>((set, get) => ({
       return newOrder >= 0 ? { ...c, order: newOrder } : c
     })
     set({ columns: newColumns })
-    debouncedSave({ tasks: state.tasks, columns: newColumns })
+    debouncedSave({ tasks: state.tasks, columns: newColumns, tags: state.tags })
   },
 
   getColumnByBehavior: (behavior) => {
@@ -205,5 +224,37 @@ export const useBoardStore = create<BoardState>((set, get) => ({
       state.columns.find((c) => c.behavior === 'default-inbox') ??
       state.columns.sort((a, b) => a.order - b.order)[0]
     )
+  },
+
+  addTag: (name, color) => {
+    const state = get()
+    const normalized = name.trim().toLowerCase().replace(/^#/, '')
+    if (!normalized) return
+    if (state.tags.some((t) => t.name === normalized)) return
+    const newTags = [...state.tags, { name: normalized, color: color ?? nextTagColor(state.tags) }]
+    set({ tags: newTags })
+    debouncedSave({ tasks: state.tasks, columns: state.columns, tags: newTags })
+  },
+
+  removeTag: (name) => {
+    const state = get()
+    const newTags = state.tags.filter((t) => t.name !== name)
+    const newTasks = state.tasks.map((t) =>
+      t.tags.includes(name) ? { ...t, tags: t.tags.filter((tag) => tag !== name), updatedAt: Date.now() } : t
+    )
+    set({ tags: newTags, tasks: newTasks })
+    if (state.activeTagFilter === name) set({ activeTagFilter: null })
+    debouncedSave({ tasks: newTasks, columns: state.columns, tags: newTags })
+  },
+
+  updateTagColor: (name, color) => {
+    const state = get()
+    const newTags = state.tags.map((t) => (t.name === name ? { ...t, color } : t))
+    set({ tags: newTags })
+    debouncedSave({ tasks: state.tasks, columns: state.columns, tags: newTags })
+  },
+
+  setActiveTagFilter: (tagName) => {
+    set({ activeTagFilter: tagName })
   }
 }))


### PR DESCRIPTION
## Motivation

The current task queue is fire-and-forget: you store a prompt, run it, and the task disappears. There's no way to track work through stages, see what's running, or review completed work.

This PR transforms the queue into a workflow board that makes Claude Code sessions visible and manageable across their full lifecycle — from backlog through active work to completion.

## Screenshots

> Board view with columns, tags, and live session status:

<!-- Drag-drop kanban-board.png here -->

> Task detail panel with notes, prompt, folder, tags, and autocomplete:

<!-- Drag-drop kanban-detail.png here -->

## What's included

### Kanban board (replaces flat queue)
- 4 default columns: Backlog, Ready, Running, Done
- Drag-and-drop cards between columns (hand-rolled, no new dependencies)
- Column management: add, rename, delete, reorder, move left/right
- Task detail panel with notes, prompt, folder, and metadata editing
- Search bar and horizontal scrolling when columns exceed viewport

### Column behavior system
Columns have a `behavior` field (`default-inbox`, `active`, `terminal`, `none`) so system logic queries by behavior, not by name. Users can rename "Backlog" to "Ideas" or "Done" to "Shipped" without breaking anything.

### Live session status on cards
Cards show real-time status based on the linked Claude session:
- **Working** (green pulsing) — actively outputting
- **Idle** (blue) — paused between operations
- **Needs permission** (amber pulsing + border glow) — waiting for tool approval
- **Session ended** (gray) — process exited

### Automatic lifecycle management
- Running a task moves the card to the Running column
- Session ending auto-moves the card to Done
- Closing a session via X also moves the card to Done
- No manual card management needed for the common workflow

### Tagging system
- 8-color palette with auto-color assignment
- Autocomplete tag input (type to search, Enter to create)
- Board-level filter — click a tag to show only matching cards
- Tags persist through the full task lifecycle

### History integration
- `claudeSessionId` persisted on cards — survives app restart
- Cold-start resume: restart the app, click Resume on any card, picks up where Claude left off
- History summary (message count, conversation summary) shown on completed cards
- "Browse History" button navigates to the history panel for the linked session

### Universal session tracking
- All Claude-mode sessions auto-create a board card — not just tasks started from the board
- Sessions started from the sidebar, history panel, or session duplication are all tracked
- Startup sessions (templates, pinned groups) are excluded to avoid card bursts on launch
- Deduplication by both runtime ID and persistent `claudeSessionId` prevents duplicate cards

## Technical notes

- **No new dependencies** — drag-and-drop is hand-rolled (same pattern as sidebar DnD)
- **Migration safe** — existing `board.json` files are auto-migrated to column layout; fresh installs get default columns
- **Sidebar updated** — renamed "Queue" to "Board", count excludes Done column
- **16 files changed**, +2,165 / -309 lines across main process, preload types, store, components, and hooks

## Test plan

- [ ] Fresh install: board loads with 4 default columns, no tasks
- [ ] Create task with tags — card shows in Backlog with color-coded pills
- [ ] Run task — card moves to Running, session status updates live
- [ ] Session ends — card auto-moves to Done with history summary
- [ ] Close session via X — card moves to Done
- [ ] Restart app — Resume on a card resumes the Claude conversation
- [ ] Start session from sidebar — card auto-created in Running
- [ ] Tag filter: click tag pill — only matching cards shown
- [ ] Drag card between columns
- [ ] Right-click Running column — no Delete option (locked)
- [ ] Existing flat `board.json` — migrated cleanly to column layout