### PR TITLE
PRDCT-1425: probe-first toolbar server buttons

### DIFF
--- a/src/main/ipc-handlers/clave-file-handlers.ts
+++ b/src/main/ipc-handlers/clave-file-handlers.ts
@@ -197,7 +197,7 @@ interface ClaveGroupData {
   category?: string
   logo?: string
   sessions: { cwd: string; name: string; claudeMode: boolean; antigravityMode: boolean; codexMode: boolean; claudeAgentsMode?: boolean; dangerousMode: boolean; prompt?: string; rootSession?: boolean; /** @deprecated legacy alias for antigravityMode, read for back-compat */ geminiMode?: boolean }[]
-  terminals: { command: string; commandMode: 'prefill' | 'auto'; color: string; icon?: string; cwd?: string; autoLaunchLocalhost?: boolean; persistent?: boolean }[]
+  terminals: { command: string; commandMode: 'prefill' | 'auto'; color: string; icon?: string; cwd?: string; autoLaunchLocalhost?: boolean; persistent?: boolean; serverUrl?: string }[]
 }
 
 interface ClaveFileRaw {
@@ -277,7 +277,8 @@ function resolveGroup(raw: { name?: string; cwd?: string; color?: string | null;
       icon: t.icon,
       cwd: t.cwd ? path.resolve(dir, t.cwd) : undefined,
       autoLaunchLocalhost: t.autoLaunchLocalhost ?? undefined,
-      persistent: t.persistent ?? undefined
+      persistent: t.persistent ?? undefined,
+      serverUrl: t.serverUrl ?? undefined
     }))
   }
 }
@@ -400,7 +401,8 @@ export function registerClaveFileHandlers(): void {
             ...(t.icon ? { icon: t.icon } : {}),
             ...(t.cwd ? { cwd: toRelative(t.cwd) } : {}),
             ...(t.autoLaunchLocalhost ? { autoLaunchLocalhost: true } : {}),
-            ...(t.persistent ? { persistent: true } : {})
+            ...(t.persistent ? { persistent: true } : {}),
+            ...(t.serverUrl ? { serverUrl: t.serverUrl } : {})
           }))
         })
 

--- a/src/main/ipc-handlers/shell-handlers.ts
+++ b/src/main/ipc-handlers/shell-handlers.ts
@@ -1,5 +1,7 @@
 import { ipcMain, dialog, shell, BrowserWindow } from 'electron'
 import net from 'node:net'
