### PR TITLE
clave_offer_copy: agent hands the user a click-to-copy value

### DIFF
--- a/src/main/copy-offer-manager.ts
+++ b/src/main/copy-offer-manager.ts
@@ -1,0 +1,121 @@
+import { randomUUID } from 'crypto'
+import { clipboard } from 'electron'
+import { getMainWindow } from './window-utils'
+
+/**
+ * Lifecycle for agent-offered copyable values — the outbound mirror of the
+ * secret-request flow (secret-request-manager.ts brings a value FROM the user
+ * without it entering the conversation; this hands a value TO the user without
+ * them scraping it out of terminal output). Main owns the full values; the
+ * renderer only ever receives previews. Copying happens here, straight from
+ * the stored record to the OS clipboard, so the exact bytes are preserved.
+ */
+
+export interface CopyOffer {
+  id: string
+  callerSessionId: string
+  label: string
+  value: string
+  sensitive: boolean
+  createdAt: number
+  copiedAt?: number
+}
+
+/** Renderer-facing shape: preview only, never the full value. */
+export interface CopyOfferView {
+  id: string
+  callerSessionId: string
+  label: string
+  preview: string
+  truncated: boolean
+  lineCount: number
+  charCount: number
+  sensitive: boolean
+  createdAt: number
+  copiedAt?: number
+}
+
+const MAX_PER_SESSION = 20
+const PREVIEW_LINES = 3
+const PREVIEW_CHARS = 240
+
+const offers = new Map<string, CopyOffer>()
+
+function toView(offer: CopyOffer): CopyOfferView {
+  const lines = offer.value.split('\n')
+  const head = lines.slice(0, PREVIEW_LINES).join('\n')
+  return {
+    id: offer.id,
+    callerSessionId: offer.callerSessionId,
+    label: offer.label,
+    // Sensitive values never leave main, not even as a preview.
+    preview: offer.sensitive ? '' : head.slice(0, PREVIEW_CHARS),
+    truncated: !offer.sensitive && (lines.length > PREVIEW_LINES || head.length > PREVIEW_CHARS),
+    lineCount: lines.length,
+    charCount: offer.value.length,
+    sensitive: offer.sensitive,
+    createdAt: offer.createdAt,
+    ...(offer.copiedAt ? { copiedAt: offer.copiedAt } : {})
+  }
+}
+
+export function listOfferViews(): CopyOfferView[] {
+  return Array.from(offers.values())
+    .sort((a, b) => a.createdAt - b.createdAt)
+    .map(toView)
+}
+
+function pushToRenderer(): void {
+  getMainWindow()?.webContents.send('copy-offer:changed', listOfferViews())
+}
+
+export function createOffer(input: {
+  callerSessionId: string
+  label: string
+  value: string
+  sensitive: boolean
+}): CopyOffer {
+  const offer: CopyOffer = {
+    id: randomUUID(),
+    callerSessionId: input.callerSessionId,
+    label: input.label,
+    value: input.value,
+    sensitive: input.sensitive,
+    createdAt: Date.now()
+  }
+  // Cap per session: drop the oldest offers of the same tab beyond the limit.
+  const siblings = Array.from(offers.values())
+    .filter((o) => o.callerSessionId === input.callerSessionId)
+    .sort((a, b) => a.createdAt - b.createdAt)
+  for (const stale of siblings.slice(0, Math.max(0, siblings.length - (MAX_PER_SESSION - 1)))) {
+    offers.delete(stale.id)
+  }
+  offers.set(offer.id, offer)
+  pushToRenderer()
+  return offer
+}
+
+/** Copy the exact stored bytes to the OS clipboard and stamp the offer. */
+export function copyOfferToClipboard(id: string): CopyOfferView {
+  const offer = offers.get(id)
+  if (!offer) throw new Error(`No copy offer "${id}"`)
+  clipboard.writeText(offer.value)
+  offer.copiedAt = Date.now()
+  pushToRenderer()
+  return toView(offer)
+}
+
+export function dismissOffer(id: string): void {
+  if (offers.delete(id)) pushToRenderer()
+}
+
+export function dismissSessionOffers(callerSessionId: string): void {
+  let changed = false
+  for (const offer of offers.values()) {
+    if (offer.callerSessionId === callerSessionId) {
+      offers.delete(offer.id)
+      changed = true
+    }
+  }
+  if (changed) pushToRenderer()
+}

