### PR TITLE
docs: explain how adoption is measured (Privacy & network)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ The only network requests Clave makes are:
 
 > A "Dangerous Mode" session (Cmd+D) launches Claude Code with `--dangerously-skip-permissions`. It is never the default and is clearly labelled in the UI.
 
+### How we measure adoption
+
+Since Clave sends nothing home, the only adoption numbers we look at are the aggregate statistics GitHub computes on its side: release download counts, repository stars, and repository traffic. A scheduled job snapshots those public-API numbers once a day. They contain no user identifiers, no IPs, and no device information — GitHub never exposes any of that to us, and nothing is ever collected from your machine. You can verify in this codebase that no analytics code exists.
+
 ## Build from source
 
 ```bash


### PR DESCRIPTION
Adds a short "How we measure adoption" subsection to the Privacy & network section of the README.

Context: we now snapshot GitHub-side aggregate statistics (release download counts, stars, repo traffic) daily in a separate repo. This makes the practice explicit to users: all numbers come from GitHub's public aggregates, nothing is collected from user machines, and the absence of analytics code is verifiable in this codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)