+import http from 'node:http'
+import https from 'node:https'
 
 export function registerShellHandlers(): void {
   ipcMain.handle('shell:openExternal', (_event, url: string) => {
@@ -40,6 +42,41 @@ export function registerShellHandlers(): void {
 
     // Try IPv4 first, then IPv6 — covers servers bound to 127.0.0.1, ::1, or 0.0.0.0
     return tryConnect('127.0.0.1').then((ok) => (ok ? true : tryConnect('::1')))
+  })
+
+  // HTTP liveness probe for toolbar server buttons. Stricter than net:check-port:
+  // a TCP connect proves only that something *bound* the port, while any HTTP
+  // response (any status code) proves a server is actually answering. Known
+  // residual, by design: an unrelated process answering on the declared port
+  // passes the probe (port hijack) — we do not engineer around it.
+  ipcMain.handle('net:probe-url', (_event, url: string, timeoutMs?: number): Promise<boolean> => {
+    return new Promise((resolve) => {
+      let parsed: URL
+      try {
+        parsed = new URL(url)
+      } catch {
+        resolve(false)
+        return
+      }
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        resolve(false)
+        return
+      }
+      const timeout = timeoutMs ?? 500
+      const mod = parsed.protocol === 'https:' ? https : http
+      const req = mod.get(url, { timeout, rejectUnauthorized: false }, (res) => {
+        // Headers received — the server is up. Status code irrelevant.
+        res.destroy()
+        resolve(true)
+      })
+      req.once('timeout', () => {
+        req.destroy()
+        resolve(false)
+      })
+      req.once('error', () => {
+        resolve(false)
+      })
+    })
   })
 
   ipcMain.handle('shell:openPath', (_event, filePath: string) => {

--- a/src/main/mcp/mcp-server.ts
+++ b/src/main/mcp/mcp-server.ts
@@ -199,6 +199,12 @@ function buildServer(callerSessionId: string | undefined): McpServer {
           .default('terminal')
           .describe('Icon shown on the group'),
         cwd: z.string().optional().describe("Working directory; defaults to the group's directory"),
+        serverUrl: z
+          .string()
+          .optional()
+          .describe(
+            'Declared dev-server URL (e.g. "http://localhost:3000") for commands that serve one. On toolbar server buttons this enables probe-first "ensure running, then open"; stored but inert for sidebar group terminals today.'
+          ),
         launch: z
           .boolean()
           .optional()

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -47,7 +47,10 @@ export interface ClaveFileGroupData {
     commandMode: 'prefill' | 'auto'
     color: string
     icon?: string
+    cwd?: string
     autoLaunchLocalhost?: boolean
+    persistent?: boolean
+    serverUrl?: string
   }[]
 }
 
@@ -70,7 +73,7 @@ export interface ClaveFileWriteData {
     prompt?: string
     rootSession?: boolean
   }[]
-  terminals?: { command: string; commandMode: 'prefill' | 'auto'; color: string; icon?: string }[]
+  terminals?: { command: string; commandMode: 'prefill' | 'auto'; color: string; icon?: string; cwd?: string | null; autoLaunchLocalhost?: boolean; persistent?: boolean; serverUrl?: string }[]
   groups?: Array<{
     name: string
     cwd: string | null
@@ -94,7 +97,10 @@ export interface ClaveFileWriteData {
       commandMode: 'prefill' | 'auto'
       color: string
       icon?: string
+      cwd?: string | null
       autoLaunchLocalhost?: boolean
+      persistent?: boolean
+      serverUrl?: string
     }[]
   }>
 }
@@ -318,6 +324,9 @@ export interface ElectronAPI {
   ) => Promise<{ success: boolean; error?: string }>
   openExternal: (url: string) => Promise<void>
   checkPort: (port: number) => Promise<boolean>
+  /** HTTP liveness probe (any HTTP response = true). Stricter than checkPort:
+   *  proves a server answers, not just that something bound the port. */
+  probeServerUrl: (url: string, timeoutMs?: number) => Promise<boolean>
   openPath: (filePath: string) => Promise<string>
   openFolderDialog: (defaultPath?: string) => Promise<string | null>
   onUpdateAvailable: (callback: (version: string) => void) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -106,6 +106,8 @@ const electronAPI = {
 
   openExternal: (url: string) => ipcRenderer.invoke('shell:openExternal', url),
   checkPort: (port: number) => ipcRenderer.invoke('net:check-port', port) as Promise<boolean>,
+  probeServerUrl: (url: string, timeoutMs?: number) =>
+    ipcRenderer.invoke('net:probe-url', url, timeoutMs) as Promise<boolean>,
 
   openPath: (filePath: string) => ipcRenderer.invoke('shell:openPath', filePath),
 

--- a/src/renderer/src/components/layout/AppShell.tsx
+++ b/src/renderer/src/components/layout/AppShell.tsx
@@ -751,18 +751,51 @@ function ToolbarQuickActions() {
                 key={key}
                 cwd={pg.cwd || '.'}
                 command={t.command}
-                persistent={t.persistent}
+                // A declared serverUrl implies persistent: closing the popover
+                // must never kill the server the click just asked to exist.
+                persistent={t.persistent || !!t.serverUrl}
+                serverUrl={t.serverUrl}
                 open={openId === key}
                 onOpenChange={(open) => setOpenId(open ? key : null)}
                 header={<IconComp className="w-3.5 h-3.5 shrink-0" style={{ color: colorHex }} />}
               >
-                <button
-                  className="p-1.5 rounded-lg hover:bg-surface-200 transition-colors"
-                  style={{ color: colorHex }}
-                  title={t.command || 'Shell'}
-                >
-                  <IconComp className="w-4 h-4" />
-                </button>
+                {t.serverUrl
+                  ? (api) => (
+                      <button
+                        onClick={(e) => {
+                          if (e.altKey) api.openTerminalOnly()
+                          else api.handleClick()
+                        }}
+                        onContextMenu={(e) => {
+                          e.preventDefault()
+                          api.openTerminalOnly()
+                        }}
+                        className="relative p-1.5 rounded-lg hover:bg-surface-200 transition-colors"
+                        style={{ color: colorHex }}
+                        title={api.title}
+                      >
+                        <IconComp className="w-4 h-4" />
+                        {api.state !== 'unknown' && (
+                          <span
+                            className={cn(
+                              'absolute right-0.5 bottom-0.5 w-1.5 h-1.5 rounded-full',
+                              api.state === 'up' && 'bg-emerald-500',
+                              api.state === 'starting' && 'bg-amber-400 animate-pulse',
+                              api.state === 'down' && 'bg-text-tertiary'
+                            )}
+                          />
+                        )}
+                      </button>
+                    )
+                  : (
+                      <button
+                        className="p-1.5 rounded-lg hover:bg-surface-200 transition-colors"
+                        style={{ color: colorHex }}
+                        title={t.command || 'Shell'}
+                      >
+                        <IconComp className="w-4 h-4" />
+                      </button>
+                    )}
               </ToolbarTerminalPopover>
             )
           })}