--- a/src/main/ipc-handlers/copy-offer-handlers.ts
+++ b/src/main/ipc-handlers/copy-offer-handlers.ts
@@ -1,0 +1,16 @@
+import { ipcMain } from 'electron'
+import {
+  listOfferViews,
+  copyOfferToClipboard,
+  dismissOffer,
+  dismissSessionOffers
+} from '../copy-offer-manager'
+
+export function registerCopyOfferHandlers(): void {
+  ipcMain.handle('copy-offer:list', () => listOfferViews())
+  ipcMain.handle('copy-offer:copy', (_event, id: string) => copyOfferToClipboard(id))
+  ipcMain.handle('copy-offer:dismiss', (_event, id: string) => dismissOffer(id))
+  ipcMain.handle('copy-offer:dismiss-session', (_event, sessionId: string) =>
+    dismissSessionOffers(sessionId)
+  )
+}

--- a/src/main/ipc-handlers/index.ts
+++ b/src/main/ipc-handlers/index.ts
@@ -15,6 +15,7 @@ import { registerSessionExportHandlers } from './session-export-handlers'
 import { registerDroppedFileHandlers } from './dropped-file-handlers'
 import { registerSidebarLayoutHandlers } from './sidebar-layout-handlers'
 import { registerSecretHandlers } from './secret-handlers'
+import { registerCopyOfferHandlers } from './copy-offer-handlers'
 import { registerExtensionsHandlers } from './extensions-handlers'
 import { registerMissionControlHandlers } from './mission-control-handlers'
 import { registerWorkspaceHandlers } from './workspace-handlers'
