### PR TITLE
feat: remove telemetry ID reset (keep stable anonymous IDs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 ## [Unreleased]
 
 ### Added
-- **Anonymous daily usage ping** — Clave now sends one anonymous ping a day (a random ID, the app version, and your platform — nothing else) so we know how many people use it. A first-run notice explains it with a one-click "Turn off", and a new **Privacy** section in Settings → General lets you toggle the ping or reset the anonymous ID at any time. The README's "Privacy & network" section documents the exact payload.
+- **Anonymous daily usage ping** — Clave now sends one anonymous ping a day (a random ID, the app version, and your platform — nothing else) so we know how many people use it. A first-run notice explains it with a one-click "Turn off", and a new **Privacy** section in Settings → General lets you toggle the ping at any time. The README's "Privacy & network" section documents the exact payload.
 
 ## [1.53.0] — 2026-06-12
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ POST https://ping.clave.work/api/ping
 { "id": "<random uuid>", "appVersion": "1.52.0", "platform": "darwin-arm64" }
 ```
 
-That is the entire payload — three fields, nothing else, ever. The `id` is a random UUID generated on your machine; it carries no email, no username, and no hardware fingerprint, and the server stores only a keyed hash of it, never the raw ID. You can turn the ping off in **Settings → General → Privacy** (the first launch shows a notice with a one-click "Turn off"), and a **Reset anonymous ID** button there discards the current ID so the next ping uses a fresh one. The whole client is ~100 lines you can read at [`src/main/telemetry.ts`](src/main/telemetry.ts) — it fails silently, never retries within a check, and can never affect app behavior.
+That is the entire payload — three fields, nothing else, ever. The `id` is a random UUID generated on your machine; it carries no email, no username, and no hardware fingerprint, and the server stores only a keyed hash of it, never the raw ID. You can turn the ping off in **Settings → General → Privacy** (the first launch shows a notice with a one-click "Turn off"). The whole client is ~100 lines you can read at [`src/main/telemetry.ts`](src/main/telemetry.ts) — it fails silently, never retries within a check, and can never affect app behavior.
 
 The only other network requests Clave makes are:
 

--- a/src/main/ipc-handlers/telemetry-handlers.ts
+++ b/src/main/ipc-handlers/telemetry-handlers.ts
@@ -1,16 +1,10 @@
 import { ipcMain } from 'electron'
-import {
-  getTelemetryState,
-  setTelemetryEnabled,
-  resetInstallId,
-  setTelemetryNoticeShown
-} from '../telemetry'
+import { getTelemetryState, setTelemetryEnabled, setTelemetryNoticeShown } from '../telemetry'
 
 export function registerTelemetryHandlers(): void {
   ipcMain.handle('telemetry:get-state', () => getTelemetryState())
   ipcMain.handle('telemetry:set-enabled', (_event, enabled: boolean) =>
     setTelemetryEnabled(enabled === true)
   )
-  ipcMain.handle('telemetry:reset-id', () => resetInstallId())
   ipcMain.handle('telemetry:set-notice-shown', () => setTelemetryNoticeShown())
 }

--- a/src/main/telemetry.ts
+++ b/src/main/telemetry.ts
@@ -103,15 +103,6 @@ export function setTelemetryEnabled(enabled: boolean): void {
   }
 }
 
-/** Drop the anonymous install id — a fresh one is generated on the next ping. */
-export function resetInstallId(): void {
-  try {
-    preferencesManager.set('telemetryInstallId', null)
-  } catch (err) {
-    console.log('[telemetry] Failed to reset id:', err instanceof Error ? err.message : err)
-  }
-}
-
 export function setTelemetryNoticeShown(): void {
   try {
     preferencesManager.set('telemetryNoticeShown', true)

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -479,7 +479,6 @@ export interface ElectronAPI {
     noticeShown: boolean
   }>
   telemetrySetEnabled: (enabled: boolean) => Promise<void>
-  telemetryResetId: () => Promise<void>
   telemetrySetNoticeShown: () => Promise<void>
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -320,7 +320,6 @@ const electronAPI = {
       noticeShown: boolean
     }>,
   telemetrySetEnabled: (enabled: boolean) => ipcRenderer.invoke('telemetry:set-enabled', enabled),
-  telemetryResetId: () => ipcRenderer.invoke('telemetry:reset-id'),
   telemetrySetNoticeShown: () => ipcRenderer.invoke('telemetry:set-notice-shown')
 }
 

--- a/src/renderer/src/components/settings/SettingsPanel.tsx
+++ b/src/renderer/src/components/settings/SettingsPanel.tsx
@@ -369,7 +369,6 @@ function SessionsSection() {
 
 function PrivacySection(): ReactNode {
   const [enabled, setEnabled] = useState(true)
-  const [resetDone, setResetDone] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -386,12 +385,6 @@ function PrivacySection(): ReactNode {
     window.electronAPI?.telemetrySetEnabled(value)
   }
 
-  const handleReset = async (): Promise<void> => {
-    await window.electronAPI?.telemetryResetId()
-    setResetDone(true)
-    setTimeout(() => setResetDone(false), 2000)
-  }
-
   return (
     <SettingsSection title="Privacy">
       <SettingsCard>
@@ -401,17 +394,6 @@ function PrivacySection(): ReactNode {
           checked={enabled}
           onChange={handleToggle}
         />
-        <SettingsRow
-          label="Reset anonymous ID"
-          description="Drop the current random ID. A fresh one is generated for the next ping."
-        >
-          <button
-            onClick={handleReset}
-            className="btn-secondary btn-compact border border-border-subtle"
-          >
-            {resetDone ? 'ID reset' : 'Reset ID'}
-          </button>
-        </SettingsRow>
       </SettingsCard>
     </SettingsSection>
   )


### PR DESCRIPTION
Removes the "Reset anonymous ID" button and its full chain (telemetry.ts export, IPC channel, preload bridge, Settings UI row), plus the README/CHANGELOG mentions.

Rationale: resetting the install ID at will would inflate distinct-user counts — the exact metric this telemetry exists to measure (product call by Luca, 2026-06-12). The Settings toggle remains the opt-out; we can reintroduce reset if a user ever asks for it.

Verified: typecheck + build green; zero remaining references to the reset path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)