### PR TITLE
feat: anonymous daily usage ping (telemetry v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+### Added
+- **Anonymous daily usage ping** — Clave now sends one anonymous ping a day (a random ID, the app version, and your platform — nothing else) so we know how many people use it. A first-run notice explains it with a one-click "Turn off", and a new **Privacy** section in Settings → General lets you toggle the ping or reset the anonymous ID at any time. The README's "Privacy & network" section documents the exact payload.
+
 ## [1.52.0] — 2026-06-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -78,21 +78,25 @@ npx plugins add codika-io/clave-plugin   # re-run to pull latest
 
 ## Privacy & network
 
-Clave is local-first. It has no account or sign-in, and sends **no telemetry, analytics, or tracking** of any kind. Your sessions, history, and settings stay on your machine.
+Clave is local-first. It has no account or sign-in. Your sessions, history, and settings stay on your machine. The only thing it sends home is **one anonymous ping a day**, so we can count how many people actually use Clave:
 
-The only network requests Clave makes are:
+```json
+POST https://ping.clave.work/api/ping
+{ "id": "<random uuid>", "appVersion": "1.52.0", "platform": "darwin-arm64" }
+```
+
+That is the entire payload — three fields, nothing else, ever. The `id` is a random UUID generated on your machine; it carries no email, no username, and no hardware fingerprint, and the server stores only a keyed hash of it, never the raw ID. You can turn the ping off in **Settings → General → Privacy** (the first launch shows a notice with a one-click "Turn off"), and a **Reset anonymous ID** button there discards the current ID so the next ping uses a fresh one. The whole client is ~100 lines you can read at [`src/main/telemetry.ts`](src/main/telemetry.ts) — it fails silently, never retries within a check, and can never affect app behavior.
+
+The only other network requests Clave makes are:
 
 - **Claude Code** reaches the Anthropic API through your own local Claude Code install — Clave never proxies or sees that traffic.
 - **Auto-updates** — [electron-updater](https://www.electron.build/auto-update) checks [GitHub Releases](https://github.com/codika-io/clave/releases) for new versions and installs the signed, notarized build on quit. Auto-download is off by default.
+- **Usage ping** — the once-a-day anonymous `POST` to `ping.clave.work` described above (optional, toggle in Settings).
 - **Git operations** — standard fetch/pull/push to whatever remotes your own repositories use.
 - **SSH / SFTP** — only to remote hosts you explicitly add.
 - **OpenClaw agent chat** — an optional WebSocket connection, established only when you connect an SSH location that has OpenClaw running.
 
 > A "Dangerous Mode" session (Cmd+D) launches Claude Code with `--dangerously-skip-permissions`. It is never the default and is clearly labelled in the UI.
-
-### How we measure adoption
-
-Since Clave sends nothing home, the only adoption numbers we look at are the aggregate statistics GitHub computes on its side: release download counts, repository stars, and repository traffic. A scheduled job snapshots those public-API numbers once a day. They contain no user identifiers, no IPs, and no device information — GitHub never exposes any of that to us, and nothing is ever collected from your machine. You can verify in this codebase that no analytics code exists.
 
 ## Build from source
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,6 +6,7 @@ import { applyPersistedIcon } from './ipc-handlers/app-handlers'
 import { cleanupDroppedFiles } from './ipc-handlers/dropped-file-handlers'
 import { ptyManager, preloadLoginShellEnv } from './pty-manager'
 import { initAutoUpdater, cleanupAutoUpdater } from './auto-updater'
+import { initTelemetry, cleanupTelemetry } from './telemetry'
 import { initNotificationManager } from './notification-manager'
 import { sshManager } from './ssh-manager'
 import { locationManager } from './location-manager'
@@ -107,6 +108,7 @@ app.whenReady().then(() => {
   applyPersistedIcon()
   createWindow()
   initAutoUpdater()
+  initTelemetry()
 
   // Auto-connect locations with autoConnect enabled
   const locations = locationManager.getLocations()
@@ -136,6 +138,7 @@ app.whenReady().then(() => {
 app.on('before-quit', () => {
   cleanupClaveWatchers()
   cleanupAutoUpdater()
+  cleanupTelemetry()
   stopMcpServer()
 })
 

--- a/src/main/ipc-handlers/index.ts
+++ b/src/main/ipc-handlers/index.ts
@@ -3,6 +3,7 @@ import { registerBoardHandlers } from './board-handlers'
 import { registerUsageHandlers } from './usage-handlers'
 import { registerGitHandlers } from './git-handlers'
 import { registerUpdaterHandlers } from './updater-handlers'
+import { registerTelemetryHandlers } from './telemetry-handlers'
 import { registerFsHandlers } from './fs-handlers'
 import { registerPtyHandlers } from './pty-handlers'
 import { registerShellHandlers } from './shell-handlers'
@@ -21,6 +22,7 @@ export function registerIpcHandlers(): void {
   registerUsageHandlers()
   registerGitHandlers()
   registerUpdaterHandlers()
+  registerTelemetryHandlers()
   registerFsHandlers()
   registerPtyHandlers()
   registerShellHandlers()

--- a/src/main/ipc-handlers/telemetry-handlers.ts
+++ b/src/main/ipc-handlers/telemetry-handlers.ts
@@ -1,0 +1,16 @@
+import { ipcMain } from 'electron'
+import {
+  getTelemetryState,
+  setTelemetryEnabled,
+  resetInstallId,
+  setTelemetryNoticeShown
+} from '../telemetry'
+
+export function registerTelemetryHandlers(): void {
+  ipcMain.handle('telemetry:get-state', () => getTelemetryState())
+  ipcMain.handle('telemetry:set-enabled', (_event, enabled: boolean) =>
+    setTelemetryEnabled(enabled === true)
+  )
+  ipcMain.handle('telemetry:reset-id', () => resetInstallId())
+  ipcMain.handle('telemetry:set-notice-shown', () => setTelemetryNoticeShown())
+}

--- a/src/main/preferences-manager.ts
+++ b/src/main/preferences-manager.ts
@@ -6,10 +6,18 @@ export type AppIcon = 'dark' | 'light' | 'claude'
 
 interface Preferences {
   appIcon: AppIcon
+  telemetryEnabled: boolean
+  telemetryInstallId: string | null
+  telemetryLastPingAt: string | null
+  telemetryNoticeShown: boolean
 }
 
 const DEFAULTS: Preferences = {
-  appIcon: 'dark'
+  appIcon: 'dark',
+  telemetryEnabled: true,
+  telemetryInstallId: null,
+  telemetryLastPingAt: null,
+  telemetryNoticeShown: false
 }
 
 class PreferencesManager {

--- a/src/main/telemetry.ts
+++ b/src/main/telemetry.ts
@@ -1,0 +1,128 @@
+import { app } from 'electron'
+import { randomUUID } from 'crypto'
+import { preferencesManager } from './preferences-manager'
+
+const PING_URL = 'https://ping.clave.work/api/ping'
+const INITIAL_DELAY = 5000
+const CHECK_INTERVAL = 60 * 60 * 1000 // 1 hour
+const PING_INTERVAL = 24 * 60 * 60 * 1000 // 24 hours
+const FETCH_TIMEOUT = 10 * 1000
+
+let initialTimeout: ReturnType<typeof setTimeout> | null = null
+let checkInterval: ReturnType<typeof setInterval> | null = null
+
+export interface TelemetryState {
+  enabled: boolean
+  installId: string | null
+  lastPingAt: string | null
+  noticeShown: boolean
+}
+
+function isPingDue(): boolean {
+  const lastPingAt = preferencesManager.get('telemetryLastPingAt')
+  if (!lastPingAt) return true
+  const last = Date.parse(lastPingAt)
+  return !Number.isFinite(last) || Date.now() - last >= PING_INTERVAL
+}
+
+/** One check: send the daily ping if due. Never throws, never retries. */
+async function check(): Promise<void> {
+  try {
+    if (!preferencesManager.get('telemetryEnabled') || !isPingDue()) return
+
+    let installId = preferencesManager.get('telemetryInstallId')
+    if (!installId) {
+      installId = randomUUID()
+      preferencesManager.set('telemetryInstallId', installId)
+    }
+
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT)
+    try {
+      const response = await fetch(PING_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          id: installId,
+          appVersion: app.getVersion(),
+          platform: `${process.platform}-${process.arch}`
+        }),
+        signal: controller.signal
+      })
+      if (response.ok) {
+        preferencesManager.set('telemetryLastPingAt', new Date().toISOString())
+      }
+    } finally {
+      clearTimeout(timeout)
+    }
+  } catch (err) {
+    console.log('[telemetry] Ping skipped:', err instanceof Error ? err.message : err)
+  }
+}
+
+function startTimers(): void {
+  stopTimers()
+  initialTimeout = setTimeout(() => void check(), INITIAL_DELAY)
+  checkInterval = setInterval(() => void check(), CHECK_INTERVAL)
+}
+
+function stopTimers(): void {
+  if (initialTimeout) {
+    clearTimeout(initialTimeout)
+    initialTimeout = null
+  }
+  if (checkInterval) {
+    clearInterval(checkInterval)
+    checkInterval = null
+  }
+}
+
+export function initTelemetry(): void {
+  if (!app.isPackaged) return
+  if (!preferencesManager.get('telemetryEnabled')) return
+  startTimers()
+}
+
+export function getTelemetryState(): TelemetryState {
+  return {
+    enabled: preferencesManager.get('telemetryEnabled'),
+    installId: preferencesManager.get('telemetryInstallId'),
+    lastPingAt: preferencesManager.get('telemetryLastPingAt'),
+    noticeShown: preferencesManager.get('telemetryNoticeShown')
+  }
+}
+
+export function setTelemetryEnabled(enabled: boolean): void {
+  try {
+    preferencesManager.set('telemetryEnabled', enabled)
+    if (!app.isPackaged) return
+    if (enabled) startTimers()
+    else stopTimers()
+  } catch (err) {
+    console.log('[telemetry] Failed to update setting:', err instanceof Error ? err.message : err)
+  }
+}
+
+/** Drop the anonymous install id — a fresh one is generated on the next ping. */
+export function resetInstallId(): void {
+  try {
+    preferencesManager.set('telemetryInstallId', null)
+  } catch (err) {
+    console.log('[telemetry] Failed to reset id:', err instanceof Error ? err.message : err)
+  }
+}
+
+export function setTelemetryNoticeShown(): void {
+  try {
+    preferencesManager.set('telemetryNoticeShown', true)
+  } catch (err) {
+    console.log(
+      '[telemetry] Failed to persist notice flag:',
+      err instanceof Error ? err.message : err
+    )
+  }
+}
+
+export function cleanupTelemetry(): void {
+  stopTimers()
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -472,6 +472,15 @@ export interface ElectronAPI {
   readImageAsDataUrl: (absolutePath: string) => Promise<string | null>
   preferencesGet: (key: string) => Promise<unknown>
   preferencesSet: (key: string, value: unknown) => Promise<void>
+  telemetryGetState: () => Promise<{
+    enabled: boolean
+    installId: string | null
+    lastPingAt: string | null
+    noticeShown: boolean
+  }>
+  telemetrySetEnabled: (enabled: boolean) => Promise<void>
+  telemetryResetId: () => Promise<void>
+  telemetrySetNoticeShown: () => Promise<void>
 }
 
 declare global {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -308,7 +308,20 @@ const electronAPI = {
   readImageAsDataUrl: (absolutePath: string) =>
     ipcRenderer.invoke('clave:read-image', absolutePath) as Promise<string | null>,
   preferencesGet: (key: string) => ipcRenderer.invoke('preferences:get', key),
-  preferencesSet: (key: string, value: unknown) => ipcRenderer.invoke('preferences:set', key, value)
+  preferencesSet: (key: string, value: unknown) =>
+    ipcRenderer.invoke('preferences:set', key, value),
+
+  // ── Telemetry ──
+  telemetryGetState: () =>
+    ipcRenderer.invoke('telemetry:get-state') as Promise<{
+      enabled: boolean
+      installId: string | null
+      lastPingAt: string | null
+      noticeShown: boolean
+    }>,
+  telemetrySetEnabled: (enabled: boolean) => ipcRenderer.invoke('telemetry:set-enabled', enabled),
+  telemetryResetId: () => ipcRenderer.invoke('telemetry:reset-id'),
+  telemetrySetNoticeShown: () => ipcRenderer.invoke('telemetry:set-notice-shown')
 }
 
 contextBridge.exposeInMainWorld('electronAPI', electronAPI)

--- a/src/renderer/src/components/help/TelemetryNoticeBanner.tsx
+++ b/src/renderer/src/components/help/TelemetryNoticeBanner.tsx
@@ -1,0 +1,69 @@
+import { useState, useEffect, type ReactNode } from 'react'
+import { ShieldCheckIcon } from '@heroicons/react/24/outline'
+
+/** One-time notice about the anonymous daily usage ping (see src/main/telemetry.ts). */
+export function TelemetryNoticeBanner(): ReactNode {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    async function check(): Promise<void> {
+      try {
+        const state = await window.electronAPI.telemetryGetState()
+        if (!cancelled && !state.noticeShown && state.enabled) {
+          setVisible(true)
+        }
+      } catch {
+        // Silently fail — never block the sidebar on telemetry state
+      }
+    }
+    check()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  function dismiss(): void {
+    setVisible(false)
+    window.electronAPI?.telemetrySetNoticeShown()
+  }
+
+  function turnOff(): void {
+    setVisible(false)
+    window.electronAPI?.telemetrySetEnabled(false)
+    window.electronAPI?.telemetrySetNoticeShown()
+  }
+
+  if (!visible) return null
+
+  return (
+    <div>
+      <div className="px-2.5 py-2 rounded-xl bg-accent/8 border border-accent/15">
+        <div className="flex items-start gap-2">
+          <ShieldCheckIcon className="w-3.5 h-3.5 text-accent flex-shrink-0 mt-0.5" />
+          <div className="flex-1 min-w-0">
+            <span className="text-[12px] font-medium text-text-primary">Anonymous usage ping</span>
+            <p className="text-[11px] text-text-secondary mt-0.5 leading-relaxed">
+              Clave sends one anonymous ping a day — a random ID, the app version, and your platform
+              — so we know how many people use it. Nothing else is collected, ever.
+            </p>
+            <div className="flex items-center gap-3 mt-1">
+              <button
+                onClick={dismiss}
+                className="text-[11px] text-accent hover:text-accent-hover font-medium"
+              >
+                OK
+              </button>
+              <button
+                onClick={turnOff}
+                className="text-[11px] text-text-tertiary hover:text-text-secondary font-medium"
+              >
+                Turn off
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/layout/Sidebar.tsx
+++ b/src/renderer/src/components/layout/Sidebar.tsx
@@ -16,6 +16,7 @@ import { ExportClaveDialog } from '../ui/ExportClaveDialog'
 import { cn } from '../../lib/utils'
 import { SectionHeading, TaskQueueSection } from './SidebarSections'
 import { WhatsNewBanner } from '../help/WhatsNewBanner'
+import { TelemetryNoticeBanner } from '../help/TelemetryNoticeBanner'
 import { NewSessionDropdown } from './NewSessionDropdown'
 import { RemoteDirectoryPicker } from '../ui/RemoteDirectoryPicker'
 import { useAgentStore } from '../../store/agent-store'
@@ -1372,6 +1373,7 @@ export function Sidebar() {
 
       {/* Announcements — above the bottom bar */}
       <div className="flex-shrink-0 px-2 has-[>div]:pb-2 space-y-1">
+        <TelemetryNoticeBanner />
         <WhatsNewBanner />
         <UpdateBanner />
       </div>

--- a/src/renderer/src/components/settings/SettingsPanel.tsx
+++ b/src/renderer/src/components/settings/SettingsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, type ReactNode } from 'react'
 import { type Theme, useSessionStore } from '../../store/session-store'
 import { useWorkTrackerStore } from '../../store/work-tracker-store'
 import { useUserStore, USER_ICONS, USER_ICON_COLORS } from '../../store/user-store'
@@ -151,6 +151,7 @@ function GeneralSettings() {
         <GitSection />
         <SessionsSection />
         <ClaudeProfilesSection />
+        <PrivacySection />
       </div>
     </>
   )
@@ -361,6 +362,56 @@ function SessionsSection() {
           onChange={setTmuxMode}
           disabled={unavailable}
         />
+      </SettingsCard>
+    </SettingsSection>
+  )
+}
+
+function PrivacySection(): ReactNode {
+  const [enabled, setEnabled] = useState(true)
+  const [resetDone, setResetDone] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    window.electronAPI?.telemetryGetState().then((state) => {
+      if (!cancelled) setEnabled(state.enabled)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const handleToggle = (value: boolean): void => {
+    setEnabled(value)
+    window.electronAPI?.telemetrySetEnabled(value)
+  }
+
+  const handleReset = async (): Promise<void> => {
+    await window.electronAPI?.telemetryResetId()
+    setResetDone(true)
+    setTimeout(() => setResetDone(false), 2000)
+  }
+
+  return (
+    <SettingsSection title="Privacy">
+      <SettingsCard>
+        <ToggleRow
+          label="Share anonymous usage ping"
+          description="One ping a day: random ID, app version, platform. Nothing else."
+          checked={enabled}
+          onChange={handleToggle}
+        />
+        <SettingsRow
+          label="Reset anonymous ID"
+          description="Drop the current random ID. A fresh one is generated for the next ping."
+        >
+          <button
+            onClick={handleReset}
+            className="btn-secondary btn-compact border border-border-subtle"
+          >
+            {resetDone ? 'ID reset' : 'Reset ID'}
+          </button>
+        </SettingsRow>
       </SettingsCard>
     </SettingsSection>
   )


### PR DESCRIPTION
## What

The most minimal viable telemetry: **one anonymous ping per day, three fields, default-on** with a first-run notice and a Settings toggle.

- **`src/main/telemetry.ts`** — new module mirroring `auto-updater.ts` (`app.isPackaged` gate, 5s initial delay, hourly re-check for long-running instances, 24h send throttle, 10s `AbortController` timeout, no retries, fully fail-silent: no error can escape the module).
- **Persistence** — reuses the existing typed `preferences-manager.ts` (`userData/preferences.json`), adding `telemetryEnabled` (default `true`), `telemetryInstallId` (UUID generated lazily on first ping), `telemetryLastPingAt`, `telemetryNoticeShown`.
- **IPC + preload** — new `ipc-handlers/telemetry-handlers.ts` (`telemetry:get-state` / `set-enabled` / `reset-id` / `set-notice-shown`), exposed through the typed `window.electronAPI` contextBridge.
- **Settings → General → Privacy** — "Share anonymous usage ping" toggle (`ToggleRow`) + "Reset anonymous ID" action (`btn-secondary btn-compact`), built from the existing settings primitives.
- **First-run notice** — one-time dismissible sidebar banner (same pattern/placement as `WhatsNewBanner`) with **OK** and **Turn off** actions.
- **README** — "Privacy & network" rewritten honestly: exact payload shown verbatim, random-ID design (no email, no hardware fingerprint, server stores only a keyed hash), toggle + reset documented, pointer to `src/main/telemetry.ts`; ping endpoint added to the network-requests list.
- **CHANGELOG** — entry under `[Unreleased]` → Added.

## Exact payload

```json
POST https://ping.clave.work/api/ping
Content-Type: application/json
{ "id": "<uuid>", "appVersion": "<app.getVersion()>", "platform": "<process.platform>-<process.arch>" }
```

Nothing else is ever sent. On `response.ok` the module updates `lastPingAt`; any error is swallowed with a single `console.log` line.

## Verification

- `npm run typecheck` — green.
- `npm run lint` — diff is lint-neutral: the 3 new files lint clean (0 problems); every touched file has exactly the same pre-existing problem count as on `main` (the repo-wide lint baseline already fails on `main` with 233 errors, untouched here).
- `npm run build` — green.
- **Unit-style harness** (telemetry.ts bundled with esbuild against mocked `electron` + in-memory preferences + mocked `fetch`, no network): 18/18 assertions passed — no ping when disabled; ping sent when `lastPingAt` absent or ≥24h old; exact 3-field payload, endpoint, and UUID; `lastPingAt` updated only on `response.ok` (not on HTTP 500); network errors swallowed without crash; disable stops pending timers, re-enable restarts them; `resetInstallId` yields a fresh UUID on the next ping. Harness ran from `/tmp` and was deleted.
- **Settings UI runtime check**: the Playwright **Electron** MCP is not available in this environment (only the browser Playwright MCPs, which can't exercise `window.electronAPI`), so the Privacy section and notice banner were not screen-verified; they reuse the existing `SettingsSection`/`ToggleRow` primitives and the `WhatsNewBanner` pattern verbatim.

## Release checklist note

`whats-new.json` was deliberately **not** touched — per the release rules it gets its entry at release time. When cutting the release that includes this, add a `whats-new.json` entry for the anonymous usage ping (and move the CHANGELOG `[Unreleased]` entry under the new version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)