@@ -37,6 +38,7 @@ export function registerIpcHandlers(): void {
   registerDroppedFileHandlers()
   registerSidebarLayoutHandlers()
   registerSecretHandlers()
+  registerCopyOfferHandlers()
   registerExtensionsHandlers()
   registerMissionControlHandlers()
   registerWorkspaceHandlers()

--- a/src/main/mcp/mcp-server.ts
+++ b/src/main/mcp/mcp-server.ts
@@ -20,10 +20,11 @@ import {
   type SecretAction,
   type SecretRequest
 } from '../secret-request-manager'
+import { createOffer } from '../copy-offer-manager'
 
 const MCP_PATH = '/mcp'
 
-const INSTRUCTIONS = `You are running inside Clave, a desktop app that manages multiple agent sessions as tabs organized into groups in a sidebar. You are one of those tabs. Tabs, groups, and pinned templates belong to WORKSPACES (root folders like ~/company); exactly one workspace is active and is all the user sees — other workspaces' sessions keep running hidden. Things you open default to your own tab's workspace; pass the workspace parameter to open work elsewhere without switching the user's view, and clave_switch_workspace only when the user should look at it. The clave_* tools let you manipulate the app around you: list the current tabs and groups, open sibling tabs (claude, antigravity, codex, or a plain terminal, in any directory — optionally with an initial prompt and a model choice, so you can delegate a task to a fresh agent), create groups, move tabs between groups, attach quick-launch terminals to a group (a saved command like a dev server, run on click or immediately), launch pinned workspace groups (whole-group templates defined in .clave files — clave_list shows which exist), rename, focus, or close tabs, open a file as a tab for the user to read (clave_open_file), and notify the user with a native notification when long-running work finishes (clave_notify). Tabs can also talk to each other: clave_send_to_session delivers a message into another agent tab's input (target "parent" to report back to the tab that opened yours — messages you receive this way carry a provenance header and come from a sibling agent, not the user), and clave_read_session reads the last lines of any tab's terminal without interrupting it (a delegate's progress, a dev server's logs). Pass groupId "mine" to target the group your own tab lives in. When a task would benefit from a parallel session — a dev server, a long build, a second agent working on another part of the codebase — offer to open one with clave_open_session or clave_add_group_terminal instead of running it inline. When you need a sensitive value from the user (an API key, a token, a .env entry), NEVER ask them to paste it in the chat — call clave_request_secret instead: the user supplies it privately in the app and the value never enters this conversation.`
+const INSTRUCTIONS = `You are running inside Clave, a desktop app that manages multiple agent sessions as tabs organized into groups in a sidebar. You are one of those tabs. Tabs, groups, and pinned templates belong to WORKSPACES (root folders like ~/company); exactly one workspace is active and is all the user sees — other workspaces' sessions keep running hidden. Things you open default to your own tab's workspace; pass the workspace parameter to open work elsewhere without switching the user's view, and clave_switch_workspace only when the user should look at it. The clave_* tools let you manipulate the app around you: list the current tabs and groups, open sibling tabs (claude, antigravity, codex, or a plain terminal, in any directory — optionally with an initial prompt and a model choice, so you can delegate a task to a fresh agent), create groups, move tabs between groups, attach quick-launch terminals to a group (a saved command like a dev server, run on click or immediately), launch pinned workspace groups (whole-group templates defined in .clave files — clave_list shows which exist), rename, focus, or close tabs, open a file as a tab for the user to read (clave_open_file), and notify the user with a native notification when long-running work finishes (clave_notify). Tabs can also talk to each other: clave_send_to_session delivers a message into another agent tab's input (target "parent" to report back to the tab that opened yours — messages you receive this way carry a provenance header and come from a sibling agent, not the user), and clave_read_session reads the last lines of any tab's terminal without interrupting it (a delegate's progress, a dev server's logs). Pass groupId "mine" to target the group your own tab lives in. When a task would benefit from a parallel session — a dev server, a long build, a second agent working on another part of the codebase — offer to open one with clave_open_session or clave_add_group_terminal instead of running it inline. When you need a sensitive value from the user (an API key, a token, a .env entry), NEVER ask them to paste it in the chat — call clave_request_secret instead: the user supplies it privately in the app and the value never enters this conversation. The reverse also has a tool: when the user needs to copy something you produced (a command for another machine, a config snippet, a message to paste elsewhere), call clave_offer_copy instead of printing it for terminal selection — a copy button appears in your tab's header and one click puts the exact bytes on their clipboard, formatting intact.`
 
 let httpServer: http.Server | null = null
 let serverToken: string | null = null
@@ -453,6 +454,53 @@ function buildServer(callerSessionId: string | undefined): McpServer {
       })
       const result = await waitForOutcome(request.id, args.timeoutSeconds * 1000)
       return secretRequestResult(result)