--- a/src/renderer/src/components/layout/ToolbarTerminalPopover.tsx
+++ b/src/renderer/src/components/layout/ToolbarTerminalPopover.tsx
@@ -1,15 +1,22 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { Popover, PopoverTrigger, PopoverContent } from '../ui/popover'
-import { XMarkIcon } from '@heroicons/react/24/outline'
+import { Popover, PopoverTrigger, PopoverAnchor, PopoverContent } from '../ui/popover'
+import { XMarkIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline'
 import { useToolbarTerminal, type ToolbarTerminalStatus } from '../../hooks/use-toolbar-terminal'
+import { useServerButton, type ServerButtonApi } from '../../hooks/use-server-button'
+import { cn, safePort } from '../../lib/utils'
 
 interface ToolbarTerminalPopoverProps {
   cwd: string
   command: string
   persistent?: boolean
+  /** Declared dev-server URL — turns this popover's button into a server button
+   *  (probe-first "ensure running, then open"; see use-server-button.ts). */
+  serverUrl?: string
   open: boolean
   onOpenChange: (open: boolean) => void
-  children: React.ReactNode
+  /** Plain trigger node, or (for server buttons) a render prop receiving the
+   *  server-button API so the toolbar button can carry the status dot. */
+  children: React.ReactNode | ((api: ServerButtonApi) => React.ReactNode)
   header: React.ReactNode
 }
 
@@ -35,6 +42,7 @@ export function ToolbarTerminalPopover({
   cwd,
   command,
   persistent,
+  serverUrl,
   open,
   onOpenChange,
   children,
@@ -42,14 +50,41 @@ export function ToolbarTerminalPopover({
 }: ToolbarTerminalPopoverProps): React.JSX.Element {
   const [sessionId, setSessionId] = useState<string | null>(null)
   const [status, setStatus] = useState<ToolbarTerminalStatus>('running')
+  const [respawnNonce, setRespawnNonce] = useState(0)
   const persistentSessionRef = useRef<string | null>(null)
+  const persistentExitCleanupRef = useRef<(() => void) | null>(null)
   const sessionIdRef = useRef<string | null>(null)
 
   useEffect(() => {
     sessionIdRef.current = sessionId
   }, [sessionId])
 
-  // Spawn PTY when popover opens
+  // Track a persistent session's exit for the session's whole lifetime — NOT
+  // tied to the popover being open. Without this, a session dying while the
+  // popover is closed leaves a stale ref: the next open would "reattach" to a
+  // dead PTY, and a server-button restart would type into a corpse.
+  const adoptPersistentSession = useCallback((id: string) => {
+    persistentSessionRef.current = id
+    persistentExitCleanupRef.current?.()
+    persistentExitCleanupRef.current = window.electronAPI.onSessionExit(id, () => {
+      if (persistentSessionRef.current === id) {
+        persistentSessionRef.current = null
+      }
+      persistentExitCleanupRef.current?.()
+      persistentExitCleanupRef.current = null
+      setStatus('exited')
+    })
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      persistentExitCleanupRef.current?.()
+      persistentExitCleanupRef.current = null
+    }
+  }, [])
+
+  // Spawn PTY when popover opens (or when a respawn is explicitly requested
+  // while already open — a server-button restart after the session died).
   useEffect(() => {
     if (!open) return
 
@@ -77,17 +112,16 @@ export function ToolbarTerminalPopover({
         spawnedId = info.id
 
         // Listen for exit immediately so we don't miss fast-exiting commands
-        exitCleanup = window.electronAPI.onSessionExit(info.id, () => {
-          setStatus('exited')
-          if (persistent) {
-            persistentSessionRef.current = null
-          }
-        })
-
-        setSessionId(info.id)
         if (persistent) {
-          persistentSessionRef.current = info.id
+          adoptPersistentSession(info.id)
+        } else {
+          exitCleanup = window.electronAPI.onSessionExit(info.id, () => {
+            setStatus('exited')
+          })
         }
+
+        setStatus('running')
+        setSessionId(info.id)
       })
       .catch((err) => {
         console.error('[toolbar-popover] spawn failed:', err)
@@ -100,7 +134,7 @@ export function ToolbarTerminalPopover({
         window.electronAPI.killSession(spawnedId)
       }
     }
-  }, [open, cwd, command, persistent])
+  }, [open, cwd, command, persistent, respawnNonce, adoptPersistentSession])
 
   const handleOpenChange = useCallback(
     (nextOpen: boolean) => {
@@ -123,11 +157,41 @@ export function ToolbarTerminalPopover({
     [persistent]
   )
 
+  // ── Server button wiring ──
+  const openTerminal = useCallback(() => {
+    // Already open with a dead session → the open-effect won't re-run on its
+    // own; bump the nonce to force a respawn.
+    if (open && !persistentSessionRef.current) {
+      setRespawnNonce((n) => n + 1)
+    }
+    onOpenChange(true)
+  }, [open, onOpenChange])
+
+  const serverButton = useServerButton({
+    serverUrl,
+    command,
+    sessionId,
+    getLiveSessionId: () => persistentSessionRef.current,
+    openTerminal
+  })
+
   const statusColor = status === 'running' ? 'bg-green-500' : 'bg-red-400'
+  const serverState = serverButton.state
+  const serverPort = serverButton.liveUrl ? safePort(serverButton.liveUrl) : null
 
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
-      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      {serverUrl ? (
+        // Server buttons drive open/close themselves (probe-first click), so
+        // they anchor the popover instead of using Radix's toggling trigger.
+        <PopoverAnchor asChild>
+          {typeof children === 'function' ? children(serverButton) : children}
+        </PopoverAnchor>
+      ) : (
+        <PopoverTrigger asChild>
+          {typeof children === 'function' ? children(serverButton) : children}
+        </PopoverTrigger>
+      )}
       <PopoverContent
         animated
         open={open}
@@ -144,11 +208,43 @@ export function ToolbarTerminalPopover({
             <span className="text-xs text-text-secondary truncate flex-1">{command}</span>
           </div>
           <div className="flex items-center gap-2 shrink-0">
+            {serverUrl && (
+              // Server-state chip: deliberately separate from the session dot —
+              // the session (shell) surviving its server is the whole reason
+              // server buttons probe instead of trusting session liveness.
+              <button
+                onClick={serverButton.openBrowser}
+                disabled={serverState !== 'up'}
+                className={cn(
+                  'flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium transition-colors',
+                  serverState === 'up' &&
+                    'bg-emerald-500/10 text-emerald-500 hover:bg-emerald-500/20',
+                  serverState === 'starting' && 'bg-amber-400/10 text-amber-400 cursor-wait',
+                  (serverState === 'down' || serverState === 'unknown') &&
+                    'bg-surface-200 text-text-secondary'
+                )}
+                title={
+                  serverState === 'up'
+                    ? `Open ${serverButton.liveUrl}`
+                    : serverState === 'starting'
+                      ? 'Server starting…'
+                      : 'Server not running'
+                }
+              >
+                <span
+                  className={cn(
+                    'w-1 h-1 rounded-full',
+                    serverState === 'up' && 'bg-emerald-500',
+                    serverState === 'starting' && 'bg-amber-400 animate-pulse',
+                    (serverState === 'down' || serverState === 'unknown') && 'bg-text-tertiary'
+                  )}
+                />
+                <span>{serverPort !== null ? `:${serverPort}` : 'server'}</span>
+                {serverState === 'up' && <ArrowTopRightOnSquareIcon className="w-2.5 h-2.5" />}
+              </button>
+            )}
             <div className={`w-1.5 h-1.5 rounded-full ${statusColor}`} />
-            <button
-              onClick={() => handleOpenChange(false)}
-              className="btn-icon btn-icon-xs"
-            >
+            <button onClick={() => handleOpenChange(false)} className="btn-icon btn-icon-xs">
               <XMarkIcon className="w-3.5 h-3.5" />
             </button>
           </div>

--- a/src/renderer/src/hooks/use-remote-terminal.ts
+++ b/src/renderer/src/hooks/use-remote-terminal.ts
@@ -3,28 +3,8 @@ import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { useSessionStore, type Theme } from '../store/session-store'
 import { safePort } from '../lib/utils'
+import { stripAnsi, detectLocalhostUrl } from '../lib/localhost-url'
 import '@xterm/xterm/css/xterm.css'
-
-// eslint-disable-next-line no-control-regex
-const ANSI_RE = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nq-uy=><~]/g
-
-function stripAnsi(str: string): string {
-  return str.replace(ANSI_RE, '')
-}
-
-// eslint-disable-next-line no-control-regex
-const LOCALHOST_URL_RE = /https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d{1,5})(?:\/\S*)?/i
-
-function detectLocalhostUrl(buffer: string): string | null {
-  const match = buffer.match(LOCALHOST_URL_RE)
-  if (!match) return null
-  try {
-    new URL(match[0])
-    return match[0]
-  } catch {
-    return null
-  }
-}
 
 function detectPrompt(buffer: string): string | null {
   const tail = buffer.slice(-500)

--- a/src/renderer/src/hooks/use-server-button.ts
+++ b/src/renderer/src/hooks/use-server-button.ts
@@ -1,0 +1,272 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { detectLocalhostUrl, stripAnsi } from '../lib/localhost-url'
+
+/**
+ * State machine for toolbar server buttons (terminals declaring a `serverUrl`).
+ *
+ * A server button is goal-directed: the click means "make this server exist and
+ * take me to it", not "run the command again". The HTTP probe is the only
+ * source of truth — session liveness is NOT server liveness (the popover shell
+ * survives a Ctrl-C'd server, and a server can survive a Clave restart).
+ *
+ * Click algorithm:
+ *   1. Probe the live URL (~500ms HTTP). Reachable → openExternal, done. This
+ *      covers our own persistent session, a pre-restart orphan, or a server the
+ *      user started by hand — and never spawns a duplicate.
+ *   2. Not reachable → ensure a session (reattach + restart in place, or let
+ *      the popover spawn one), then open on URL detection in output or on a
+ *      successful probe during the starting window. A dead URL is never opened.
+ *
+ * Known residual, by design: an unrelated process answering on the declared
+ * port passes the probe (port hijack) — we do not engineer around it.
+ */
+
+export type ServerButtonState = 'unknown' | 'up' | 'down' | 'starting'
+
+export interface ServerButtonApi {
+  state: ServerButtonState
+  /** Adopted (detected) URL if the server hopped ports, else the declared one. */
+  liveUrl: string | null
+  /** Probe-first "ensure running, then open" click. */
+  handleClick: () => void
+  /** Show the popover terminal only — no probe, no browser (⌥/right-click). */
+  openTerminalOnly: () => void
+  /** Open liveUrl in the browser (header chip) — only acts when state is 'up'. */
+  openBrowser: () => void
+  title: string
+}
+
+const PROBE_TIMEOUT_MS = 500
+const DOT_POLL_INTERVAL_MS = 10_000
+const STARTING_PROBE_INTERVAL_MS = 2_000
+const STARTING_TIMEOUT_MS = 60_000
+const RESTART_SIGINT_DELAY_MS = 150
+/** Consecutive probe failures before an 'up' dot demotes to 'down' (HMR flap guard). */
+const DEMOTE_FAILURES = 2
+
+interface UseServerButtonArgs {
+  /** Declared server URL; undefined disables the whole state machine. */
+  serverUrl?: string
+  command: string
+  /** The popover's current session id (persists across popover close). */
+  sessionId: string | null
+  /** Live persistent session id, nulled the moment its PTY exits. */
+  getLiveSessionId: () => string | null
+  /** Open the popover, spawning a session if none is alive. */
+  openTerminal: () => void
+}
+
+export function useServerButton({
+  serverUrl,
+  command,
+  sessionId,
+  getLiveSessionId,
+  openTerminal
+}: UseServerButtonArgs): ServerButtonApi {
+  const enabled = !!serverUrl
+  const [state, setState] = useState<ServerButtonState>('unknown')
+  const [adoptedUrl, setAdoptedUrl] = useState<string | null>(null)
+  const liveUrl = enabled ? (adoptedUrl ?? serverUrl!) : null
+
+  const stateRef = useRef(state)
+  const liveUrlRef = useRef(liveUrl)
+  useEffect(() => {
+    stateRef.current = state
+    liveUrlRef.current = liveUrl
+  }, [state, liveUrl])
+  /** One consumable browser-open per click — streaming output can never re-trigger it. */
+  const intentRef = useRef(false)
+  const bufferRef = useRef('')
+  const failuresRef = useRef(0)
+  const startingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const startingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const clearStarting = useCallback(() => {
+    if (startingTimerRef.current) {
+      clearTimeout(startingTimerRef.current)
+      startingTimerRef.current = null
+    }
+    if (startingIntervalRef.current) {
+      clearInterval(startingIntervalRef.current)
+      startingIntervalRef.current = null
+    }
+  }, [])
+
+  /** The server answered at `url` — settle 'up', consume the open intent if armed. */
+  const resolveUp = useCallback(
+    (url: string) => {
+      clearStarting()
+      failuresRef.current = 0
+      setAdoptedUrl(url)
+      setState('up')
+      if (intentRef.current) {
+        intentRef.current = false
+        window.electronAPI.openExternal(url)
+      }
+    },
+    [clearStarting]
+  )
+
+  const failStarting = useCallback(() => {
+    clearStarting()
+    intentRef.current = false
+    setState('down')
+  }, [clearStarting])
+
+  /** Dot-maintenance probe (mount, interval, window focus). Never runs while starting. */
+  const probeNow = useCallback(async () => {
+    if (!enabled || stateRef.current === 'starting') return
+    const target = liveUrlRef.current
+    if (!target) return
+    const ok = await window.electronAPI.probeServerUrl(target, PROBE_TIMEOUT_MS)
+    // Re-read after the await — a click may have flipped us to 'starting'.
+    if ((stateRef.current as ServerButtonState) === 'starting') return
+    if (ok) {
+      failuresRef.current = 0
+      setState('up')
+    } else {
+      failuresRef.current++
+      if (stateRef.current !== 'up' || failuresRef.current >= DEMOTE_FAILURES) {
+        failuresRef.current = 0
+        setState('down')
+      }
+    }
+  }, [enabled])
+
+  /** Starting-window probe against the declared URL — covers servers that never
+   *  print their URL (or print it ANSI-mangled past detection). */
+  const probeStartingOnce = useCallback(
+    async (failFast: boolean) => {
+      if (!enabled || stateRef.current !== 'starting') return
+      const ok = await window.electronAPI.probeServerUrl(serverUrl!, PROBE_TIMEOUT_MS)
+      if (stateRef.current !== 'starting') return
+      if (ok) resolveUp(serverUrl!)
+      else if (failFast) failStarting()
+    },
+    [enabled, serverUrl, resolveUp, failStarting]
+  )
+
+  // Output detection on the live session — primary "server is up" signal, and
+  // the one that catches port hops (mint 3000 → 3001): detection wins over
+  // declaration, the detected URL is adopted for the rest of the app run.
+  useEffect(() => {
+    if (!enabled || !sessionId) return
+    const cleanupData = window.electronAPI.onSessionData(sessionId, (data) => {
+      bufferRef.current = (bufferRef.current + stripAnsi(data)).slice(-500)
+      const url = detectLocalhostUrl(bufferRef.current)
+      if (!url) return
+      if (stateRef.current === 'starting') {
+        resolveUp(url)
+      } else if (url !== liveUrlRef.current || stateRef.current !== 'up') {
+        // Manual restart inside the popover — adopt quietly, never open a browser.
+        failuresRef.current = 0
+        setAdoptedUrl(url)
+        setState('up')
+      }
+    })
+    const cleanupExit = window.electronAPI.onSessionExit(sessionId, () => {
+      // Session death ≠ server death — but a session dying mid-start usually
+      // means the command failed fast (e.g. not found). Learn the truth quickly
+      // instead of sitting amber for the full timeout.
+      if (stateRef.current === 'starting') {
+        setTimeout(() => void probeStartingOnce(true), 800)
+      }
+    })
+    return () => {
+      cleanupData()
+      cleanupExit()
+    }
+  }, [enabled, sessionId, resolveUp, probeStartingOnce])
+
+  // Dot maintenance: probe on mount, every 10s while the app is focused, and
+  // immediately on window refocus (user may have killed the server elsewhere).
+  useEffect(() => {
+    if (!enabled) return
+    const initialProbe = setTimeout(() => void probeNow(), 0)
+    const interval = setInterval(() => {
+      if (!document.hasFocus()) return
+      void probeNow()
+    }, DOT_POLL_INTERVAL_MS)
+    const onFocus = (): void => {
+      void probeNow()
+    }
+    window.addEventListener('focus', onFocus)
+    return () => {
+      clearTimeout(initialProbe)
+      clearInterval(interval)
+      window.removeEventListener('focus', onFocus)
+      clearStarting()
+    }
+  }, [enabled, probeNow, clearStarting])
+
+  const handleClick = useCallback(async () => {
+    if (!enabled) return
+    const target = liveUrlRef.current!
+    const ok = await window.electronAPI.probeServerUrl(target, PROBE_TIMEOUT_MS)
+    if (ok) {
+      // The probe is the only source of truth: reachable → just go there.
+      failuresRef.current = 0
+      setState('up')
+      window.electronAPI.openExternal(target)
+      return
+    }
+    if (stateRef.current === 'starting') {
+      // Already booting — surface the logs, never ^C a starting server.
+      openTerminal()
+      return
+    }
+    // Not reachable → ensure running. Reset adoption so the starting window
+    // probes the declared URL, and reset the buffer so a stale URL lingering
+    // in old output can never satisfy detection.
+    setAdoptedUrl(null)
+    liveUrlRef.current = serverUrl!
+    bufferRef.current = ''
+    intentRef.current = true
+    setState('starting')
+    const sid = getLiveSessionId()
+    openTerminal()
+    if (sid) {
+      // Restart in place: ^C clears a half-typed prompt line or kills a wedged
+      // foreground process; scrollback (the evidence of why it died) survives.
+      window.electronAPI.writeSession(sid, '\x03')
+      setTimeout(() => {
+        window.electronAPI.writeSession(sid, command + '\r')
+      }, RESTART_SIGINT_DELAY_MS)
+    }
+    // Else: openTerminal() spawns a fresh session that runs `command` itself.
+    startingIntervalRef.current = setInterval(() => {
+      void probeStartingOnce(false)
+    }, STARTING_PROBE_INTERVAL_MS)
+    startingTimerRef.current = setTimeout(() => {
+      // Last-chance probe before giving up — still a bounded response to the click.
+      void probeStartingOnce(true)
+    }, STARTING_TIMEOUT_MS)
+  }, [enabled, serverUrl, command, getLiveSessionId, openTerminal, probeStartingOnce])
+
+  const openTerminalOnly = useCallback(() => {
+    openTerminal()
+  }, [openTerminal])
+
+  const openBrowser = useCallback(() => {
+    if (stateRef.current === 'up' && liveUrlRef.current) {
+      window.electronAPI.openExternal(liveUrlRef.current)
+    }
+  }, [])
+
+  const title = !enabled
+    ? command || 'Shell'
+    : state === 'up'
+      ? `Open ${liveUrl}\n⌥-click / right-click: terminal`
+      : state === 'starting'
+        ? `Starting ${command}…`
+        : `Start ${command} → ${serverUrl}\n⌥-click / right-click: terminal`
+
+  return {
+    state,
+    liveUrl,
+    handleClick: () => void handleClick(),
+    openTerminalOnly,
+    openBrowser,
+    title
+  }
+}

--- a/src/renderer/src/hooks/use-terminal.ts
+++ b/src/renderer/src/hooks/use-terminal.ts
@@ -5,28 +5,8 @@ import { useSessionStore } from '../store/session-store'
 import { shellEscape } from '../lib/shell'
 import { getXtermTheme } from '../lib/terminal-theme'
 import { safePort } from '../lib/utils'
+import { stripAnsi, detectLocalhostUrl } from '../lib/localhost-url'
 import '@xterm/xterm/css/xterm.css'
-
-// eslint-disable-next-line no-control-regex
-const ANSI_RE = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nq-uy=><~]/g
-
-function stripAnsi(str: string): string {
-  return str.replace(ANSI_RE, '')
-}
-
-// eslint-disable-next-line no-control-regex
-const LOCALHOST_URL_RE = /https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d{1,5})(?:\/\S*)?/i
-
-function detectLocalhostUrl(buffer: string): string | null {
-  const match = buffer.match(LOCALHOST_URL_RE)
-  if (!match) return null
-  try {
-    new URL(match[0])
-    return match[0]
-  } catch {
-    return null
-  }
-}
 
 function detectPrompt(buffer: string): string | null {
   // Collapse whitespace for matching (ANSI stripping removes cursor positioning,

--- a/src/renderer/src/lib/localhost-url.ts
+++ b/src/renderer/src/lib/localhost-url.ts
@@ -1,0 +1,23 @@
+// Shared terminal-output helpers for localhost dev-server detection, used by
+// use-terminal.ts (group sessions), use-remote-terminal.ts (remote sessions),
+// and use-server-button.ts (toolbar server buttons).
+
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nq-uy=><~]/g
+
+export function stripAnsi(str: string): string {
+  return str.replace(ANSI_RE, '')
+}
+
+const LOCALHOST_URL_RE = /https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d{1,5})(?:\/\S*)?/i
+
+export function detectLocalhostUrl(buffer: string): string | null {
+  const match = buffer.match(LOCALHOST_URL_RE)
+  if (!match) return null
+  try {
+    new URL(match[0])
+    return match[0]
+  } catch {
+    return null
+  }
+}

--- a/src/renderer/src/lib/mcp-dispatcher.ts
+++ b/src/renderer/src/lib/mcp-dispatcher.ts
@@ -73,6 +73,7 @@ function handleList(payload: { callerSessionId?: string }): unknown {
       commandMode: t.commandMode,
       color: t.color,
       icon: t.icon ?? null,
+      serverUrl: t.serverUrl ?? null,
       sessionId: t.sessionId
     }))
   }))
