### PR TITLE
fix(workspace): unload Init pins when activating first workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+### Fixed
+- **Activating your first workspace no longer leaves stale pins behind** — if you already had pinned groups before adding a workspace, Clave snapshots them into an "Init" workspace. That snapshot is now correctly unloaded when you activate another workspace, instead of leaving the old pins on top of the new ones with no way to unload them. The Init workspace also stops disappearing from Settings → Workspaces right after it is created.
+
 ## [1.59.0] — 2026-07-03
 
 ### Added

--- a/src/renderer/src/store/workspace-store.ts
+++ b/src/renderer/src/store/workspace-store.ts
@@ -92,28 +92,35 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
   },
 
   setActiveWorkspace: async (id: string | null) => {
-    const state = get()
-    const previousId = state.activeWorkspaceId
+    const previousId = get().activeWorkspaceId
 
-    // First workspace activation — snapshot current pins as "Init" workspace
-    if (id && !previousId && state.workspaces.length <= 1) {
-      await saveInitWorkspace()
+    // First workspace activation — snapshot the ad-hoc pins into an "Init"
+    // workspace so they stay recoverable, then unload them. Activating a
+    // workspace must show that workspace's pins, not these on top of them —
+    // and `previousId` is null here, so the deactivation branch below can't
+    // do it for us.
+    if (id && !previousId && get().workspaces.length <= 1) {
+      const initFilePath = await saveInitWorkspace()
+      if (initFilePath) removeWorkspacePins(initFilePath)
     }
 
     // Deactivate previous workspace — remove its pins
     if (previousId && previousId !== id) {
-      const prev = state.workspaces.find((w) => w.id === previousId)
+      const prev = get().workspaces.find((w) => w.id === previousId)
       if (prev) {
         removeWorkspacePins(prev.claveFilePath)
       }
     }
 
     set({ activeWorkspaceId: id })
-    persistWorkspaces(state.workspaces, id)
+    // Re-read rather than reusing a pre-await snapshot: saveInitWorkspace may
+    // have prepended the Init workspace, and persisting a stale array would
+    // write it straight back out of existence.
+    persistWorkspaces(get().workspaces, id)
 
     // Activate new workspace — import its .clave file (pins only, no auto-launch)
     if (id) {
-      const workspace = state.workspaces.find((w) => w.id === id)
+      const workspace = get().workspaces.find((w) => w.id === id)
       if (workspace) {
         await importClaveFile(workspace.claveFilePath, {
           autoLaunch: false,
@@ -166,20 +173,21 @@ function persistWorkspaces(workspaces: ClaveWorkspace[], activeId: string | null
   window.electronAPI?.preferencesSet('activeWorkspaceId', activeId).catch(() => {})
 }
 
-/** Save current pinned groups as an "Init" workspace in the app's data folder */
-async function saveInitWorkspace(): Promise<void> {
+/** Save current pinned groups as an "Init" workspace in the app's data folder.
+ *  Returns the file the snapshot was written to, or null if nothing was saved. */
+async function saveInitWorkspace(): Promise<string | null> {
   const pins = usePinnedStore.getState().pinnedGroups.filter((pg) => !pg.filePath)
-  if (pins.length === 0) return
+  if (pins.length === 0) return null
 
   try {
     const userDataPath = await window.electronAPI?.getUserDataPath()
-    if (!userDataPath) return
+    if (!userDataPath) return null
 
     const initFilePath = `${userDataPath}/workspace.clave`
 
     // Check if Init workspace already exists
     const store = useWorkspaceStore.getState()
-    if (store.workspaces.some((w) => w.claveFilePath === initFilePath)) return
+    if (store.workspaces.some((w) => w.claveFilePath === initFilePath)) return null
 
     // Write current pins as a multi-group .clave file
     const groups = pins.map((pg) => ({
@@ -208,6 +216,16 @@ async function saveInitWorkspace(): Promise<void> {
 
     await window.electronAPI?.writeClaveFile(initFilePath, { groups })
 
+    // Bind the snapshotted pins to the file we just wrote. Without this they
+    // keep `filePath: null`, so removeWorkspacePins() can never match them and
+    // the Init pins outlive every workspace switch, piling up alongside the pins
+    // of whatever workspace is activated next. `groupIndex` mirrors the
+    // multi-group layout written above so watch/sync-back address the right group.
+    const pinnedStore = usePinnedStore.getState()
+    pins.forEach((pg, i) => {
+      pinnedStore.updatePinnedGroup(pg.id, { filePath: initFilePath, groupIndex: i })
+    })
+
     // Register as the "Init" workspace
     const initWorkspace: ClaveWorkspace = {
       id: crypto.randomUUID(),
@@ -220,8 +238,11 @@ async function saveInitWorkspace(): Promise<void> {
       persistWorkspaces(next, s.activeWorkspaceId)
       return { workspaces: next }
     })
+
+    return initFilePath
   } catch (err) {
     console.error('[workspace] Failed to save Init workspace:', err)
+    return null
   }
 }
 


### PR DESCRIPTION
## Problem

Activating your first workspace leaves the pre-existing pins on screen, stacked on top of the newly activated workspace's pins, with no way to unload them.

## Root cause

Three defects, all on the first-activation path in `workspace-store.ts`:

1. **Pins never bound to the file.** `saveInitWorkspace()` snapshots the ad-hoc pins into `workspace.clave` and registers the Init workspace, but never stamps `filePath` onto those pins. They keep `filePath: null`, so `removeWorkspacePins()` — which matches on `filePath` / `discoveredBy` — can never find them again.

2. **The snapshot is never unloaded.** `setActiveWorkspace()` only unloads the *previous* workspace's pins, and `previousId` is `null` on first activation. So even once the pins are bound, nothing removes them.

3. **The Init registration is clobbered.** `setActiveWorkspace()` persisted `state.workspaces`, captured by `get()` *before* `await saveInitWorkspace()`. That stale array does not contain the Init workspace it had just prepended, so Init gets written straight back out of the prefs file — leaving orphaned pins and no workspace to unload them from.

## Fix

- `saveInitWorkspace()` stamps `filePath` + `groupIndex` on the snapshotted pins and returns the file it wrote (or `null`).
- `setActiveWorkspace()` unloads that snapshot immediately after creating it, and re-reads the store instead of reusing a pre-`await` value.

## Verification

`npm run typecheck` passes. `npx eslint` on the changed file reports the same 5 pre-existing problems as on `main` (2 `any` errors in `migrateWorkspaces`, 3 prettier warnings) — no new ones.

Note this does not retroactively repair already-broken state: pins orphaned by the old code still have `filePath: null` and must be removed by hand (right-click → Remove Pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)