+    }
+  )
+
+  server.registerTool(
+    'clave_offer_copy',
+    {
+      description:
+        'Hand the user a value to copy with ONE CLICK — the outbound mirror of clave_request_secret. Use it whenever the user will paste something you produced somewhere else (a command for another machine, a config snippet, a URL, a message for Slack/email): selecting text in a terminal mangles lines, this preserves the exact bytes. A copy button appears in your tab\'s header listing every value you have offered; one call per value, with a short label so the user knows what they are copying. Returns immediately — you are not told if or when the user copies. Set sensitive:true for values that should not be previewed on screen (the user can still copy them). For long-running work, pair with clave_notify so the user knows a value is waiting.',
+      inputSchema: {
+        label: z
+          .string()
+          .min(1)
+          .max(120)
+          .describe('Short human-readable name for the value, e.g. "Webhook URL for the Stripe dashboard"'),
+        value: z
+          .string()
+          .min(1)
+          .max(262144)
+          .describe('The exact text to place on the clipboard — newlines and formatting are preserved byte-for-byte'),
+        sensitive: z
+          .boolean()
+          .default(false)
+          .describe('Mask the on-screen preview (for values like tokens that should not be shoulder-surfable)')
+      }
+    },
+    async (args) => {
+      // Identity-gated like the cross-tab tools: the button is rendered in the
+      // calling tab's header, so an anonymous caller has nowhere to surface it.
+      if (!callerSessionId) {
+        return errorResult(
+          'clave_offer_copy requires a per-session token (it surfaces the value in the calling tab). The shared discovery token is anonymous.'
+        )
+      }
+      const offer = createOffer({
+        callerSessionId,
+        label: args.label,
+        value: args.value,
+        sensitive: args.sensitive
+      })
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ ok: true, offerId: offer.id, label: offer.label })
+          }
+        ]
+      }
     }
   )
 

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -8,6 +8,7 @@ import { DEFAULT_TERMINAL_COLS, DEFAULT_TERMINAL_ROWS, INITIAL_COMMAND_DELAY_MS 
 import { stateFilePath } from './agent-state-manager'
 import { getMcpRuntime, writeSessionMcpConfig, deleteSessionMcpConfig } from './mcp/mcp-runtime'
 import { workspaceManager } from './workspace-manager'
+import { dismissSessionOffers } from './copy-offer-manager'
 
 const isWindows = process.platform === 'win32'
 
@@ -891,7 +892,12 @@ class PtyManager {
       }
       // On a real close the session is gone for good; on app quit (tmux
       // survivor) the config must stay valid for the reattached agent.
-      if (killTmuxSession) deleteSessionMcpConfig(id)
+      if (killTmuxSession) {
+        deleteSessionMcpConfig(id)
+        // Copy offers are surfaced in the tab's own header — once the tab is
+        // gone they are unreachable, so don't keep their values in memory.
+        dismissSessionOffers(id)
+      }
       if (session.alive && session.ptyProcess) {
         session.ptyProcess.kill()
       }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -25,6 +25,19 @@ export interface SecretRequestView {
   }
 }
 