@@ -266,6 +267,7 @@ async function handleAddGroupTerminal(payload: {
   color?: string
   icon?: string
   cwd?: string
+  serverUrl?: string
   launch?: boolean
   callerSessionId?: string
 }): Promise<unknown> {
@@ -288,7 +290,8 @@ async function handleAddGroupTerminal(payload: {
     color: (payload.color as GroupTerminalConfig['color']) ?? 'green',
     icon: (payload.icon as GroupTerminalConfig['icon']) ?? 'terminal',
     // Per-terminal cwd is stored only when it differs from the group default.
-    cwd: payload.cwd && payload.cwd !== groupCwd ? payload.cwd : null
+    cwd: payload.cwd && payload.cwd !== groupCwd ? payload.cwd : null,
+    serverUrl: payload.serverUrl
   })
 
   if (payload.launch === false) return { terminalId, groupId: group.id, sessionId: null }

--- a/src/renderer/src/store/pinned-store.ts
+++ b/src/renderer/src/store/pinned-store.ts
@@ -177,7 +177,7 @@ function syncToClaveFile(pg: PinnedGroup): void {
         ...(p.toolbar ? { toolbar: true } : {}),
         ...(p.logo ? { logo: p.logo } : {}),
         sessions: p.sessions.map((s) => ({ cwd: s.cwd, name: s.name, claudeMode: s.claudeMode, antigravityMode: s.antigravityMode, codexMode: s.codexMode, claudeAgentsMode: s.claudeAgentsMode, dangerousMode: s.dangerousMode, ...(s.prompt ? { prompt: s.prompt } : {}), ...(s.rootSession ? { rootSession: true } : {}) })),
-        terminals: p.terminals.map((t) => ({ command: t.command, commandMode: t.commandMode, color: t.color, icon: t.icon, cwd: t.cwd, autoLaunchLocalhost: t.autoLaunchLocalhost, persistent: t.persistent })),
+        terminals: p.terminals.map((t) => ({ command: t.command, commandMode: t.commandMode, color: t.color, icon: t.icon, cwd: t.cwd, autoLaunchLocalhost: t.autoLaunchLocalhost, persistent: t.persistent, serverUrl: t.serverUrl })),
         ...(p.category ? { category: p.category } : {})
       })
 
