### PR TITLE
feat(sessions): persistent tmux sessions (UTF-8 fix + on by default)

### DIFF
--- a/src/main/ipc-handlers/clave-file-handlers.ts
+++ b/src/main/ipc-handlers/clave-file-handlers.ts
@@ -465,3 +465,9 @@ class PreferencesManager {
 }
 
 const preferencesManager = new PreferencesManager()
+
+/** Read a persisted app preference from the main process (e.g. the global
+ *  tmux toggle, which the PTY spawn handler consults as a default). */
+export function getPreference(key: string): unknown {
+  return preferencesManager.get(key)
+}

--- a/src/main/ipc-handlers/pty-handlers.ts
+++ b/src/main/ipc-handlers/pty-handlers.ts
@@ -16,9 +16,10 @@ export function registerPtyHandlers(): void {
   })
 
   ipcMain.handle('pty:spawn', (_event, cwd: string, options?: PtySpawnOptions) => {
-    // tmux mode is a global app setting; honour it as the default unless a
-    // caller explicitly overrides per-spawn.
-    const tmuxMode = options?.tmuxMode ?? getPreference('tmuxMode') === true
+    // tmux mode is a global app setting, ON by default. Honour it unless a
+    // caller overrides per-spawn or the user explicitly turned it off. (When
+    // tmux isn't installed the spawn transparently falls back to a plain shell.)
+    const tmuxMode = options?.tmuxMode ?? getPreference('tmuxMode') !== false
     const session = ptyManager.spawn(cwd, { ...options, tmuxMode })
     const win = BrowserWindow.fromWebContents(_event.sender)
     const isClaudeMode = options?.claudeMode !== false && !options?.geminiMode && !options?.codexMode && !options?.claudeAgentsMode

--- a/src/main/ipc-handlers/pty-handlers.ts
+++ b/src/main/ipc-handlers/pty-handlers.ts
@@ -1,5 +1,6 @@
 import { ipcMain, BrowserWindow } from 'electron'
-import { ptyManager, type PtySpawnOptions } from '../pty-manager'
+import { ptyManager, isTmuxAvailable, type PtySpawnOptions } from '../pty-manager'
+import { getPreference } from './clave-file-handlers'
 import * as titleGenerator from '../title-generator'
 import { startWatching as startAgentStateWatching, clearState as clearAgentState } from '../agent-state-manager'
 
@@ -15,7 +16,10 @@ export function registerPtyHandlers(): void {
   })
 
   ipcMain.handle('pty:spawn', (_event, cwd: string, options?: PtySpawnOptions) => {
-    const session = ptyManager.spawn(cwd, options)
+    // tmux mode is a global app setting; honour it as the default unless a
+    // caller explicitly overrides per-spawn.
+    const tmuxMode = options?.tmuxMode ?? getPreference('tmuxMode') === true
+    const session = ptyManager.spawn(cwd, { ...options, tmuxMode })
     const win = BrowserWindow.fromWebContents(_event.sender)
     const isClaudeMode = options?.claudeMode !== false && !options?.geminiMode && !options?.codexMode && !options?.claudeAgentsMode
     const isResumed = !!options?.resumeSessionId
@@ -99,5 +103,22 @@ export function registerPtyHandlers(): void {
 
   ipcMain.handle('pty:list', () => {
     return ptyManager.getAllSessions()
+  })
+
+  // Lets the settings UI enable/disable the "persistent sessions" toggle.
+  ipcMain.handle('tmux:available', () => {
+    return isTmuxAvailable()
+  })
+
+  // On launch the renderer asks which tmux-backed sessions survived a previous
+  // run so it can recreate their tabs and reattach. This call also prunes stale
+  // sidecars and reaps orphaned clave sessions.
+  ipcMain.handle('tmux:list-adoptable', () => {
+    return ptyManager.listAdoptableTmuxSessions()
+  })
+
+  // User declined to adopt a survivor → destroy it.
+  ipcMain.handle('tmux:discard', (_event, tmuxName: string) => {
+    ptyManager.discardTmuxSession(tmuxName)
   })
 }

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -462,7 +462,13 @@ class PtyManager {
       if (sidecarOk) {
         tmuxName = candidateName
         const confPath = getTmuxConfigPath()
-        const tmuxArgs: string[] = ['-L', TMUX_SOCKET]
+        // `-u` forces UTF-8 client output. Electron apps are launched without a
+        // UTF-8 locale (no LANG/LC_* in the GUI environment), so tmux would
+        // otherwise run the client in non-UTF-8 mode and downsample every
+        // multibyte glyph — box-drawing, the agent's logo, em-dashes — to `_`.
+        // (Direct, non-tmux PTYs are unaffected: the agent + xterm.js are always
+        // UTF-8; only tmux gates UTF-8 on the locale env.)
+        const tmuxArgs: string[] = ['-u', '-L', TMUX_SOCKET]
         if (confPath) tmuxArgs.push('-f', confPath)
         // `new-session -A`: attach if the session already exists (reattach a live
         // agent after an app restart / from elsewhere), otherwise create it and

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -1,6 +1,9 @@
 import * as pty from 'node-pty'
 import { execFile, execFileSync } from 'child_process'
 import { randomUUID } from 'crypto'
+import * as fs from 'fs'
+import * as path from 'path'
+import { app } from 'electron'
 import { DEFAULT_TERMINAL_COLS, DEFAULT_TERMINAL_ROWS, INITIAL_COMMAND_DELAY_MS } from './constants'
 import { stateFilePath } from './agent-state-manager'
 
@@ -122,6 +125,189 @@ export function getLoginShellEnv(): Record<string, string> {
   return loginShellEnv
 }
 
+// ---------------------------------------------------------------------------
+// tmux integration (opt-in, macOS/Linux)
+//
+// When enabled, a session's agent runs *inside* a named tmux session. The
+// node-pty process is merely the tmux client; the agent lives in the tmux
+// server (a daemon), so it survives the client dying — i.e. the app quitting
+// or crashing. Re-opening the same session slot reattaches the live process,
+// and it can also be reached from any terminal via `tmux -L clave attach`.
+// ---------------------------------------------------------------------------
+
+/** Dedicated tmux socket so Clave's sessions never collide with the user's
+ *  default tmux server (and a stray `tmux kill-server` can't nuke their work). */
+const TMUX_SOCKET = 'clave'
+
+// undefined = not probed yet, null = tmux not installed, string = absolute path
+let tmuxPathCache: string | null | undefined
+let tmuxConfigPathCache: string | null = null
+
+/** Resolve tmux against the *login* shell PATH (Homebrew lives in /opt/homebrew
+ *  which is usually absent from Electron's process.env.PATH). Uses the already
+ *  preloaded login-shell env instead of spawning another `-lic` shell, so it
+ *  doesn't block the main thread on the user's rc files. */
+function detectTmux(): string | null {
+  if (tmuxPathCache !== undefined) return tmuxPathCache
+  if (isWindows) {
+    tmuxPathCache = null
+    return null
+  }
+  const env = getLoginShellEnv()
+  const pathDirs = (env.PATH || process.env.PATH || '').split(':')
+  for (const dir of pathDirs) {
+    if (!dir) continue
+    const candidate = path.join(dir, 'tmux')
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK)
+      tmuxPathCache = candidate
+      return candidate
+    } catch {
+      // not here, keep looking
+    }
+  }
+  tmuxPathCache = null
+  return null
+}
+
+export function isTmuxAvailable(): boolean {
+  return detectTmux() !== null
+}
+
+/** Minimal, predictable config for embedded agent terminals. Passed via `-f`
+ *  so the user's ~/.tmux.conf can't change behaviour (no surprise keybindings,
+ *  no `destroy-unattached on` killing our sessions, no status bar stealing a
+ *  row). Truecolor is forwarded and ESC latency dropped for snappy TUIs. */
+function getTmuxConfigPath(): string {
+  if (tmuxConfigPathCache) return tmuxConfigPathCache
+  const conf = [
+    'set -g default-terminal "tmux-256color"',
+    'set -as terminal-features ",xterm-256color:RGB"',
+    'set -g destroy-unattached off',
+    'set -g status off',
+    'set -g mouse on',
+    'set -g history-limit 50000',
+    'set -sg escape-time 10',
+    'set -g focus-events on',
+    // If a second client (e.g. an external `tmux attach`) joins, follow the
+    // most-recently-active client's size instead of shrinking to the smallest.
+    'set -g window-size latest',
+    ''
+  ].join('\n')
+  const p = path.join(app.getPath('userData'), 'clave.tmux.conf')
+  try {
+    fs.writeFileSync(p, conf, 'utf-8')
+    tmuxConfigPathCache = p
+  } catch {
+    // Fall back to running without a config file rather than failing the spawn.
+    return ''
+  }
+  return tmuxConfigPathCache
+}
+
+function agentModeTag(options?: PtySpawnOptions): string {
+  if (options?.geminiMode) return 'gemini'
+  if (options?.codexMode) return 'codex'
+  if (options?.claudeAgentsMode) return 'agents'
+  if (options?.claudeMode === false) return 'shell'
+  return 'claude'
+}
+
+/** Tiny stable hash (djb2) → base36, so the same session slot maps to the same
+ *  tmux session name across app restarts (enabling reattach on re-open). */
+function shortHash(input: string): string {
+  let h = 5381
+  for (let i = 0; i < input.length; i++) {
+    h = (h * 33) ^ input.charCodeAt(i)
+  }
+  return (h >>> 0).toString(36).slice(0, 6)
+}
+
+/** Deterministic, human-readable, tmux-legal session name (no `.` or `:`). */
+function baseTmuxName(cwd: string, modeTag: string): string {
+  const folder = (cwd.split('/').pop() || 'clave')
+    .replace(/[^A-Za-z0-9_-]/g, '-')
+    .replace(/-+/g, '-')
+    .slice(0, 24)
+  return `clave-${folder}-${shortHash(`${cwd}|${modeTag}`)}`
+}
+
+// --- Sidecar metadata + orphan management -------------------------------------
+//
+// tmux sessions outlive the app, so the tmux server itself is our source of
+// truth for "what was running". For each tmux-backed session we drop a tiny
+// JSON sidecar describing how to recreate its tab. On launch the renderer asks
+// for the adoptable list: we cross-check sidecars against the live tmux server,
+// hand back the survivors (to be reattached as tabs), prune sidecars whose
+// session is gone, and reap any stray `clave-*` session that has no sidecar —
+// so nothing can pile up invisibly.
+
+/** What the renderer needs to recreate + reattach a surviving session's tab. */
+export interface AdoptableTmuxSession {
+  tmuxName: string
+  /** Original PTY session id, reused on adoption so the Claude lifecycle-hook
+   *  state file (keyed by this id) keeps matching after reattach. */
+  id: string
+  claudeSessionId?: string
+  cwd: string
+  folderName: string
+  claudeMode: boolean
+  geminiMode: boolean
+  codexMode: boolean
+  claudeAgentsMode: boolean
+  dangerousMode: boolean
+}
+
+/** tmux session names we create are always `clave-<sanitized>`. Validate before
+ *  using a name in a filesystem path or a kill-session call — it crosses the IPC
+ *  boundary on the adoption/discard paths. */
+function isValidTmuxName(name: string): boolean {
+  return /^clave-[A-Za-z0-9_-]+$/.test(name)
+}
+
+function tmuxSidecarDir(): string {
+  return path.join(app.getPath('userData'), 'clave-tmux-sessions')
+}
+
+/** Persist restore metadata. Returns false if it couldn't be written, in which
+ *  case the caller falls back to a non-tmux spawn so we never create a tmux
+ *  session we can't track (and would later be unable to adopt or clean up). */
+function writeTmuxSidecar(meta: AdoptableTmuxSession): boolean {
+  if (!isValidTmuxName(meta.tmuxName)) return false
+  try {
+    const dir = tmuxSidecarDir()
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(path.join(dir, `${meta.tmuxName}.json`), JSON.stringify(meta), 'utf-8')
+    return true
+  } catch {
+    return false
+  }
+}
+
+function deleteTmuxSidecar(tmuxName: string): void {
+  if (!isValidTmuxName(tmuxName)) return
+  try {
+    fs.unlinkSync(path.join(tmuxSidecarDir(), `${tmuxName}.json`))
+  } catch {
+    // already gone
+  }
+}
+
+/** List live tmux sessions on the clave socket (empty if tmux/socket absent). */
+function liveTmuxSessions(tmuxPath: string): Set<string> {
+  try {
+    const out = execFileSync(
+      tmuxPath,
+      ['-L', TMUX_SOCKET, 'list-sessions', '-F', '#{session_name}'],
+      { encoding: 'utf-8' }
+    )
+    return new Set(out.split('\n').map((s) => s.trim()).filter(Boolean))
+  } catch {
+    // No server running → no sessions.
+    return new Set()
+  }
+}
+
 export interface PtySpawnOptions {
   dangerousMode?: boolean
   claudeMode?: boolean
@@ -132,10 +318,19 @@ export interface PtySpawnOptions {
   claudeSessionId?: string
   initialCommand?: string
   autoExecute?: boolean
+  /** Opt-in: run this session inside a persistent tmux session. */
+  tmuxMode?: boolean
+  /** Reattach to this exact existing tmux session instead of deriving a new
+   *  name. Set when adopting a session that survived a previous app run. */
+  adoptTmuxName?: string
+  /** Reuse this exact PTY session id (instead of a fresh UUID) when adopting,
+   *  so the Claude lifecycle-hook state file keeps matching the live agent. */
+  adoptSessionId?: string
 }
 
 interface PendingSpawn {
-  shellArgs: string[]
+  file: string
+  args: string[]
   cwd: string
   initialCommand?: string
   autoExecute?: boolean
@@ -148,6 +343,8 @@ export interface PtySession {
   ptyProcess: pty.IPty | null
   alive: boolean
   claudeSessionId?: string
+  /** Set when this session is backed by a tmux session (the tmux session name). */
+  tmuxName?: string
   pending?: PendingSpawn
   onData?: (data: string) => void
   onExit?: (exitCode: number) => void
@@ -165,7 +362,10 @@ class PtyManager {
    * `start(id, cols, rows)` finalises the spawn at the correct size.
    */
   spawn(cwd: string, options?: PtySpawnOptions): PtySession {
-    const id = randomUUID()
+    // Reuse the original id when adopting a survivor, so the Claude hook state
+    // file (baked with this id at first spawn) still routes to this tab.
+    const id =
+      options?.adoptSessionId && options?.adoptTmuxName ? options.adoptSessionId : randomUUID()
     const folderName = (isWindows ? cwd.split('\\') : cwd.split('/')).pop() || cwd
     const useAgentsMode = options?.claudeAgentsMode === true
     const useGeminiMode = options?.geminiMode === true
@@ -228,6 +428,53 @@ class PtyManager {
       }
     }
 
+    // By default we spawn the user's shell directly. When tmux mode is opted in
+    // (and tmux is installed), we instead spawn a tmux client that runs the very
+    // same shell command inside a persistent, named tmux session.
+    const shellName = getUserShell()
+    let spawnFile = shellName
+    let spawnArgs = shellArgs
+    let tmuxName: string | undefined
+
+    const tmuxPath = options?.tmuxMode ? detectTmux() : null
+    if (tmuxPath) {
+      // When adopting a survivor, reattach to its exact (validated) name;
+      // otherwise derive a fresh name that doesn't clash with any live session.
+      const adopt = options?.adoptTmuxName
+      const candidateName =
+        adopt && isValidTmuxName(adopt) ? adopt : this.uniqueTmuxName(cwd, agentModeTag(options))
+
+      // Persist restore metadata first. If we can't track the session, fall back
+      // to a plain shell spawn rather than create an untrackable tmux session.
+      const sidecarOk = writeTmuxSidecar({
+        tmuxName: candidateName,
+        id,
+        claudeSessionId,
+        cwd,
+        folderName,
+        claudeMode: useClaudeMode,
+        geminiMode: useGeminiMode,
+        codexMode: useCodexMode,
+        claudeAgentsMode: useAgentsMode,
+        dangerousMode: options?.dangerousMode === true
+      })
+
+      if (sidecarOk) {
+        tmuxName = candidateName
+        const confPath = getTmuxConfigPath()
+        const tmuxArgs: string[] = ['-L', TMUX_SOCKET]
+        if (confPath) tmuxArgs.push('-f', confPath)
+        // `new-session -A`: attach if the session already exists (reattach a live
+        // agent after an app restart / from elsewhere), otherwise create it and
+        // run the shell command. Attaching never re-runs the command. Fresh names
+        // are guaranteed not to collide with a survivor, so `-A` only reattaches
+        // on the explicit adoption path.
+        tmuxArgs.push('new-session', '-A', '-s', tmuxName, shellName, ...shellArgs)
+        spawnFile = tmuxPath
+        spawnArgs = tmuxArgs
+      }
+    }
+
     const session: PtySession = {
       id,
       cwd,
@@ -235,15 +482,36 @@ class PtyManager {
       ptyProcess: null,
       alive: true,
       pending: {
-        shellArgs,
+        file: spawnFile,
+        args: spawnArgs,
         cwd,
         initialCommand: options?.initialCommand,
         autoExecute: options?.autoExecute
       }
     }
     if (claudeSessionId) session.claudeSessionId = claudeSessionId
+    if (tmuxName) session.tmuxName = tmuxName
     this.sessions.set(id, session)
     return session
+  }
+
+  /** Pick a fresh tmux session name that clashes with neither an in-process
+   *  session nor a live session on the tmux server. Checking the server too is
+   *  essential: it stops a brand-new session from silently `-A`-attaching to a
+   *  not-yet-adopted survivor of the same cwd+mode (which would hijack it). */
+  private uniqueTmuxName(cwd: string, modeTag: string): string {
+    const base = baseTmuxName(cwd, modeTag)
+    const taken = new Set(
+      Array.from(this.sessions.values())
+        .map((s) => s.tmuxName)
+        .filter((n): n is string => !!n)
+    )
+    const tmuxPath = detectTmux()
+    if (tmuxPath) for (const n of liveTmuxSessions(tmuxPath)) taken.add(n)
+    if (!taken.has(base)) return base
+    let n = 2
+    while (taken.has(`${base}-${n}`)) n++
+    return `${base}-${n}`
   }
 
   /**
@@ -274,13 +542,12 @@ class PtyManager {
       return
     }
     if (!session.pending) return
-    const { shellArgs, cwd, initialCommand, autoExecute } = session.pending
+    const { file, args, cwd, initialCommand, autoExecute } = session.pending
     session.pending = undefined
 
-    const shellName = getUserShell()
     const ptyName = isWindows ? undefined : 'xterm-256color'
 
-    const ptyProcess = pty.spawn(shellName, shellArgs, {
+    const ptyProcess = pty.spawn(file, args, {
       name: ptyName,
       cols: Math.max(1, cols),
       rows: Math.max(1, rows),
@@ -333,14 +600,99 @@ class PtyManager {
     }
   }
 
-  kill(id: string): void {
+  /**
+   * Terminate a session.
+   *
+   * @param killTmuxSession when true (a user explicitly closing the session)
+   *   the backing tmux session is destroyed for real. When false (the app is
+   *   quitting) we only kill the local tmux *client*, which detaches and leaves
+   *   the agent running in the tmux server to be reattached next launch.
+   */
+  kill(id: string, killTmuxSession = true): void {
     const session = this.sessions.get(id)
     if (session) {
+      if (session.tmuxName && killTmuxSession) {
+        const tmuxPath = detectTmux()
+        if (tmuxPath) {
+          execFile(
+            tmuxPath,
+            ['-L', TMUX_SOCKET, 'kill-session', '-t', session.tmuxName],
+            () => {}
+          )
+        }
+        deleteTmuxSidecar(session.tmuxName)
+      }
       if (session.alive && session.ptyProcess) {
         session.ptyProcess.kill()
       }
       this.sessions.delete(id)
     }
+  }
+
+  /**
+   * Reconcile sidecars with the live tmux server and return the sessions that
+   * survived a previous run and should be re-adopted as tabs. Sidecars whose
+   * tmux session is gone are pruned. We deliberately do NOT kill live sessions
+   * that lack a sidecar: the `clave` socket is user-attachable (the settings
+   * panel advertises `tmux -L clave attach`), so a name prefix isn't proof of
+   * ownership. Because every Clave-created session is written a sidecar before
+   * it is spawned (and falls back to a non-tmux spawn if that write fails), our
+   * own sessions are always tracked and adopted — they can't accumulate.
+   */
+  listAdoptableTmuxSessions(): AdoptableTmuxSession[] {
+    const tmuxPath = detectTmux()
+    if (!tmuxPath) return []
+
+    const live = liveTmuxSessions(tmuxPath)
+    const alreadyAdopted = new Set(
+      Array.from(this.sessions.values())
+        .map((s) => s.tmuxName)
+        .filter((n): n is string => !!n)
+    )
+
+    const dir = tmuxSidecarDir()
+    let files: string[] = []
+    try {
+      files = fs.readdirSync(dir).filter((f) => f.endsWith('.json'))
+    } catch {
+      files = []
+    }
+
+    const adoptable: AdoptableTmuxSession[] = []
+    for (const file of files) {
+      let meta: AdoptableTmuxSession | null = null
+      try {
+        meta = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf-8'))
+      } catch {
+        meta = null
+      }
+      if (!meta?.tmuxName || !isValidTmuxName(meta.tmuxName)) {
+        try {
+          fs.unlinkSync(path.join(dir, file))
+        } catch {
+          /* ignore */
+        }
+        continue
+      }
+      if (!live.has(meta.tmuxName)) {
+        // Session is gone — its sidecar is stale.
+        deleteTmuxSidecar(meta.tmuxName)
+      } else if (!alreadyAdopted.has(meta.tmuxName)) {
+        adoptable.push(meta)
+      }
+    }
+
+    return adoptable
+  }
+
+  /** Destroy a surviving tmux session the user chose not to adopt. */
+  discardTmuxSession(tmuxName: string): void {
+    if (!isValidTmuxName(tmuxName)) return
+    const tmuxPath = detectTmux()
+    if (tmuxPath) {
+      execFile(tmuxPath, ['-L', TMUX_SOCKET, 'kill-session', '-t', tmuxName], () => {})
+    }
+    deleteTmuxSidecar(tmuxName)
   }
 
   getSession(id: string): PtySession | undefined {
@@ -356,9 +708,13 @@ class PtyManager {
     }))
   }
 
+  /**
+   * Kill every session. Used on app quit: tmux-backed sessions are only
+   * detached (not destroyed) so the agents survive until the next launch.
+   */
   killAll(): void {
     for (const [id] of this.sessions) {
-      this.kill(id)
+      this.kill(id, false)
     }
   }
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -39,6 +39,19 @@ export interface SessionInfo {
   claudeSessionId: string | null
 }
 
+export interface AdoptableTmuxSession {
+  tmuxName: string
+  id: string
+  claudeSessionId?: string
+  cwd: string
+  folderName: string
+  claudeMode: boolean
+  geminiMode: boolean
+  codexMode: boolean
+  claudeAgentsMode: boolean
+  dangerousMode: boolean
+}
+
 export interface DirEntry {
   name: string
   path: string
@@ -174,12 +187,15 @@ export interface DownloadProgress {
 }
 
 export interface ElectronAPI {
-  spawnSession: (cwd: string, options?: { dangerousMode?: boolean; claudeMode?: boolean; geminiMode?: boolean; codexMode?: boolean; claudeAgentsMode?: boolean; resumeSessionId?: string; claudeSessionId?: string; initialCommand?: string; autoExecute?: boolean }) => Promise<SessionInfo>
+  spawnSession: (cwd: string, options?: { dangerousMode?: boolean; claudeMode?: boolean; geminiMode?: boolean; codexMode?: boolean; claudeAgentsMode?: boolean; resumeSessionId?: string; claudeSessionId?: string; initialCommand?: string; autoExecute?: boolean; tmuxMode?: boolean; adoptTmuxName?: string; adoptSessionId?: string }) => Promise<SessionInfo>
   writeSession: (id: string, data: string) => void
   startSession: (id: string, cols: number, rows: number) => void
   resizeSession: (id: string, cols: number, rows: number) => void
   killSession: (id: string) => Promise<void>
   listSessions: () => Promise<SessionInfo[]>
+  tmuxAvailable: () => Promise<boolean>
+  tmuxListAdoptable: () => Promise<AdoptableTmuxSession[]>
+  tmuxDiscard: (tmuxName: string) => Promise<void>
   onSessionData: (id: string, callback: (data: string) => void) => () => void
   onSessionExit: (id: string, callback: (exitCode: number) => void) => () => void
   onSessionAutoTitle: (sessionId: string, callback: (title: string) => void) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -14,7 +14,7 @@ function createIpcListener<T extends unknown[]>(
 }
 
 const electronAPI = {
-  spawnSession: (cwd: string, options?: { dangerousMode?: boolean; claudeMode?: boolean; geminiMode?: boolean; codexMode?: boolean; claudeAgentsMode?: boolean; resumeSessionId?: string; initialCommand?: string; autoExecute?: boolean }) =>
+  spawnSession: (cwd: string, options?: { dangerousMode?: boolean; claudeMode?: boolean; geminiMode?: boolean; codexMode?: boolean; claudeAgentsMode?: boolean; resumeSessionId?: string; claudeSessionId?: string; initialCommand?: string; autoExecute?: boolean; tmuxMode?: boolean; adoptTmuxName?: string; adoptSessionId?: string }) =>
     ipcRenderer.invoke('pty:spawn', cwd, options),
 
   writeSession: (id: string, data: string) => ipcRenderer.send('pty:write', id, data),
@@ -28,6 +28,12 @@ const electronAPI = {
   killSession: (id: string) => ipcRenderer.invoke('pty:kill', id),
 
   listSessions: () => ipcRenderer.invoke('pty:list'),
+
+  tmuxAvailable: () => ipcRenderer.invoke('tmux:available'),
+
+  tmuxListAdoptable: () => ipcRenderer.invoke('tmux:list-adoptable'),
+
+  tmuxDiscard: (tmuxName: string) => ipcRenderer.invoke('tmux:discard', tmuxName),
 
   onSessionData: (id: string, callback: (data: string) => void) =>
     createIpcListener<[string]>(`pty:data:${id}`, callback),

--- a/src/renderer/src/components/layout/AppShell.tsx
+++ b/src/renderer/src/components/layout/AppShell.tsx
@@ -27,6 +27,10 @@ const sidebarTransition = {
   ease: [0.2, 0, 0, 1] as const
 }
 
+/** Process-wide latch so tmux-session adoption runs exactly once per launch,
+ *  even across React StrictMode's mount→unmount→mount in development. */
+let tmuxAdoptionStarted = false
+
 export function AppShell() {
   const sidebarOpen = useSessionStore((s) => s.sidebarOpen)
   const sidebarWidth = useSessionStore((s) => s.sidebarWidth)
@@ -85,6 +89,59 @@ export function AppShell() {
     },
     [addSession]
   )
+
+  // On launch, re-adopt tmux-backed sessions that survived a previous run:
+  // recreate each tab and reattach the live agent. The module-level latch makes
+  // this run once per process even under React StrictMode's mount/remount (a
+  // component-scoped ref would be recreated). The main process also dedupes by
+  // tmux name, so a re-adopted survivor is never spawned twice.
+  useEffect(() => {
+    if (tmuxAdoptionStarted) return
+    tmuxAdoptionStarted = true
+    void (async () => {
+      try {
+        const survivors = await window.electronAPI?.tmuxListAdoptable?.()
+        if (!survivors?.length) return
+        for (const s of survivors) {
+          try {
+            const info = await window.electronAPI.spawnSession(s.cwd, {
+              claudeMode: s.claudeMode,
+              geminiMode: s.geminiMode,
+              codexMode: s.codexMode,
+              claudeAgentsMode: s.claudeAgentsMode,
+              dangerousMode: s.dangerousMode,
+              tmuxMode: true,
+              adoptTmuxName: s.tmuxName,
+              // Reuse the original id + claude session id so lifecycle-hook
+              // status routing and resume keep working after reattach.
+              adoptSessionId: s.id,
+              claudeSessionId: s.claudeSessionId
+            })
+            addSession({
+              id: info.id,
+              cwd: info.cwd,
+              folderName: info.folderName,
+              name: s.folderName,
+              alive: info.alive,
+              activityStatus: 'idle',
+              promptWaiting: null,
+              claudeMode: s.claudeMode,
+              geminiMode: s.geminiMode,
+              codexMode: s.codexMode,
+              claudeAgentsMode: s.claudeAgentsMode,
+              dangerousMode: s.dangerousMode,
+              claudeSessionId: info.claudeSessionId,
+              sessionType: 'local'
+            })
+          } catch (err) {
+            console.error('Failed to adopt persistent session:', s.tmuxName, err)
+          }
+        }
+      } catch (err) {
+        console.error('Failed to list adoptable tmux sessions:', err)
+      }
+    })()
+  }, [addSession])
 
   const sidebarRef = useRef<HTMLDivElement>(null)
   const fileTreeRef = useRef<HTMLDivElement>(null)

--- a/src/renderer/src/components/settings/SettingsPanel.tsx
+++ b/src/renderer/src/components/settings/SettingsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { type Theme, useSessionStore } from '../../store/session-store'
 import { useWorkTrackerStore } from '../../store/work-tracker-store'
 import { useUserStore, USER_ICONS, USER_ICON_COLORS } from '../../store/user-store'
@@ -196,8 +196,47 @@ export function SettingsPanel() {
         </section>
 
         <SidebarWidgetsSection />
+
+        <SessionsSection />
       </div>
     </div>
+  )
+}
+
+function SessionsSection() {
+  const tmuxMode = useSessionStore((s) => s.tmuxMode)
+  const setTmuxMode = useSessionStore((s) => s.setTmuxMode)
+  const [tmuxAvailable, setTmuxAvailable] = useState<boolean | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    window.electronAPI?.tmuxAvailable().then((available) => {
+      if (!cancelled) setTmuxAvailable(available)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const unavailable = tmuxAvailable === false
+
+  return (
+    <section className="mt-8">
+      <h3 className="settings-section-title mb-3">Sessions</h3>
+      <div className="space-y-4">
+        <ToggleRow
+          label="Persistent sessions (tmux)"
+          description={
+            unavailable
+              ? 'Install tmux (e.g. `brew install tmux`) to enable. New sessions then keep running after you quit Clave and reattach on next launch.'
+              : 'Run new sessions inside tmux so agents keep running after you quit Clave, survive crashes, and reattach on next launch. Also reachable from any terminal via `tmux -L clave attach`.'
+          }
+          checked={tmuxMode && !unavailable}
+          onChange={setTmuxMode}
+          disabled={unavailable}
+        />
+      </div>
+    </section>
   )
 }
 
@@ -205,15 +244,17 @@ function ToggleRow({
   label,
   description,
   checked,
-  onChange
+  onChange,
+  disabled = false
 }: {
   label: string
   description: string
   checked: boolean
   onChange: (value: boolean) => void
+  disabled?: boolean
 }) {
   return (
-    <div className="flex items-center justify-between gap-4">
+    <div className={`flex items-center justify-between gap-4 ${disabled ? 'opacity-50' : ''}`}>
       <div className="min-w-0">
         <p className="text-sm text-text-secondary">{label}</p>
         <p className="text-xs text-text-tertiary mt-0.5">{description}</p>
@@ -221,10 +262,11 @@ function ToggleRow({
       <button
         role="switch"
         aria-checked={checked}
+        disabled={disabled}
         onClick={() => onChange(!checked)}
         className={`relative flex-shrink-0 w-9 h-5 rounded-full transition-colors ${
-          checked ? 'bg-accent' : 'bg-surface-300'
-        }`}
+          disabled ? 'cursor-not-allowed ' : ''
+        }${checked ? 'bg-accent' : 'bg-surface-300'}`}
       >
         <div
           className={`absolute top-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform ${

--- a/src/renderer/src/store/session-store.ts
+++ b/src/renderer/src/store/session-store.ts
@@ -29,7 +29,8 @@ interface SessionState {
   sidebarWidth: number
   theme: Theme
   appIcon: AppIcon
-  /** Opt-in: run new sessions inside persistent tmux sessions. */
+  /** Run new sessions inside persistent tmux sessions. On by default; falls
+   *  back to a plain shell automatically when tmux isn't installed. */
   tmuxMode: boolean
   searchQuery: string
   claudeMode: boolean
@@ -223,7 +224,7 @@ export const useSessionStore = create<SessionState>((set) => ({
   sidebarWidth: 260,
   theme: (localStorage.getItem('clave-theme') as Theme) || 'light',
   appIcon: (localStorage.getItem('clave-app-icon') as AppIcon) || 'dark',
-  tmuxMode: localStorage.getItem('clave-tmux-mode') === 'true',
+  tmuxMode: localStorage.getItem('clave-tmux-mode') !== 'false',
   searchQuery: '',
   claudeMode: true,
   geminiMode: false,

--- a/src/renderer/src/store/session-store.ts
+++ b/src/renderer/src/store/session-store.ts
@@ -29,6 +29,8 @@ interface SessionState {
   sidebarWidth: number
   theme: Theme
   appIcon: AppIcon
+  /** Opt-in: run new sessions inside persistent tmux sessions. */
+  tmuxMode: boolean
   searchQuery: string
   claudeMode: boolean
   geminiMode: boolean
@@ -82,6 +84,7 @@ interface SessionState {
   setSidebarWidth: (width: number) => void
   setTheme: (theme: Theme) => void
   setAppIcon: (icon: AppIcon) => void
+  setTmuxMode: (enabled: boolean) => void
   updateSessionAlive: (id: string, alive: boolean) => void
   setSessionActivity: (id: string, status: ActivityStatus) => void
   setAgentState: (id: string, state: import('./session-types').AgentRunState) => void
@@ -220,6 +223,7 @@ export const useSessionStore = create<SessionState>((set) => ({
   sidebarWidth: 260,
   theme: (localStorage.getItem('clave-theme') as Theme) || 'light',
   appIcon: (localStorage.getItem('clave-app-icon') as AppIcon) || 'dark',
+  tmuxMode: localStorage.getItem('clave-tmux-mode') === 'true',
   searchQuery: '',
   claudeMode: true,
   geminiMode: false,
@@ -639,6 +643,13 @@ export const useSessionStore = create<SessionState>((set) => ({
     localStorage.setItem('clave-app-icon', appIcon)
     set({ appIcon })
     window.electronAPI?.setAppIcon(appIcon)
+  },
+
+  setTmuxMode: (tmuxMode) => {
+    localStorage.setItem('clave-tmux-mode', String(tmuxMode))
+    set({ tmuxMode })
+    // Persist to the main process too: pty:spawn reads this as the default.
+    window.electronAPI?.preferencesSet('tmuxMode', tmuxMode)
   },
 
   updateSessionAlive: (id, alive) =>


### PR DESCRIPTION
Lands @Ruslan660's opt-in tmux-backed persistent sessions (originally #20), plus two follow-ups found while reviewing/testing:

- **fix(tmux): force UTF-8 client output (`-u`).** Electron launches tmux without a UTF-8 locale, so tmux ran the client in non-UTF-8 mode and downsampled every multibyte glyph (the agent logo, box-drawing, em-dashes) to `_`. Verified in the real app via a Playwright-driven Electron buffer dump — logo cells go from code 95 (`_`) to the correct block glyphs.
- **feat(tmux): on by default.** New sessions run inside tmux unless explicitly turned off; falls back to a plain shell when tmux isn't installed, so it's safe for everyone.

Supersedes #20 (fork PR — couldn't push the fixes onto it. Closes #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)