+export interface CopyOfferView {
+  id: string
+  callerSessionId: string
+  label: string
+  preview: string
+  truncated: boolean
+  lineCount: number
+  charCount: number
+  sensitive: boolean
+  createdAt: number
+  copiedAt?: number
+}
+
 export interface ClaveFileGroupData {
   name: string
   cwd: string
@@ -320,6 +333,11 @@ export interface ElectronAPI {
   secretSubmit: (id: string, secret: string) => Promise<SecretRequestView>
   secretDismiss: (id: string) => Promise<SecretRequestView>
   onSecretRequestsChanged: (callback: (requests: SecretRequestView[]) => void) => () => void
+  copyOfferList: () => Promise<CopyOfferView[]>
+  copyOfferCopy: (id: string) => Promise<CopyOfferView>
+  copyOfferDismiss: (id: string) => Promise<void>
+  copyOfferDismissSession: (sessionId: string) => Promise<void>
+  onCopyOffersChanged: (callback: (offers: CopyOfferView[]) => void) => () => void
   saveDiscussion: (
     cwd: string,
     claudeSessionId: string,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -95,6 +95,18 @@ const electronAPI = {
   onSecretRequestsChanged: (callback: (requests: unknown[]) => void) =>
     createIpcListener<[unknown[]]>('secret:requests-changed', callback),
 
+  copyOfferList: () => ipcRenderer.invoke('copy-offer:list'),
+
+  copyOfferCopy: (id: string) => ipcRenderer.invoke('copy-offer:copy', id),
+
+  copyOfferDismiss: (id: string) => ipcRenderer.invoke('copy-offer:dismiss', id),
+
+  copyOfferDismissSession: (sessionId: string) =>
+    ipcRenderer.invoke('copy-offer:dismiss-session', sessionId),
+
+  onCopyOffersChanged: (callback: (offers: unknown[]) => void) =>
+    createIpcListener<[unknown[]]>('copy-offer:changed', callback),
+
   saveDiscussion: (
     cwd: string,
     claudeSessionId: string,

--- a/src/renderer/src/components/layout/AppShell.tsx
+++ b/src/renderer/src/components/layout/AppShell.tsx
@@ -28,6 +28,7 @@ import { promptRestore } from '../../store/restore-prompt-store'
 import { RestorePromptDialog } from '../ui/RestorePromptDialog'
 import { initMcpDispatcher } from '../../lib/mcp-dispatcher'
 import { initSecretStore } from '../../store/secret-store'
+import { initCopyOfferStore } from '../../store/copy-offer-store'
 import { ToolbarSecretPopover } from './ToolbarSecretPopover'
 import { resolveColorHex } from '../../store/session-types'
 import { getTerminalIconComponent } from '../ui/GroupCommandDialog'
@@ -125,6 +126,7 @@ export function AppShell() {
     mcpDispatcherStarted = true
     initMcpDispatcher()
     initSecretStore()
+    initCopyOfferStore()
   }, [])
 
   useEffect(() => {

--- a/src/renderer/src/components/terminal/SessionCopyOffers.tsx
+++ b/src/renderer/src/components/terminal/SessionCopyOffers.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  ClipboardDocumentIcon,
+  CheckIcon,
+  XMarkIcon,
+  LockClosedIcon
+} from '@heroicons/react/24/outline'
+import { Popover, PopoverTrigger, PopoverContent } from '../ui/popover'
+import { useCopyOfferStore } from '../../store/copy-offer-store'
+import { cn } from '../../lib/utils'
+import type { CopyOfferView } from '../../../../preload/index.d'
+
+/**
+ * Session-header entry point for agent-offered copyable values (the outbound
+ * mirror of the toolbar secret popover). Renders nothing until the session's
+ * agent has offered at least one value; then a copy button appears next to the
+ * save-discussion/plan actions. The popover lists every offered value with a
+ * preview — one click asks main to put the exact stored bytes on the
+ * clipboard, formatting intact.
+ */
+export function SessionCopyOffers({ sessionId }: { sessionId: string }): React.JSX.Element | null {
+  // Select the stable array and filter in a memo — a filtering selector would
+  // return a fresh reference every snapshot and re-render forever.
+  const allOffers = useCopyOfferStore((s) => s.offers)
+  const offers = useMemo(
+    () => allOffers.filter((o) => o.callerSessionId === sessionId),
+    [allOffers, sessionId]
+  )
+  const dismissSession = useCopyOfferStore((s) => s.dismissSession)
+  const [open, setOpen] = useState(false)
+
+  if (offers.length === 0) return null
+
+  const uncopiedCount = offers.filter((o) => !o.copiedAt).length
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          className="btn-icon btn-icon-sm hover:bg-surface-300 relative"
+          title={
+            uncopiedCount > 0
+              ? `${uncopiedCount} value(s) to copy`
+              : 'Copyable values from this session'
+          }
+          style={uncopiedCount > 0 ? { color: 'var(--color-status-waiting)' } : undefined}
+        >
+          <ClipboardDocumentIcon className="w-3.5 h-3.5" />
+          {uncopiedCount > 0 && (
+            <span
+              className="badge absolute -top-1 -right-1 text-white"
+              style={{
+                backgroundColor: 'var(--color-status-waiting)',
+                animation: 'pulse-dot 1.5s cubic-bezier(0.4, 0, 0.6, 1) infinite'
+              }}
+            >
+              {uncopiedCount}
+            </span>
+          )}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        animated
+        open={open}
+        side="bottom"
+        align="end"
+        sideOffset={8}
+        className="w-[380px]"
+        // The terminal grabs focus whenever output arrives; without this the
+        // popover closes mid-read every time the agent prints something.
+        // Click-outside and Escape still close it.
+        onFocusOutside={(e) => e.preventDefault()}
+      >
+        <div className="flex items-center gap-2 px-3 py-1.5 border-b border-border-subtle">
+          <ClipboardDocumentIcon className="w-3.5 h-3.5 text-text-tertiary" />
+          <span className="text-xs text-text-secondary flex-1">Copyable values</span>
+          <button
+            onClick={() => void dismissSession(sessionId)}
+            className="text-[10px] text-text-tertiary hover:text-text-secondary transition-colors"
+          >
+            Clear all
+          </button>
+          <button onClick={() => setOpen(false)} className="btn-icon btn-icon-xs">
+            <XMarkIcon className="w-3.5 h-3.5" />
+          </button>
+        </div>
+        <div className="max-h-[400px] overflow-y-auto">
+          {offers.map((offer, i) => (
+            <div key={offer.id} className={cn(i > 0 && 'border-t border-border-subtle')}>
+              <CopyOfferCard offer={offer} />
+            </div>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+function CopyOfferCard({ offer }: { offer: CopyOfferView }): React.JSX.Element {
+  const copy = useCopyOfferStore((s) => s.copy)
+  const dismiss = useCopyOfferStore((s) => s.dismiss)
+  const [justCopied, setJustCopied] = useState(false)
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (resetTimer.current) clearTimeout(resetTimer.current)
+    }
+  }, [])
+
+  const handleCopy = async (): Promise<void> => {
+    await copy(offer.id)
+    setJustCopied(true)
+    if (resetTimer.current) clearTimeout(resetTimer.current)
+    resetTimer.current = setTimeout(() => setJustCopied(false), 1500)
+  }
+
+  const meta = [offer.lineCount > 1 ? `${offer.lineCount} lines` : null, `${offer.charCount} chars`]
+    .filter(Boolean)
+    .join(' · ')
+
+  return (
+    <div className="px-3 py-2.5 flex flex-col gap-1.5">
+      <div className="flex items-start gap-2">
+        <p className="text-xs text-text-primary flex-1 leading-snug">
+          {offer.label}
+          {offer.copiedAt && !justCopied && (
+            <CheckIcon className="w-3 h-3 inline-block ml-1 text-text-tertiary align-[-1px]" />
+          )}
+        </p>
+        <button
+          onClick={() => void dismiss(offer.id)}
+          className="btn-icon btn-icon-xs shrink-0"
+          title="Dismiss"
+        >
+          <XMarkIcon className="w-3 h-3" />
+        </button>
+      </div>
+
+      <div
+        className="rounded p-2 max-h-28 overflow-auto select-text font-mono text-[11px] text-text-secondary"
+        style={{ backgroundColor: 'var(--surface-0)' }}
+      >
+        {offer.sensitive ? (
+          <span className="flex items-center gap-1.5 text-text-tertiary">
+            <LockClosedIcon className="w-3 h-3" />
+            hidden value — copy to use it
+          </span>
+        ) : (
+          <span className="whitespace-pre-wrap break-all">
+            {offer.preview}
+            {offer.truncated && <span className="text-text-tertiary">…</span>}
+          </span>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <span className="text-[10px] text-text-tertiary flex-1">{meta}</span>
+        <button
+          onClick={() => void handleCopy()}
+          className={cn('btn-secondary flex items-center gap-1', justCopied && 'text-status-ready')}
+        >
+          {justCopied ? (
+            <>
+              <CheckIcon className="w-3 h-3" />
+              Copied
+            </>
+          ) : (
+            <>
+              <ClipboardDocumentIcon className="w-3 h-3" />
+              Copy
+            </>
+          )}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/terminal/TerminalHeader.tsx
+++ b/src/renderer/src/components/terminal/TerminalHeader.tsx
@@ -4,6 +4,7 @@ import { useSessionStore } from '../../store/session-store'
 import { useClaudeProfileStore } from '../../store/claude-profile-store'
 import { cn, safePort } from '../../lib/utils'
 import { ConfirmDialog } from '../ui/ConfirmDialog'
+import { SessionCopyOffers } from './SessionCopyOffers'
 
 interface TerminalHeaderProps {
   sessionId: string
@@ -126,6 +127,7 @@ export function TerminalHeader({ sessionId }: TerminalHeaderProps) {
         </div>
 
         <div className="flex items-center gap-1.5 flex-shrink-0">
+          <SessionCopyOffers sessionId={sessionId} />
           {session.claudeMode && session.claudeSessionId && (
             <>
               <button

--- a/src/renderer/src/store/copy-offer-store.ts
+++ b/src/renderer/src/store/copy-offer-store.ts
@@ -1,0 +1,46 @@
+import { create } from 'zustand'
+import type { CopyOfferView } from '../../../preload/index.d'
+
+/**
+ * Transient mirror of the main process's copy-offer records (agent-offered
+ * click-to-copy values). Main owns the full values — this store only ever
+ * holds previews; copying asks main to write the stored bytes to the OS
+ * clipboard directly, so the renderer never touches the value itself.
+ */
+interface CopyOfferState {
+  offers: CopyOfferView[]
+  setOffers: (offers: CopyOfferView[]) => void
+  copy: (id: string) => Promise<void>
+  dismiss: (id: string) => Promise<void>
+  dismissSession: (sessionId: string) => Promise<void>
+}
+
+export const useCopyOfferStore = create<CopyOfferState>((set) => ({
+  offers: [],
+
+  setOffers: (offers) => set({ offers }),
+
+  copy: async (id) => {
+    await window.electronAPI.copyOfferCopy(id)
+  },
+
+  dismiss: async (id) => {
+    await window.electronAPI.copyOfferDismiss(id)
+  },
+
+  dismissSession: async (sessionId) => {
+    await window.electronAPI.copyOfferDismissSession(sessionId)
+  }
+}))
+
+/** Subscribe to main-process pushes + load the initial snapshot. */
+export function initCopyOfferStore(): () => void {
+  const unsubscribe = window.electronAPI.onCopyOffersChanged((offers) => {
+    useCopyOfferStore.getState().setOffers(offers)
+  })
+  window.electronAPI
+    .copyOfferList()
+    .then((offers) => useCopyOfferStore.getState().setOffers(offers))
+    .catch(() => {})
+  return unsubscribe
+}


### PR DESCRIPTION
Implements PRDCT-1234 (and its duplicate PRDCT-1456): the outbound mirror of `clave_request_secret`.

## What it does

An agent calls `clave_offer_copy` with a `label`, a `value`, and optionally `sensitive: true`. A clipboard button appears in that tab's header, next to the save-discussion and save-plan actions, badged with how many values are still uncopied. The popover lists every value the tab has offered — label, three-line preview, line and character counts — with a Copy button per row, per-card dismiss, and Clear all.

The point is byte fidelity: selecting multi-line output out of a PTY mangles it, and this doesn't.

## Design decisions

- **Main owns the values.** The renderer only ever receives a preview; the copy happens in main, straight from the stored record to the OS clipboard.
- **`sensitive: true` withholds the preview entirely** rather than masking it in CSS, so the value never reaches the DOM.
- **Lifetime is the tab's lifetime**, not a timer: capped at 20 per session, dropped when the tab is really closed (`PtyManager.kill`), dismissable individually or all at once.
- **Identity-gated** like the cross-tab tools — requires a per-session token, since the anonymous discovery token has no tab whose header could show the button.
- **Fire and forget**: the tool returns an `offerId` immediately and the agent is never told whether the user copied.
- The popover blocks focus-outside dismissal, because the terminal grabs focus whenever output arrives and otherwise closed it mid-read. Click-outside and Escape still work.

## Verification

An E2E drives the built Electron app with an isolated profile and calls the MCP server over HTTP the way a real agent would. 13 checks pass:

- anonymous (shared-token) caller refused
- header button appears with the correct uncopied badge
- label listed, preview shows the first line
- sensitive value masked, and absent from the DOM
- **clipboard bytes identical** for a value with blank lines, a tab, and leading indentation
- badge decrements after a copy; sensitive value copies correctly
- dismiss removes one card; clear-all removes the header button
- closing the tab drops its offers from memory

Mutation-checked: flattening newlines in `copyOfferToClipboard` turns the byte-comparison check red, so the suite isn't vacuous.

`npm run typecheck` passes; the four new files are lint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss9tJTiqe7JJpab4uCH8ob