@@ -198,7 +198,7 @@ function syncToClaveFile(pg: PinnedGroup): void {
 // ── Import / Export ──
 
 function createPinnedFromGroup(
-  g: { name: string; cwd: string; color: string | null; toolbar?: boolean; category?: string; logo?: string; sessions: { cwd: string; name: string; claudeMode: boolean; antigravityMode: boolean; codexMode: boolean; claudeAgentsMode?: boolean; dangerousMode: boolean; prompt?: string; rootSession?: boolean }[]; terminals: { command: string; commandMode: 'prefill' | 'auto'; color: string; icon?: string }[] },
+  g: { name: string; cwd: string; color: string | null; toolbar?: boolean; category?: string; logo?: string; sessions: { cwd: string; name: string; claudeMode: boolean; antigravityMode: boolean; codexMode: boolean; claudeAgentsMode?: boolean; dangerousMode: boolean; prompt?: string; rootSession?: boolean }[]; terminals: { command: string; commandMode: 'prefill' | 'auto'; color: string; icon?: string; cwd?: string; autoLaunchLocalhost?: boolean; persistent?: boolean; serverUrl?: string }[] },
   filePath: string,
   groupIndex?: number,
   rootDir?: string | null,
@@ -226,7 +226,7 @@ function createPinnedFromGroup(
   }
 }
 
-function groupDataToPinnedTerminals(terminals: { command: string; commandMode: 'prefill' | 'auto'; color: string; icon?: string; cwd?: string; autoLaunchLocalhost?: boolean; persistent?: boolean }[]): PinnedGroupTerminal[] {
+function groupDataToPinnedTerminals(terminals: { command: string; commandMode: 'prefill' | 'auto'; color: string; icon?: string; cwd?: string; autoLaunchLocalhost?: boolean; persistent?: boolean; serverUrl?: string }[]): PinnedGroupTerminal[] {
   return terminals.map((t) => ({
     command: t.command,
     commandMode: t.commandMode,
@@ -234,7 +234,8 @@ function groupDataToPinnedTerminals(terminals: { command: string; commandMode: '
     icon: t.icon as PinnedGroupTerminal['icon'],
     cwd: t.cwd,
     autoLaunchLocalhost: t.autoLaunchLocalhost,
-    persistent: t.persistent
+    persistent: t.persistent,
+    serverUrl: t.serverUrl
   }))
 }
 
@@ -343,7 +344,8 @@ export async function exportClaveFile(pinnedId: string, folder: string, fileName
       color: t.color,
       icon: t.icon,
       cwd: t.cwd,
-      persistent: t.persistent
+      persistent: t.persistent,
+      serverUrl: t.serverUrl
     })),
     ...(pg.category ? { category: pg.category } : {})
   })
