### PR TITLE
feat(clave): folder-level trust for .clave workspace files

### DIFF
--- a/src/main/ipc-handlers/clave-file-handlers.ts
+++ b/src/main/ipc-handlers/clave-file-handlers.ts
@@ -74,6 +74,78 @@ function isTrusted(content: string): boolean {
   return loadTrustedHashes().has(hashContent(content))
 }
 
+// ── Trusted workspace roots (VS Code Workspace Trust style) ──────────────────
+// Content-hash trust above is fragile: every distinct .clave file prompts, and
+// any edit (incl. the app's own rewrites) re-prompts. Instead, when the user
+// explicitly *adds a workspace folder* we trust that folder as a root, and every
+// .clave discovered under it skips the prompt. Files opened from outside any
+// trusted root still fall back to the content-hash gate.
+
+let trustedRoots: string[] | null = null
+
+function trustedRootsPath(): string {
+  return path.join(app.getPath('userData'), 'clave-trusted-roots.json')
+}
+
+/** Resolve symlinks + normalize so trust checks can't be defeated by path tricks. */
+function normalizeRoot(p: string): string {
+  try {
+    return fs.realpathSync(path.resolve(p))
+  } catch {
+    return path.resolve(p)
+  }
+}
+
+function loadTrustedRoots(): string[] {
+  if (trustedRoots) return trustedRoots
+  try {
+    const raw = fs.readFileSync(trustedRootsPath(), 'utf-8')
+    trustedRoots = (JSON.parse(raw) as string[]).map(normalizeRoot)
+  } catch {
+    trustedRoots = []
+  }
+  return trustedRoots
+}
+
+function persistTrustedRoots(): void {
+  if (!trustedRoots) return
+  try {
+    fs.writeFileSync(trustedRootsPath(), JSON.stringify(trustedRoots), 'utf-8')
+  } catch {
+    // best effort
+  }
+}
+
+function addTrustedRoot(root: string): void {
+  const set = loadTrustedRoots()
+  const norm = normalizeRoot(root)
+  if (!set.includes(norm)) {
+    set.push(norm)
+    persistTrustedRoots()
+  }
+}
+
+function removeTrustedRoot(root: string): void {
+  const norm = normalizeRoot(root)
+  trustedRoots = loadTrustedRoots().filter((r) => r !== norm)
+  persistTrustedRoots()
+}
+
+/** True if absolutePath lives at or under any trusted root (after realpath). */
+function isUnderTrustedRoot(absolutePath: string): boolean {
+  let real: string
+  try {
+    real = fs.realpathSync(absolutePath)
+  } catch {
+    real = path.resolve(absolutePath)
+  }
+  for (const root of loadTrustedRoots()) {
+    const rel = path.relative(root, real)
+    if (rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel))) return true
+  }
+  return false
+}
+
 /** Auto-run commands or dangerousMode sessions present in a parsed result. */
 function describeElevated(result: ClaveFileReadResult): { autoCommands: string[]; dangerous: boolean } {
   const groups = result.type === 'multi' ? result.groups : [result]
@@ -209,9 +281,17 @@ export function registerClaveFileHandlers(): void {
 
         // Trust gate: a file requesting auto-run or dangerousMode that the user
         // has neither authored nor trusted must be confirmed before its commands
-        // can execute. Default to the safe (no-elevation) outcome.
+        // can execute. Trust is resolved in order: (1) the file lives under a
+        // trusted workspace root, (2) the supplied rootDir is itself a trusted
+        // root, (3) the exact content hash was previously trusted/authored
+        // (back-compat). Default to the safe (no-elevation) outcome.
         const { autoCommands, dangerous } = describeElevated(result)
-        if ((autoCommands.length > 0 || dangerous) && !isTrusted(raw)) {
+        const elevated = autoCommands.length > 0 || dangerous
+        const trusted =
+          isUnderTrustedRoot(absolutePath) ||
+          (rootDir != null && isUnderTrustedRoot(rootDir)) ||
+          isTrusted(raw)
+        if (elevated && !trusted) {
           const win = BrowserWindow.fromWebContents(_event.sender)
           const detailLines: string[] = []
           if (autoCommands.length > 0) {
@@ -222,22 +302,27 @@ export function registerClaveFileHandlers(): void {
             detailLines.push('')
             detailLines.push('One or more agents would start with permission prompts disabled (--dangerously-skip-permissions).')
           }
-          const { response } = await dialog.showMessageBox(win!, {
+          const folderForTrust = rootDir || path.dirname(absolutePath)
+          const { response, checkboxChecked } = await dialog.showMessageBox(win!, {
             type: 'warning',
             buttons: ['Open safely', 'Trust and run', 'Cancel'],
             defaultId: 0,
             cancelId: 2,
             noLink: true,
+            checkboxLabel: `Trust all workspace files in “${path.basename(folderForTrust)}”`,
+            checkboxChecked: false,
             title: 'Review workspace file',
             message: `“${path.basename(absolutePath)}” wants to run commands automatically.`,
             detail: detailLines.join('\n') + '\n\nOnly trust this file if you recognise and understand these commands.'
           })
           if (response === 2) return null // Cancel
+          if (checkboxChecked) addTrustedRoot(folderForTrust)
           if (response === 1) {
-            trustContent(raw) // Trust and run as configured
+            if (!checkboxChecked) trustContent(raw) // Trust and run this exact file
             return result
           }
-          return sanitizeElevated(result) // Open safely — no auto-run, no dangerous mode
+          // Open safely — but folder trust (if ticked) supersedes sanitization
+          return checkboxChecked ? result : sanitizeElevated(result)
         }
 
         return result
@@ -516,6 +601,17 @@ export function registerClaveFileHandlers(): void {
   // Read an image file and return as data URL
   ipcMain.handle('clave:read-image', (_event, absolutePath: string): string | null => {
     return readImageAsDataUrl(absolutePath)
+  })
+
+  // Trusted workspace roots (folder-level trust for .clave files)
+  ipcMain.handle('clave:trust-root', (_event, root: string) => {
+    addTrustedRoot(root)
+  })
+  ipcMain.handle('clave:untrust-root', (_event, root: string) => {
+    removeTrustedRoot(root)
+  })
+  ipcMain.handle('clave:list-trusted-roots', (): string[] => {
+    return loadTrustedRoots()
   })
 
   // Preferences get/set

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -458,6 +458,9 @@ export interface ElectronAPI {
   readImageAsDataUrl: (absolutePath: string) => Promise<string | null>
   preferencesGet: (key: string) => Promise<unknown>
   preferencesSet: (key: string, value: unknown) => Promise<void>
+  trustWorkspaceRoot: (root: string) => Promise<void>
+  untrustWorkspaceRoot: (root: string) => Promise<void>
+  listTrustedRoots: () => Promise<string[]>
   extensionsGetInventory: (configDir?: string) => Promise<ExtensionsInventory>
   telemetryGetState: () => Promise<{
     enabled: boolean

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -306,6 +306,12 @@ const electronAPI = {
   preferencesGet: (key: string) => ipcRenderer.invoke('preferences:get', key),
   preferencesSet: (key: string, value: unknown) =>
     ipcRenderer.invoke('preferences:set', key, value),
+  trustWorkspaceRoot: (root: string) =>
+    ipcRenderer.invoke('clave:trust-root', root) as Promise<void>,
+  untrustWorkspaceRoot: (root: string) =>
+    ipcRenderer.invoke('clave:untrust-root', root) as Promise<void>,
+  listTrustedRoots: () =>
+    ipcRenderer.invoke('clave:list-trusted-roots') as Promise<string[]>,
 
   // ── Extensions (read-only inventory of installed plugins/skills/MCP) ──
   extensionsGetInventory: (configDir?: string) =>

--- a/src/renderer/src/components/settings/SettingsPanel.tsx
+++ b/src/renderer/src/components/settings/SettingsPanel.tsx
@@ -6,7 +6,7 @@ import { useWorkspaceStore } from '../../store/workspace-store'
 import { useClaudeProfileStore, DEFAULT_CLAUDE_PROFILE_ID } from '../../store/claude-profile-store'
 import { UserIconDisplay, ICON_MAP } from '../ui/UserIconDisplay'
 import { CheckIcon } from '@heroicons/react/24/solid'
-import { TrashIcon, PlusIcon, PencilIcon, FolderIcon } from '@heroicons/react/24/outline'
+import { TrashIcon, PlusIcon, PencilIcon, FolderIcon, ShieldCheckIcon } from '@heroicons/react/24/outline'
 import { LocationsTab } from './LocationsTab'
 import { UsagePanel } from '../usage/UsagePanel'
 import { SettingsSection, SettingsCard, SettingsRow, ToggleRow } from './primitives'
@@ -479,6 +479,14 @@ function WorkspacesSection() {
   const [discoveredFiles, setDiscoveredFiles] = useState<{ name: string; path: string; rootDir: string | null }[] | null>(null)
   const [selectedFiles, setSelectedFiles] = useState<Set<string>>(new Set())
   const [discoveryError, setDiscoveryError] = useState<string | null>(null)
+  const [trustedRoots, setTrustedRoots] = useState<string[]>([])
+
+  const refreshTrustedRoots = () => {
+    window.electronAPI?.listTrustedRoots().then((r) => setTrustedRoots(r ?? []))
+  }
+  useEffect(() => {
+    refreshTrustedRoots()
+  }, [])
 
   const handleAddWorkspace = async () => {
     setDiscoveryError(null)
@@ -486,6 +494,11 @@ function WorkspacesSection() {
 
     const folder = await window.electronAPI?.openFolderDialog()
     if (!folder) return
+
+    // Explicitly picking a folder is the trust grant: every .clave discovered
+    // under it runs its auto commands without re-prompting.
+    await window.electronAPI?.trustWorkspaceRoot(folder)
+    refreshTrustedRoots()
 
     // Try discovery first
     const files = await window.electronAPI?.discoverClaveFiles(folder)
@@ -652,6 +665,40 @@ function WorkspacesSection() {
       {/* Error message */}
       {discoveryError && (
         <p className="mt-2 text-xs text-red-400 px-1">{discoveryError}</p>
+      )}
+
+      {/* Trusted workspace folders */}
+      {trustedRoots.length > 0 && (
+        <>
+          <div className="settings-row-title px-1 pt-4 pb-1 flex items-center gap-2">
+            <ShieldCheckIcon className="w-4 h-4 text-text-tertiary" />
+            Trusted workspace folders
+          </div>
+          <p className="settings-row-description px-1 pb-2">
+            Workspace files inside these folders run their auto commands without prompting.
+          </p>
+          <SettingsCard>
+            {trustedRoots.map((root) => (
+              <div key={root} className="settings-row">
+                <div className="flex items-center gap-3 flex-1 min-w-0">
+                  <FolderIcon className="w-4 h-4 flex-shrink-0 text-text-tertiary" />
+                  <p className="settings-row-description truncate" title={root}>{root}</p>
+                </div>
+                <button
+                  onClick={async () => {
+                    await window.electronAPI?.untrustWorkspaceRoot(root)
+                    setTrustedRoots((r) => r.filter((x) => x !== root))
+                  }}
+                  className="btn-icon btn-icon-xs hover:text-red-400 flex-shrink-0"
+                  title="Revoke trust"
+                  aria-label="Revoke trust"
+                >
+                  <TrashIcon className="w-3.5 h-3.5" />
+                </button>
+              </div>
+            ))}
+          </SettingsCard>
+        </>
       )}
     </SettingsSection>
   )

--- a/src/renderer/src/store/workspace-store.ts
+++ b/src/renderer/src/store/workspace-store.ts
@@ -237,6 +237,27 @@ function migrateWorkspaces(workspaces: unknown[]): ClaveWorkspace[] {
   })
 }
 
+/** Folder containing a file path (string-only dirname for renderer use). */
+function dirOf(filePath: string): string {
+  return filePath.replace(/[\\/][^\\/]*$/, '') || filePath
+}
+
+/** One-time: trust the folders of already-registered workspaces (outside userData). */
+async function backfillTrustedRoots(workspaces: ClaveWorkspace[]): Promise<void> {
+  try {
+    if (await window.electronAPI?.preferencesGet('trustRootsBackfilled')) return
+    const userDataPath = await window.electronAPI?.getUserDataPath()
+    for (const ws of workspaces) {
+      const root = ws.rootDir ?? dirOf(ws.claveFilePath)
+      if (userDataPath && root.startsWith(userDataPath)) continue // skip Init/app dir
+      await window.electronAPI?.trustWorkspaceRoot(root)
+    }
+    await window.electronAPI?.preferencesSet('trustRootsBackfilled', true)
+  } catch (err) {
+    console.error('[workspace] Failed to backfill trusted roots:', err)
+  }
+}
+
 /** Load workspace config from preferences (call once on app start) */
 export async function loadWorkspaces(): Promise<void> {
   const raw = (await window.electronAPI?.preferencesGet('workspaces')) as unknown[] | null
@@ -254,6 +275,12 @@ export async function loadWorkspaces(): Promise<void> {
     activeWorkspaceId: activeId || null,
     loaded: true
   })
+
+  // One-time backfill: existing users added these workspace folders before
+  // folder-level trust existed, so retroactively trust them — otherwise the
+  // content-hash gate keeps re-prompting for files they already rely on.
+  // Exclude the app's own data dir (the generated "Init" workspace lives there).
+  await backfillTrustedRoots(workspaces)
 
   // Auto-load active workspace pins (idle, no auto-launch)
   if (activeId && workspaces.length > 0) {


### PR DESCRIPTION
## Problem

The `.clave` trust gate stored trust as a SHA256 of exact file content, so the warning dialog reappeared constantly:
- Every distinct `.clave` prompted separately (20 workspaces running `npm run dev` = 20 prompts).
- Any content change re-prompted — and Clave rewrites its own `.clave` files (toolbar persistence, autoDiscover slimming); a `git pull` or hand-edit also invalidated the trusted hash.
- "Open safely" was the **default** button and persisted nothing, so hitting Enter re-prompted forever.

The gate isn't really about `npm run dev` being unsafe — it's about auto-running *anything* from a file you didn't author (plus `--dangerously-skip-permissions` agents = RCE-on-open). So the fix is durable, coarse-grained trust, not removing the gate.

## Change — VS Code Workspace Trust model

Explicitly adding a workspace folder trusts it as a root; every `.clave` discovered under it skips the prompt. Files opened from outside any trusted root still fall back to the content-hash gate (back-compat preserved).

- **clave-file-handlers**: `clave-trusted-roots.json` store + `realpath`/`path.relative` containment (rejects symlink-escape and prefix-collision); layered read-file gate; dialog "Trust all workspace files in <folder>" checkbox; trust/untrust/list IPC handlers.
- **preload**: expose `trustWorkspaceRoot` / `untrustWorkspaceRoot` / `listTrustedRoots`.
- **SettingsPanel**: grant trust on folder-add; "Trusted workspace folders" card with revoke.
- **workspace-store**: one-time backfill trusting existing workspace roots (outside `userData`) so current users stop seeing prompts on upgrade.

## Verification

- `npm run typecheck` clean; `npx electron-vite build` succeeds.
- Path-containment logic tested standalone: file-under-root, deep-nested, root-itself, sibling-outside, symlink-escape, and prefix-collision all behave correctly.
- Not yet clicked through the live Electron UI (Playwright Electron MCP unavailable in the authoring session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)