### PR TITLE
clave_send_to_session: stash the user's draft, deliver clean, restore it (PRDCT-1569)

### DIFF
--- a/src/renderer/src/hooks/use-terminal.ts
+++ b/src/renderer/src/hooks/use-terminal.ts
@@ -7,7 +7,7 @@ import { getXtermTheme } from '../lib/terminal-theme'
 import { safePort } from '../lib/utils'
 import { stripAnsi, detectLocalhostUrl } from '../lib/localhost-url'
 import { registerTerminal, unregisterTerminal } from '../lib/terminal-registry'
-import { getDraftShadow } from '../lib/draft-shadow'
+import { writeUserInput } from '../lib/user-input'
 import '@xterm/xterm/css/xterm.css'
 
 function detectPrompt(buffer: string): string | null {
@@ -70,17 +70,10 @@ export function useTerminal(sessionId: string) {
     fitAddonRef.current = fitAddon
     registerTerminal(sessionId, terminal)
 
-    // User input -> PTY, mirrored into the session's draft shadow so
-    // clave_send_to_session can stash/clear/restore a half-typed draft
-    // (PRDCT-1569). While the CLI shows a permission prompt the keystrokes
-    // drive a dialog, not the input line, so they are fed as opaque.
-    const writeUser = (data: string): void => {
-      const shadow = getDraftShadow(sessionId)
-      const s = useSessionStore.getState().sessions.find((x) => x.id === sessionId)
-      if (s && (s.promptWaiting !== null || s.agentState === 'blocked')) shadow.noteOpaqueInput()
-      else shadow.feed(data)
-      window.electronAPI.writeSession(sessionId, data)
-    }
+    // User input -> PTY through the shared helper, which mirrors it into the
+    // session's draft shadow (PRDCT-1569: clave_send_to_session stashes,
+    // clears, and restores a half-typed draft).
+    const writeUser = (data: string): void => writeUserInput(sessionId, data)
 
     // Custom key bindings — bypass xterm.js local processing, send directly to PTY
     terminal.attachCustomKeyEventHandler((e) => {

--- a/src/renderer/src/hooks/use-terminal.ts
+++ b/src/renderer/src/hooks/use-terminal.ts
@@ -7,6 +7,7 @@ import { getXtermTheme } from '../lib/terminal-theme'
 import { safePort } from '../lib/utils'
 import { stripAnsi, detectLocalhostUrl } from '../lib/localhost-url'
 import { registerTerminal, unregisterTerminal } from '../lib/terminal-registry'
+import { getDraftShadow } from '../lib/draft-shadow'
 import '@xterm/xterm/css/xterm.css'
 
 function detectPrompt(buffer: string): string | null {
@@ -69,37 +70,49 @@ export function useTerminal(sessionId: string) {
     fitAddonRef.current = fitAddon
     registerTerminal(sessionId, terminal)
 
+    // User input -> PTY, mirrored into the session's draft shadow so
+    // clave_send_to_session can stash/clear/restore a half-typed draft
+    // (PRDCT-1569). While the CLI shows a permission prompt the keystrokes
+    // drive a dialog, not the input line, so they are fed as opaque.
+    const writeUser = (data: string): void => {
+      const shadow = getDraftShadow(sessionId)
+      const s = useSessionStore.getState().sessions.find((x) => x.id === sessionId)
+      if (s && (s.promptWaiting !== null || s.agentState === 'blocked')) shadow.noteOpaqueInput()
+      else shadow.feed(data)
+      window.electronAPI.writeSession(sessionId, data)
+    }
+
     // Custom key bindings — bypass xterm.js local processing, send directly to PTY
     terminal.attachCustomKeyEventHandler((e) => {
       if (e.type !== 'keydown') return true
       // Shift+Enter → newline
       if (e.key === 'Enter' && e.shiftKey) {
         e.preventDefault()
-        window.electronAPI.writeSession(sessionId, '\n')
+        writeUser('\n')
         return false
       }
       // Option+Backspace → word delete backward
       if (e.key === 'Backspace' && e.altKey && !e.metaKey && !e.ctrlKey) {
         e.preventDefault()
-        window.electronAPI.writeSession(sessionId, '\x1b\x7f')
+        writeUser('\x1b\x7f')
         return false
       }
       // Option+Delete → forward word delete
       if (e.key === 'Delete' && e.altKey && !e.metaKey && !e.ctrlKey) {
         e.preventDefault()
-        window.electronAPI.writeSession(sessionId, '\x1bd')
+        writeUser('\x1bd')
         return false
       }
       // Option+Left → word backward
       if (e.key === 'ArrowLeft' && e.altKey && !e.metaKey && !e.ctrlKey) {
         e.preventDefault()
-        window.electronAPI.writeSession(sessionId, '\x1bb')
+        writeUser('\x1bb')
         return false
       }
       // Option+Right → word forward
       if (e.key === 'ArrowRight' && e.altKey && !e.metaKey && !e.ctrlKey) {
         e.preventDefault()
-        window.electronAPI.writeSession(sessionId, '\x1bf')
+        writeUser('\x1bf')
         return false
       }
       return true
@@ -107,7 +120,7 @@ export function useTerminal(sessionId: string) {
 
     // Wire terminal input -> PTY
     const inputDisposable = terminal.onData((data) => {
-      window.electronAPI.writeSession(sessionId, data)
+      writeUser(data)
     })
 
     // Wire terminal resize -> PTY.
@@ -396,7 +409,7 @@ export function useTerminal(sessionId: string) {
       const escaped = stablePaths.map((p) => shellEscape(p))
 
       if (escaped.length > 0) {
-        window.electronAPI.writeSession(sessionId, escaped.join(' '))
+        writeUser(escaped.join(' '))
         terminal.focus()
       }
     }

--- a/src/renderer/src/hooks/use-toolbar-terminal.ts
+++ b/src/renderer/src/hooks/use-toolbar-terminal.ts
@@ -3,6 +3,7 @@ import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { useSessionStore } from '../store/session-store'
 import { getXtermTheme } from '../lib/terminal-theme'
+import { writeUserInput } from '../lib/user-input'
 import '@xterm/xterm/css/xterm.css'
 
 export type ToolbarTerminalStatus = 'running' | 'exited'
@@ -49,9 +50,11 @@ export function useToolbarTerminal({ sessionId, persistent }: UseToolbarTerminal
     terminalRef.current = terminal
     fitAddonRef.current = fitAddon
 
-    // Wire terminal input -> PTY
+    // Wire terminal input -> PTY via the shared user-input helper (toolbar
+    // terminals are never send targets, but every user-input writer feeds the
+    // draft shadow so the rule has no exceptions).
     const inputDisposable = terminal.onData((data) => {
-      window.electronAPI.writeSession(sessionId, data)
+      writeUserInput(sessionId, data)
     })
 
     // Wire terminal resize -> PTY

--- a/src/renderer/src/lib/draft-shadow.ts
+++ b/src/renderer/src/lib/draft-shadow.ts
@@ -36,14 +36,20 @@
  * Degraded-case stance (decided for PRDCT-1569): when confidence is lost we
  * still deliver — never hold the message hostage to screen-scraping the TUI —
  * and we clear with a generous overshoot instead of an exact count. The clear
- * sequence is built ONLY from keys verified on the real CLI to be no-ops both
- * at the input-buffer boundary and inside its Ink dialogs (e.g. /model):
- * backspace and forward-delete. Right-arrow is deliberately never used — it
- * is inert in the input box but adjusts the effort control in /model, and a
- * degraded shadow is exactly the state in which such a dialog may be open.
- * Undershoot would leave residue that gets co-submitted. The degradation is
- * reported only in the send tool's result (draftHandling: best-effort); the
- * app UI does not surface it.
+ * sequence uses two keys only, backspace and forward-delete, measured on the
+ * real CLI to be no-ops at the input-buffer boundary and inside the /model
+ * and /mcp dialogs. That is exactly what was measured, not a property of
+ * every dialog: with /config open in filter mode (empty filter after "Esc to
+ * clear"), forward-deletes change nothing but the FIRST backspace flips the
+ * dialog from filter mode to select mode, and the CR the dispatcher sends
+ * next would act on that. This residual is an accepted, documented limit of
+ * this fix; the structural answer (deferring delivery while a dialog is
+ * open) is a follow-up filed by coordination. Right-arrow is deliberately
+ * never used — inert in the input box, it adjusts the effort control in
+ * /model, and a degraded shadow is exactly the state in which such a dialog
+ * may be open. Undershoot would leave residue that gets co-submitted. The
+ * degradation is reported only in the send tool's result (draftHandling:
+ * best-effort); the app UI does not surface it.
  * Residual honesty: an untracked input larger than the cushion (e.g. a very
  * long history recall) can still leave residue; that is the documented limit
  * of a keystroke shadow with no read-back of the TUI screen.
@@ -60,8 +66,8 @@ export interface DraftStash {
 
 /** Overshoot applied to the clear sequence when tracking confidence is lost.
  *  Covers completion-inserted paths and typical history recalls; excess
- *  presses are no-ops at the input boundary and in the CLI's dialogs (only
- *  keys verified for both are used — see beginInjection). */
+ *  presses are no-ops at the input boundary and in the /model and /mcp
+ *  dialogs (measured), not in every dialog — see beginInjection. */
 const UNCONFIDENT_CLEAR_CUSHION = 1024
 
 const segmenter = new Intl.Segmenter()
@@ -424,13 +430,21 @@ export class DraftShadow {
    * lost both counts get a cushion; undershoot would leave residue to be
    * co-submitted.
    *
-   * Only these two keys are used, and nothing that moves the cursor: both
-   * were verified on the real CLI to be no-ops at the input boundary AND
-   * inside its Ink dialogs (/model with 64 presses each), whereas right-arrow
-   * — inert in the input box — adjusts the effort control in /model, and the
+   * Only these two keys are used, and nothing that moves the cursor. Measured
+   * on the real CLI: both are no-ops at the input boundary and inside the
+   * /model and /mcp dialogs (64 presses each in /model; a full degraded burst
+   * leaves /model and /mcp byte-identical), whereas right-arrow — inert in
+   * the input box — adjusts the effort control in /model, and the
    * dispatcher's very next write is the submitting CR. A degraded shadow is
    * precisely the state in which such a dialog may be open (the user pressed
    * Down to browse), so the clear sequence itself has to be dialog-safe.
+   *
+   * Measured NOT to hold everywhere: in /config's filter mode (empty filter
+   * after "Esc to clear") forward-deletes change nothing, but the first
+   * backspace flips the dialog into select mode, which the following CR
+   * would then act on. Accepted here as a documented limitation; the general
+   * dialog class (defer delivery while a dialog is open) is a follow-up
+   * filed by coordination.
    */
   beginInjection(): DraftStash {
     this.injectionActive = true

--- a/src/renderer/src/lib/draft-shadow.ts
+++ b/src/renderer/src/lib/draft-shadow.ts
@@ -35,11 +35,15 @@
  *
  * Degraded-case stance (decided for PRDCT-1569): when confidence is lost we
  * still deliver — never hold the message hostage to screen-scraping the TUI —
- * and we clear with a generous overshoot instead of an exact count. Overshoot
- * is safe because backspace and right-arrow are no-ops at the buffer
- * boundaries in every target CLI, while undershoot would leave residue that
- * gets co-submitted. The send result is labeled best-effort so the sender
- * (and the user, via the injected-from badge) can see the degradation.
+ * and we clear with a generous overshoot instead of an exact count. The clear
+ * sequence is built ONLY from keys verified on the real CLI to be no-ops both
+ * at the input-buffer boundary and inside its Ink dialogs (e.g. /model):
+ * backspace and forward-delete. Right-arrow is deliberately never used — it
+ * is inert in the input box but adjusts the effort control in /model, and a
+ * degraded shadow is exactly the state in which such a dialog may be open.
+ * Undershoot would leave residue that gets co-submitted. The degradation is
+ * reported only in the send tool's result (draftHandling: best-effort); the
+ * app UI does not surface it.
  * Residual honesty: an untracked input larger than the cushion (e.g. a very
  * long history recall) can still leave residue; that is the documented limit
  * of a keystroke shadow with no read-back of the TUI screen.
@@ -56,7 +60,8 @@ export interface DraftStash {
 
 /** Overshoot applied to the clear sequence when tracking confidence is lost.
  *  Covers completion-inserted paths and typical history recalls; excess
- *  presses are boundary no-ops in the target TUIs. */
+ *  presses are no-ops at the input boundary and in the CLI's dialogs (only
+ *  keys verified for both are used — see beginInjection). */
 const UNCONFIDENT_CLEAR_CUSHION = 1024
 
 const segmenter = new Intl.Segmenter()
@@ -413,10 +418,19 @@ export class DraftShadow {
 
   /**
    * Start an injection (stash → clear → deliver → submit → restore). Returns
-   * the stash plus the precomputed clear sequence: right-arrows to reach the
-   * end of the buffer, then backspaces over its full length. When confidence
-   * is lost both counts get a cushion — overshoot is a boundary no-op,
-   * undershoot would leave residue to be co-submitted.
+   * the stash plus the precomputed clear sequence: forward-deletes over
+   * everything after the cursor, then backspaces over the buffer's full
+   * length (code points: an upper bound on keypresses). When confidence is
+   * lost both counts get a cushion; undershoot would leave residue to be
+   * co-submitted.
+   *
+   * Only these two keys are used, and nothing that moves the cursor: both
+   * were verified on the real CLI to be no-ops at the input boundary AND
+   * inside its Ink dialogs (/model with 64 presses each), whereas right-arrow
+   * — inert in the input box — adjusts the effort control in /model, and the
+   * dispatcher's very next write is the submitting CR. A degraded shadow is
+   * precisely the state in which such a dialog may be open (the user pressed
+   * Down to browse), so the clear sequence itself has to be dialog-safe.
    */
   beginInjection(): DraftStash {
     this.injectionActive = true
@@ -425,10 +439,10 @@ export class DraftShadow {
     const cpAfterCursor = codePointCount(this.text.slice(this.cursor))
     let clear = ''
     if (this.confident) {
-      if (cpAll > 0) clear = '\x1b[C'.repeat(cpAfterCursor) + '\x7f'.repeat(cpAll)
+      if (cpAll > 0) clear = '\x1b[3~'.repeat(cpAfterCursor) + '\x7f'.repeat(cpAll)
     } else {
       const n = cpAll + UNCONFIDENT_CLEAR_CUSHION
-      clear = '\x1b[C'.repeat(n) + '\x7f'.repeat(n)
+      clear = '\x1b[3~'.repeat(n) + '\x7f'.repeat(n)
     }
     return { text: this.text, confident: this.confident, clear }
   }

--- a/src/renderer/src/lib/draft-shadow.ts
+++ b/src/renderer/src/lib/draft-shadow.ts
@@ -1,0 +1,466 @@
+/**
+ * Draft shadow — a per-session, best-effort mirror of the text the USER has
+ * typed into an agent CLI's input box since their last submit.
+ *
+ * Why it exists (PRDCT-1569): clave_send_to_session delivers a paste + CR into
+ * the target's PTY. Both land in the target CLI's own input buffer — the same
+ * buffer holding the user's half-typed draft — so without intervention the
+ * submitted turn is `<user draft><injected message>`: the draft leaks into the
+ * sibling's turn AND vanishes from the input. The dispatcher uses this shadow
+ * to stash the draft, clear the input line, deliver the message alone, and
+ * restore the draft unsubmitted.
+ *
+ * This module is deliberately PURE: no Electron, no DOM, no imports — so it
+ * can be probed standalone with plain node. Callers feed it the exact byte
+ * strings they write to the PTY on the user-input path.
+ *
+ * Tracking model. The shadow replays the user's keystrokes against a
+ * `text` + `cursor` model of the CLI's input buffer, and carries a
+ * `confident` flag:
+ *
+ * - Edits with near-universal TUI semantics keep confidence: printable
+ *   inserts, bracketed/plain paste, backspace (grapheme-wise), forward
+ *   delete, plain left/right arrows, line home/end, Shift+Enter newline.
+ * - Anything whose effect on the real buffer we cannot know for sure applies
+ *   a best guess AND drops confidence: word ops (boundary rules differ per
+ *   CLI), up/down (history recall may REPLACE the input), Tab (completion
+ *   inserts text we never see), lone ESC, Ctrl+C, unknown control bytes and
+ *   escape sequences, and any input typed while the CLI is showing a
+ *   permission prompt (fed via noteOpaqueInput — those keys drive a dialog,
+ *   not the input line).
+ * - Enter resyncs: it clears the shadow and restores confidence — EXCEPT when
+ *   the token at the cursor starts with '@' (the CLI's file-completion menu is
+ *   open, so Enter inserts the completion instead of submitting) or the char
+ *   before the cursor is '\' (line continuation).
+ *
+ * Degraded-case stance (decided for PRDCT-1569): when confidence is lost we
+ * still deliver — never hold the message hostage to screen-scraping the TUI —
+ * and we clear with a generous overshoot instead of an exact count. Overshoot
+ * is safe because backspace and right-arrow are no-ops at the buffer
+ * boundaries in every target CLI, while undershoot would leave residue that
+ * gets co-submitted. The send result is labeled best-effort so the sender
+ * (and the user, via the injected-from badge) can see the degradation.
+ * Residual honesty: an untracked input larger than the cushion (e.g. a very
+ * long history recall) can still leave residue; that is the documented limit
+ * of a keystroke shadow with no read-back of the TUI screen.
+ */
+
+export interface DraftStash {
+  /** The tracked draft text (may be '' when the input is believed empty). */
+  text: string
+  /** False once any keystroke with uncertain semantics was seen since the last resync. */
+  confident: boolean
+  /** Raw key sequence that clears the target's input line; '' when nothing to clear. */
+  clear: string
+}
+
+/** Overshoot applied to the clear sequence when tracking confidence is lost.
+ *  Covers completion-inserted paths and typical history recalls; excess
+ *  presses are boundary no-ops in the target TUIs. */
+const UNCONFIDENT_CLEAR_CUSHION = 1024
+
+const segmenter = new Intl.Segmenter()
+
+function graphemeBefore(text: string, index: number): string {
+  let last = ''
+  for (const seg of segmenter.segment(text.slice(0, index))) last = seg.segment
+  return last
+}
+
+function graphemeAfter(text: string, index: number): string {
+  for (const seg of segmenter.segment(text.slice(index))) return seg.segment
+  return ''
+}
+
+function codePointCount(s: string): number {
+  let n = 0
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  for (const _ of s) n++
+  return n
+}
+
+function lineStart(text: string, cursor: number): number {
+  const nl = text.lastIndexOf('\n', cursor - 1)
+  return nl === -1 ? 0 : nl + 1
+}
+
+function lineEnd(text: string, cursor: number): number {
+  const nl = text.indexOf('\n', cursor)
+  return nl === -1 ? text.length : nl
+}
+
+const isSpace = (ch: string): boolean => ch === ' ' || ch === '\t' || ch === '\n'
+
+function wordLeft(text: string, cursor: number): number {
+  let i = cursor
+  while (i > 0 && isSpace(text[i - 1])) i--
+  while (i > 0 && !isSpace(text[i - 1])) i--
+  return i
+}
+
+function wordRight(text: string, cursor: number): number {
+  let i = cursor
+  while (i < text.length && isSpace(text[i])) i++
+  while (i < text.length && !isSpace(text[i])) i++
+  return i
+}
+
+/** Normalize pasted content the way TUI inputs ingest it: newlines become
+ *  '\n', all other control bytes are dropped. */
+function normalizePasted(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\r\n?/g, '\n').replace(/[\x00-\x08\x0b-\x1f\x7f]/g, '')
+}
+
+export class DraftShadow {
+  private text = ''
+  private cursor = 0
+  private confident = true
+  private injectionActive = false
+  private dirtiedDuringInjection = false
+
+  /** Best guess + confidence drop, for input whose real effect is unknowable. */
+  private degrade(): void {
+    this.confident = false
+  }
+
+  private insert(s: string): void {
+    this.text = this.text.slice(0, this.cursor) + s + this.text.slice(this.cursor)
+    this.cursor += s.length
+  }
+
+  private backspace(): void {
+    const g = graphemeBefore(this.text, this.cursor)
+    if (!g) return
+    this.text = this.text.slice(0, this.cursor - g.length) + this.text.slice(this.cursor)
+    this.cursor -= g.length
+  }
+
+  private deleteForward(): void {
+    const g = graphemeAfter(this.text, this.cursor)
+    if (!g) return
+    this.text = this.text.slice(0, this.cursor) + this.text.slice(this.cursor + g.length)
+  }
+
+  private deleteRange(from: number, to: number): void {
+    this.text = this.text.slice(0, from) + this.text.slice(to)
+    this.cursor = from
+  }
+
+  private moveLeft(): void {
+    this.cursor -= graphemeBefore(this.text, this.cursor).length
+  }
+
+  private moveRight(): void {
+    this.cursor += graphemeAfter(this.text, this.cursor).length
+  }
+
+  /** Enter: submit in the overwhelmingly common case. Two exceptions where the
+   *  CLI does something else with the keypress: '\' before the cursor is line
+   *  continuation, and an '@'-prefixed token at the cursor means the file
+   *  completion menu is open (Enter inserts the completion — length unknown). */
+  private enter(): void {
+    if (this.text[this.cursor - 1] === '\\') {
+      this.text = this.text.slice(0, this.cursor - 1) + '\n' + this.text.slice(this.cursor)
+      return
+    }
+    const tokenStart =
+      Math.max(
+        this.text.lastIndexOf(' ', this.cursor - 1),
+        this.text.lastIndexOf('\n', this.cursor - 1),
+        this.text.lastIndexOf('\t', this.cursor - 1)
+      ) + 1
+    if (this.text[tokenStart] === '@' && tokenStart < this.cursor) {
+      this.degrade()
+      return
+    }
+    this.text = ''
+    this.cursor = 0
+    this.confident = true
+  }
+
+  /** CSI sequence body (between '\x1b[' and including the final byte). */
+  private handleCsi(body: string): void {
+    switch (body) {
+      case 'C':
+      case '1C':
+        this.moveRight()
+        return
+      case 'D':
+      case '1D':
+        this.moveLeft()
+        return
+      case 'H':
+      case '1~':
+      case '7~':
+        this.cursor = lineStart(this.text, this.cursor)
+        return
+      case 'F':
+      case '4~':
+      case '8~':
+        this.cursor = lineEnd(this.text, this.cursor)
+        return
+      case '3~':
+        this.deleteForward()
+        return
+      case 'Z': // Shift+Tab: mode toggle in the CLIs, no input-text effect
+      case 'I': // focus in
+      case 'O': // focus out
+      case '5~': // page up
+      case '6~': // page down
+        return
+      case 'A':
+      case 'B':
+        // Up/down: history recall can REPLACE the input with unknown text, and
+        // in multi-line drafts the visual line moves depend on wrapping.
+        this.degrade()
+        return
+      default:
+        // SGR mouse reporting ('<...M/m') is a display-side no-op; anything
+        // else is unknown. (X10 mouse '\x1b[M…' is skipped in feed() — its
+        // three payload bytes would otherwise read as typed text.)
+        if (body.startsWith('<')) return
+        // Terminal protocol REPLIES that xterm emits on the data channel in
+        // response to CLI queries — device attributes ('?1;2c' / '>…c'),
+        // cursor-position and status reports ('…R' / '…n'), mode reports
+        // ('…$y'). Protocol traffic, not keystrokes: no input-text effect.
+        // (Observed live: claude queries DA on boot and xterm auto-replies
+        // \x1b[?1;2c before the user ever types.)
+        if (body.startsWith('?') || body.startsWith('>') || body.startsWith('=')) return
+        if (/^[0-9;]*[Rn]$/.test(body) || /^[0-9;]*\$y$/.test(body)) return
+        this.degrade()
+    }
+  }
+
+  /**
+   * Feed a chunk written to the PTY on the USER input path (xterm onData,
+   * custom key bindings, drag-drop insertion). Never feed the dispatcher's
+   * own injected writes — those are accounted for via begin/endInjection.
+   */
+  feed(data: string): void {
+    if (this.injectionActive) {
+      // A keystroke racing a stash→deliver→restore sequence has an unknowable
+      // fate (joins the injected turn or lands after the restore).
+      this.dirtiedDuringInjection = true
+      return
+    }
+    let i = 0
+    while (i < data.length) {
+      const ch = data[i]
+      if (ch === '\x1b') {
+        // Bracketed paste from xterm (user clipboard paste while the CLI has
+        // paste mode on): insert the envelope's content wholesale.
+        if (data.startsWith('\x1b[200~', i)) {
+          const end = data.indexOf('\x1b[201~', i + 6)
+          if (end === -1) {
+            this.insert(normalizePasted(data.slice(i + 6)))
+            this.degrade() // unterminated envelope — resync on next submit
+            return
+          }
+          this.insert(normalizePasted(data.slice(i + 6, end)))
+          i = end + 6
+          continue
+        }
+        if (data.startsWith('\x1b[M', i)) {
+          // X10 mouse report: 'M' + 3 payload bytes, no input-text effect.
+          i += Math.min(6, data.length - i)
+          continue
+        }
+        {
+          // OSC / DCS / APC / PM / SOS string sequences: terminal replies to
+          // CLI queries (e.g. an OSC 11 background-color report), terminated
+          // by BEL or ST. Protocol traffic, not keystrokes — skipping them
+          // whole also keeps their payload from being read as typed text.
+          const kind = data[i + 1]
+          if (kind === ']' || kind === 'P' || kind === '_' || kind === '^' || kind === 'X') {
+            const bel = kind === ']' ? data.indexOf('\x07', i + 2) : -1
+            const st = data.indexOf('\x1b\\', i + 2)
+            const end = bel !== -1 && (st === -1 || bel < st) ? bel + 1 : st !== -1 ? st + 2 : -1
+            if (end === -1) {
+              this.degrade() // truncated string sequence
+              return
+            }
+            i = end
+            continue
+          }
+        }
+        if (data.startsWith('\x1b[', i)) {
+          // CSI: params/intermediates then a final byte in 0x40–0x7e.
+          let j = i + 2
+          while (j < data.length && !(data[j] >= '@' && data[j] <= '~')) j++
+          if (j >= data.length) {
+            this.degrade() // truncated sequence
+            return
+          }
+          this.handleCsi(data.slice(i + 2, j + 1))
+          i = j + 1
+          continue
+        }
+        if (data.startsWith('\x1bO', i) && i + 2 < data.length) {
+          // SS3 form (application cursor keys): map to the CSI equivalents.
+          this.handleCsi(data[i + 2])
+          i += 3
+          continue
+        }
+        const next = data[i + 1]
+        if (next === '\x7f') {
+          // Option+Backspace: word delete backward. Word-boundary rules differ
+          // per CLI, so apply the guess and drop confidence.
+          this.deleteRange(wordLeft(this.text, this.cursor), this.cursor)
+          this.degrade()
+          i += 2
+          continue
+        }
+        if (next === 'd') {
+          const to = wordRight(this.text, this.cursor)
+          this.text = this.text.slice(0, this.cursor) + this.text.slice(to)
+          this.degrade()
+          i += 2
+          continue
+        }
+        if (next === 'b') {
+          this.cursor = wordLeft(this.text, this.cursor)
+          this.degrade()
+          i += 2
+          continue
+        }
+        if (next === 'f') {
+          this.cursor = wordRight(this.text, this.cursor)
+          this.degrade()
+          i += 2
+          continue
+        }
+        // Lone ESC (menu close / interrupt / double-ESC history) or an
+        // unrecognized Alt+key: effect unknown.
+        this.degrade()
+        i += next === undefined ? 1 : 2
+        continue
+      }
+      if (ch === '\r') {
+        this.enter()
+        i++
+        continue
+      }
+      if (ch === '\n') {
+        this.insert('\n') // Shift+Enter newline
+        i++
+        continue
+      }
+      if (ch === '\x7f' || ch === '\x08') {
+        this.backspace()
+        i++
+        continue
+      }
+      if (ch === '\x01') {
+        this.cursor = lineStart(this.text, this.cursor)
+        i++
+        continue
+      }
+      if (ch === '\x05') {
+        this.cursor = lineEnd(this.text, this.cursor)
+        i++
+        continue
+      }
+      if (ch === '\x15') {
+        // Ctrl+U: kill to line start (readline-ish; exact scope differs per CLI)
+        this.deleteRange(lineStart(this.text, this.cursor), this.cursor)
+        this.degrade()
+        i++
+        continue
+      }
+      if (ch === '\x0b') {
+        // Ctrl+K: kill to line end
+        this.text =
+          this.text.slice(0, this.cursor) + this.text.slice(lineEnd(this.text, this.cursor))
+        this.degrade()
+        i++
+        continue
+      }
+      if (ch === '\x17') {
+        // Ctrl+W: word delete backward
+        this.deleteRange(wordLeft(this.text, this.cursor), this.cursor)
+        this.degrade()
+        i++
+        continue
+      }
+      if (ch === '\x0c') {
+        i++ // Ctrl+L: clear screen, input untouched
+        continue
+      }
+      if (ch < ' ') {
+        // Ctrl+C (clears input in some CLIs, interrupts the turn in others),
+        // Tab (completion inserts unseen text), and every other control byte:
+        // keep the text — resurrecting a discarded draft is annoying but safe,
+        // while assuming empty when text remains would co-submit it.
+        this.degrade()
+        i++
+        continue
+      }
+      // Printable run
+      let j = i
+      while (j < data.length && data[j] >= ' ' && data[j] !== '\x7f' && data[j] !== '\x1b') j++
+      this.insert(data.slice(i, j))
+      i = j
+    }
+  }
+
+  /** Input typed while the CLI shows a permission prompt / dialog: the keys
+   *  drive the dialog, not the input line. Keep the draft, drop confidence
+   *  (the Enter that answers the dialog must NOT read as a submit). */
+  noteOpaqueInput(): void {
+    this.degrade()
+  }
+
+  /**
+   * Start an injection (stash → clear → deliver → submit → restore). Returns
+   * the stash plus the precomputed clear sequence: right-arrows to reach the
+   * end of the buffer, then backspaces over its full length. When confidence
+   * is lost both counts get a cushion — overshoot is a boundary no-op,
+   * undershoot would leave residue to be co-submitted.
+   */
+  beginInjection(): DraftStash {
+    this.injectionActive = true
+    this.dirtiedDuringInjection = false
+    const cpAll = codePointCount(this.text)
+    const cpAfterCursor = codePointCount(this.text.slice(this.cursor))
+    let clear = ''
+    if (this.confident) {
+      if (cpAll > 0) clear = '\x1b[C'.repeat(cpAfterCursor) + '\x7f'.repeat(cpAll)
+    } else {
+      const n = cpAll + UNCONFIDENT_CLEAR_CUSHION
+      clear = '\x1b[C'.repeat(n) + '\x7f'.repeat(n)
+    }
+    return { text: this.text, confident: this.confident, clear }
+  }
+
+  /** End an injection: the input now holds exactly the restored text (when the
+   *  clear was complete). Confidence carries over, and drops if a user
+   *  keystroke raced the sequence. */
+  endInjection(restoredText: string): void {
+    this.text = restoredText
+    this.cursor = restoredText.length
+    if (this.dirtiedDuringInjection) this.confident = false
+    this.injectionActive = false
+    this.dirtiedDuringInjection = false
+  }
+
+  /** Read-only view for diagnostics/probing. */
+  snapshot(): { text: string; cursor: number; confident: boolean } {
+    return { text: this.text, cursor: this.cursor, confident: this.confident }
+  }
+}
+
+// Session-keyed registry. Deliberately never pruned: a session's draft
+// outlives its xterm mount (hidden tabs unmount their terminal while the CLI
+// keeps running), and the residual footprint of a dead session's entry is one
+// small object per app run.
+const shadows = new Map<string, DraftShadow>()
+
+export function getDraftShadow(sessionId: string): DraftShadow {
+  let s = shadows.get(sessionId)
+  if (!s) {
+    s = new DraftShadow()
+    shadows.set(sessionId, s)
+  }
+  return s
+}

--- a/src/renderer/src/lib/mcp-dispatcher.ts
+++ b/src/renderer/src/lib/mcp-dispatcher.ts
@@ -5,6 +5,7 @@ import type { PinnedGroupSession } from '../store/session-types'
 import { useWorkspaceStore, type Workspace } from '../store/workspace-store'
 import { setActiveWorkspace } from './workspace-actions'
 import { getRegisteredTerminal } from './terminal-registry'
+import { getDraftShadow, type DraftStash } from './draft-shadow'
 
 /**
  * Renderer-side executor for the in-app MCP server. The sidebar state (groups,
@@ -722,21 +723,57 @@ async function handleSendToSession(payload: {
   const text = sanitizeForPaste(`${header}\n${payload.message}`)
 
   const targetId = target.id
+
+  // PRDCT-1569: the target CLI's input buffer may hold the user's half-typed
+  // draft, which would otherwise be co-submitted with (and swallowed by) the
+  // injected turn. Stash the tracked draft, clear the input line, deliver
+  // header+message and submit ALONE, then restore the draft unsubmitted.
+  // The whole sequence lives inside one per-target chain link so a concurrent
+  // send cannot interleave with the restore.
+  //
+  // Degraded-case stance: when the shadow's tracking confidence is lost
+  // (word ops, history recall, completions, dialog input…) we still deliver —
+  // never hold the message on screen-scraping the TUI — clearing with a
+  // cushioned overshoot (boundary presses are no-ops; undershoot would leave
+  // residue to co-submit) and labeling the result best-effort.
+  const runInjection = async (): Promise<DraftStash> => {
+    const shadow = getDraftShadow(targetId)
+    const stash = shadow.beginInjection()
+    try {
+      if (stash.clear) {
+        window.electronAPI.writeSession(targetId, stash.clear)
+        await new Promise((r) => setTimeout(r, 150))
+      }
+      // Deliver as one bracketed paste so embedded newlines don't submit early,
+      // then submit. The TUI queues input that arrives mid-turn, so a busy agent
+      // sees the message as its next user turn.
+      window.electronAPI.writeSession(targetId, `\x1b[200~${text}\x1b[201~`)
+      await new Promise((r) => setTimeout(r, 150))
+      window.electronAPI.writeSession(targetId, '\r')
+      if (stash.text) {
+        // Give the TUI a beat to consume the submit, then re-paste the draft
+        // with NO trailing submit — same sanitize + bracketed-paste discipline
+        // as the message itself (the draft is user text, not keystrokes).
+        await new Promise((r) => setTimeout(r, 150))
+        window.electronAPI.writeSession(
+          targetId,
+          `\x1b[200~${sanitizeForPaste(stash.text)}\x1b[201~`
+        )
+      }
+    } finally {
+      shadow.endInjection(stash.text)
+    }
+    return stash
+  }
+
   const prior = sendChains.get(targetId) ?? Promise.resolve()
-  const run = prior.catch(() => {}).then(async () => {
-    // Deliver as one bracketed paste so embedded newlines don't submit early,
-    // then submit. The TUI queues input that arrives mid-turn, so a busy agent
-    // sees the message as its next user turn.
-    window.electronAPI.writeSession(targetId, `\x1b[200~${text}\x1b[201~`)
-    await new Promise((r) => setTimeout(r, 150))
-    window.electronAPI.writeSession(targetId, '\r')
-  })
+  const run = prior.catch(() => {}).then(runInjection)
   sendChains.set(targetId, run)
   run.finally(() => {
     // Drop the chain once it drains so the map doesn't grow unboundedly.
     if (sendChains.get(targetId) === run) sendChains.delete(targetId)
   })
-  await run
+  const stash = await run
 
   // The target can exit during the 150ms envelope→submit gap; the PTY write is
   // then a silent no-op, so report what actually happened rather than a blanket
@@ -750,12 +787,22 @@ async function handleSendToSession(payload: {
     store.setSessionInjectedFrom(targetId, sender?.name ?? 'another tab')
     if (!store.selectedSessionIds.includes(targetId)) store.setSessionUnseenActivity(targetId, true)
   }
+  // How the user's pending input draft was handled: 'none' (input believed
+  // empty, nothing touched), 'stashed-restored' (draft cleared before the
+  // injected turn and re-pasted unsubmitted after it), or the best-effort
+  // variant when keystroke tracking had lost confidence.
+  const draftHandling = stash.confident
+    ? stash.text
+      ? 'stashed-restored'
+      : 'none'
+    : 'stashed-restored-best-effort'
   return {
     delivered: stillAlive,
     sessionId: targetId,
     name: target.name,
     mode,
-    agentState: target.agentState ?? null
+    agentState: target.agentState ?? null,
+    draftHandling
   }
 }
 

--- a/src/renderer/src/lib/mcp-dispatcher.ts
+++ b/src/renderer/src/lib/mcp-dispatcher.ts
@@ -734,8 +734,10 @@ async function handleSendToSession(payload: {
   // Degraded-case stance: when the shadow's tracking confidence is lost
   // (word ops, history recall, completions, dialog input…) we still deliver —
   // never hold the message on screen-scraping the TUI — clearing with a
-  // cushioned overshoot (boundary presses are no-ops; undershoot would leave
-  // residue to co-submit) and labeling the result best-effort.
+  // cushioned overshoot built only from keys verified inert both at the input
+  // boundary and inside the CLI's dialogs (see draft-shadow.ts; undershoot
+  // would leave residue to co-submit). The degradation is reported ONLY in
+  // this tool's result (draftHandling) — nothing in the app UI shows it.
   const runInjection = async (): Promise<DraftStash> => {
     const shadow = getDraftShadow(targetId)
     const stash = shadow.beginInjection()

--- a/src/renderer/src/lib/shell.ts
+++ b/src/renderer/src/lib/shell.ts
@@ -1,7 +1,11 @@
+import { writeUserInput } from './user-input'
+
 export function shellEscape(p: string): string {
   return `'${p.replace(/'/g, "'\\''")}'`
 }
 
+/** Insert a shell-escaped path into the session's input as USER input (file
+ *  palette) — through the shared helper so the draft shadow tracks it. */
 export function insertPath(sessionId: string, filePath: string): void {
-  window.electronAPI.writeSession(sessionId, shellEscape(filePath))
+  writeUserInput(sessionId, shellEscape(filePath))
 }

--- a/src/renderer/src/lib/user-input.ts
+++ b/src/renderer/src/lib/user-input.ts
@@ -1,0 +1,26 @@
+import { useSessionStore } from '../store/session-store'
+import { getDraftShadow } from './draft-shadow'
+
+/**
+ * The one write path for USER input into a local session's PTY. Every
+ * renderer writer of user-originated input (xterm onData, custom key
+ * bindings, drag-drop and file-palette path insertion) must go through here
+ * so the session's draft shadow sees exactly what the CLI's input buffer
+ * sees — that is what lets clave_send_to_session stash, clear, and restore a
+ * half-typed draft instead of co-submitting it (PRDCT-1569).
+ *
+ * App-originated writes are NOT user input and stay on writeSession directly:
+ * the dispatcher's own injection writes (accounted for via begin/endInjection)
+ * and the server-button command/Ctrl+C writes into plain terminal sessions.
+ *
+ * While the CLI shows a permission prompt the keystrokes drive a dialog, not
+ * the input line, so they are fed as opaque (the Enter that answers the
+ * dialog must not read as a submit).
+ */
+export function writeUserInput(sessionId: string, data: string): void {
+  const shadow = getDraftShadow(sessionId)
+  const s = useSessionStore.getState().sessions.find((x) => x.id === sessionId)
+  if (s && (s.promptWaiting !== null || s.agentState === 'blocked')) shadow.noteOpaqueInput()
+  else shadow.feed(data)
+  window.electronAPI.writeSession(sessionId, data)
+}


### PR DESCRIPTION
Fixes PRDCT-1569: a user draft typed into a target tab's input was co-submitted with (prepended to) an injected `clave_send_to_session` message and lost.

## What changed
- `src/renderer/src/lib/draft-shadow.ts` (new, pure): per-session shadow of the user's typed input since the last submit, replayed from the keystroke path; `beginInjection()` returns the stash plus a dialog-safe clear sequence (forward-delete then backspace, zero right-arrows; cushioned by 1024 when confidence is lost), `endInjection()` resyncs and flags keystrokes that raced the injection.
- `src/renderer/src/lib/user-input.ts` (new): `writeUserInput()` is the single write path for user input into a session (shadow feed + opaque-during-prompt rule + `writeSession`); used by `use-terminal.ts` (onData, custom key bindings, drag-drop), `use-toolbar-terminal.ts`, and `shell.ts` `insertPath` (the file palette).
- `src/renderer/src/lib/mcp-dispatcher.ts`: delivery is now stash → clear → deliver header+message → submit alone → re-paste the draft unsubmitted, as one link in the existing per-target `sendChains`; the restored draft rides the same `sanitizeForPaste` + bracketed-paste discipline. Tool result gains `draftHandling: none | stashed-restored | stashed-restored-best-effort` (surfaces in the tool result only, not in the UI).

Degraded-case stance: deliver-and-clear-anyway, never hold; when tracking confidence is lost the clear overshoots (no-ops at the input boundary) and the result is labeled best-effort.

## Verification (independent Opus verifier, two rounds + carry-over)
- Round 1 (5802e83): FAIL — two proven findings (right-arrow clear burst moved `/model`'s ←/→ control; the file palette bypassed the shadow). Both fixed in e804dcf.
- Round 2 (e804dcf): PASS-with-findings — both fixes reproduced at the real CLI; all six prior mutations still kill (cushion, degrade triggers, race flag, sendChains atomicity, sanitize-on-restore, opaque input); writer audit re-derived, no bypass. One finding (F3): in `/config` filter mode the first backspace of the clear burst flips filter→select mode and the delivery's Enter would act on it — same class as the pre-existing "the submit confirms whatever dialog is open" behavior; documented here, structural fix tracked as PRDCT-1572 (dialog-aware delivery).
- Carry-over (910a21c): comment-only commit proven at compiled-output level (main/preload byte-identical; renderer differs only by the comment text and its hash cascade, against a deterministic rebuild control); PASS carries over.
- Gates: typecheck 0, build 0; lint 241 errors / 1275 warnings vs baseline 241 / 1283 (error set byte-identical, net −8 warnings). Node probe of the pure module: 46 checks, 0 failures. Real-app driver with real claude tabs and real MCP sends: 27 assertions, 0 failures (idle draft, two concurrent sends mid-turn, palette insert, `/model` dialog open with degraded shadow).

Known residuals, labeled not silent: untracked input beyond the cushion; keystrokes racing the ~450 ms injection window join the turn and are flagged dirty; the open-dialog class above (PRDCT-1572). Live verification used claude tabs; antigravity/codex share the path but were not exercised live.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>