@@ -481,7 +483,8 @@ export function pinGroupFromCurrent(groupId: string): void {
     command: t.command,
     commandMode: t.commandMode,
     color: t.color,
-    icon: t.icon
+    icon: t.icon,
+    serverUrl: t.serverUrl
   }))
 
   const pinned: PinnedGroup = {
@@ -636,6 +639,7 @@ async function spawnPinnedGroup(
               icon: t.icon,
               cwd: t.cwd,
               autoLaunchLocalhost: t.autoLaunchLocalhost,
+              serverUrl: t.serverUrl,
               sessionId: null
             }))
           }
@@ -718,11 +722,18 @@ export function resyncPinnedGroup(groupId: string): void {
       dangerousMode: s.dangerousMode
     }))
 
-  const updatedTerminals: PinnedGroupTerminal[] = group.terminals.map((t) => ({
+  // Carry every live-config field; `persistent` lives only on the pin (not on
+  // the live GroupTerminalConfig), so preserve it from the prior blueprint by
+  // index — dropping fields here would corrupt the backing .clave on sync.
+  const updatedTerminals: PinnedGroupTerminal[] = group.terminals.map((t, i) => ({
     command: t.command,
     commandMode: t.commandMode,
     color: t.color,
-    icon: t.icon
+    icon: t.icon,
+    cwd: t.cwd,
+    autoLaunchLocalhost: t.autoLaunchLocalhost,
+    serverUrl: t.serverUrl,
+    persistent: pg.terminals[i]?.persistent
   }))
 
   usePinnedStore.setState((s) => {

--- a/src/renderer/src/store/session-types.ts
+++ b/src/renderer/src/store/session-types.ts
@@ -104,6 +104,10 @@ export interface GroupTerminalConfig {
   icon?: GroupTerminalIcon
   cwd?: string | null
   autoLaunchLocalhost?: boolean
+  /** Declared dev-server URL (e.g. "http://localhost:3000"). On toolbar buttons
+   *  this enables probe-first "ensure running, then open" (see use-server-button.ts).
+   *  Stored but inert for sidebar group terminals today. */
+  serverUrl?: string
   sessionId: string | null
 }
 
@@ -208,6 +212,10 @@ export interface PinnedGroupTerminal {
   cwd?: string | null
   autoLaunchLocalhost?: boolean
   persistent?: boolean
+  /** Declared dev-server URL. Turns a toolbar terminal into a server button:
+   *  click = probe the URL, open it if reachable, otherwise start the command
+   *  and open on URL detection. Implies `persistent` for toolbar buttons. */
+  serverUrl?: string
 }
 
 export interface PinnedGroup {

--- a/src/renderer/src/store/workspace-store.ts
+++ b/src/renderer/src/store/workspace-store.ts
@@ -210,7 +210,10 @@ async function saveInitWorkspace(): Promise<string | null> {
         commandMode: t.commandMode,
         color: t.color,
         icon: t.icon,
-        cwd: t.cwd
+        cwd: t.cwd,
+        autoLaunchLocalhost: t.autoLaunchLocalhost,
+        persistent: t.persistent,
+        serverUrl: t.serverUrl
       }))
     }))
 


### PR DESCRIPTION
Toolbar terminals declaring `serverUrl` become **server buttons**: the click means *"make this server exist and take me to it"*, not "run the command again".

Session liveness is not server liveness — the popover shell survives a Ctrl-C'd server, and a server survives a Clave restart — so an HTTP probe (`net:probe-url`, any response = up) is the only source of truth. The earlier click-based design was rejected in the brief for exactly this reason.

**Click:** probe (~500ms) → reachable opens the browser with no spawn (our own session, a pre-restart orphan, or a hand-started server) → unreachable ensures a session (`^C` + rerun in the live shell, else spawn) and opens on URL detection, adopting the detected URL on a port hop. One consumable open-intent per click, so streaming output can never re-open.

**UI:** live status dot (emerald up / amber starting / grey down), polled every 10s while focused and on refocus; right-click or ⌥-click opens the terminal only; popover header gains a server-state port chip beside the session dot — the two disagreeing is the whole point. Terminals without `serverUrl` are untouched.

Per the `.clave` enum-sync rule, `serverUrl` lands in `session-types.ts`, the `clave_add_group_terminal` MCP schema, and the create-workspace skill (codika-io/clave-plugin#prdct-1425-server-buttons) together.

**Also fixes two latent bugs** found on the way: a persistent session dying while its popover was closed left a stale reattach ref (a restart would type into a dead PTY), and `resyncPinnedGroup` silently dropped `cwd`/`autoLaunchLocalhost`/`persistent` onto the backing `.clave`.

## Verification

Driven against the built Electron app with `shell:openExternal` intercepted in the main process, so every open is recorded and no real tabs opened:

- Orphan server up → click opens once, popover stays closed, zero sessions spawned
- Server down → popover + spawn + detection → opens the detected URL once
- Ctrl-C inside the popover → server dot grey while the session dot stays green; next click restarts in the **same PTY** (identical pid) and opens on detection
- Repeated PTY output re-matching the buffer → no re-open
- Right-click / non-server buttons → terminal only, no browser, no dot
- `.clave` round-trips `serverUrl` in both directions

Not exercised: the 60s starting timeout, fast-fail on session exit mid-boot, and the `resyncPinnedGroup` fix.

Known residual, by design: an unrelated process answering on the declared port passes the probe (port hijack) — mitigated by pinning uncommon ports, documented in the skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WXJP9G9k7ZFGRuxJgKM7J3