### PR TITLE
Render HTML live in-app + group web views (PRDCT-1504) [minor]

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -23,6 +23,10 @@ import {
 import { cleanupClaveWatchers } from './ipc-handlers/clave-file-handlers'
 import { startMcpServer, stopMcpServer } from './mcp/mcp-server'
 import { sweepSessionMcpConfigs } from './mcp/mcp-runtime'
+import { registerPreviewScheme, installPreviewProtocol } from './preview-protocol'
+
+// Scheme privileges must be declared before app ready.
+registerPreviewScheme()
 
 function createWindow(): void {
   const savedIcon = preferencesManager.get('appIcon')
@@ -110,6 +114,7 @@ app.whenReady().then(() => {
   })
 
   registerIpcHandlers()
+  installPreviewProtocol()
   // MCP failure must not break the app — spawns just omit the --mcp-config flag.
   void startMcpServer().catch((err) => console.error('[mcp] failed to start', err))
   sweepSessionMcpConfigs()

--- a/src/main/ipc-handlers/index.ts
+++ b/src/main/ipc-handlers/index.ts
@@ -20,6 +20,7 @@ import { registerExtensionsHandlers } from './extensions-handlers'
 import { registerMissionControlHandlers } from './mission-control-handlers'
 import { registerWorkspaceHandlers } from './workspace-handlers'
 import { registerExchangeHandlers } from './exchange-handlers'
+import { registerPreviewHandlers } from './preview-handlers'
 
 export function registerIpcHandlers(): void {
   registerAppHandlers()
@@ -44,4 +45,5 @@ export function registerIpcHandlers(): void {
   registerMissionControlHandlers()
   registerWorkspaceHandlers()
   registerExchangeHandlers()
+  registerPreviewHandlers()
 }

--- a/src/main/ipc-handlers/preview-handlers.ts
+++ b/src/main/ipc-handlers/preview-handlers.ts
@@ -1,0 +1,12 @@
+import { ipcMain } from 'electron'
+import { registerPreviewFile } from '../preview-protocol'
+
+export function registerPreviewHandlers(): void {
+  // Register an HTML file with the preview protocol; returns its clave-preview URL.
+  ipcMain.handle('preview:register', (_event, filePath: string) => {
+    if (typeof filePath !== 'string' || !filePath.startsWith('/')) {
+      throw new Error('preview:register requires an absolute file path')
+    }
+    return registerPreviewFile(filePath)
+  })
+}

--- a/src/main/mcp/mcp-server.ts
+++ b/src/main/mcp/mcp-server.ts
@@ -24,7 +24,7 @@ import { createOffer } from '../copy-offer-manager'
 
 const MCP_PATH = '/mcp'
 
-const INSTRUCTIONS = `You are running inside Clave, a desktop app that manages multiple agent sessions as tabs organized into groups in a sidebar. You are one of those tabs. Tabs, groups, and pinned templates belong to WORKSPACES (root folders like ~/company); exactly one workspace is active and is all the user sees — other workspaces' sessions keep running hidden. Things you open default to your own tab's workspace; pass the workspace parameter to open work elsewhere without switching the user's view, and clave_switch_workspace only when the user should look at it. The clave_* tools let you manipulate the app around you: list the current tabs and groups, open sibling tabs (claude, antigravity, codex, or a plain terminal, in any directory — optionally with an initial prompt and a model choice, so you can delegate a task to a fresh agent), create groups, move tabs between groups, attach quick-launch terminals to a group (a saved command like a dev server, run on click or immediately), launch pinned workspace groups (whole-group templates defined in .clave files — clave_list shows which exist), rename, focus, or close tabs, open a file as a tab for the user to read (clave_open_file), and notify the user with a native notification when long-running work finishes (clave_notify). Tabs can also talk to each other: clave_send_to_session delivers a message into another agent tab's input (target "parent" to report back to the tab that opened yours — messages you receive this way carry a provenance header and come from a sibling agent, not the user), and clave_read_session reads the last lines of any tab's terminal without interrupting it (a delegate's progress, a dev server's logs). Clave also records the transport layer it mediates — cross-tab message deliveries with both endpoints' token usage, agent tab spawns, Task-subagent fan-outs, session state transitions and tab closes — into an append-only event store that the exos CLI lands into each workstream's record (exos workstream capture); read it there (exos workstream events, stats, log) — there is no live query tool. Pass groupId "mine" to target the group your own tab lives in. When a task would benefit from a parallel session — a dev server, a long build, a second agent working on another part of the codebase — offer to open one with clave_open_session or clave_add_group_terminal instead of running it inline. When you need a sensitive value from the user (an API key, a token, a .env entry), NEVER ask them to paste it in the chat — call clave_request_secret instead: the user supplies it privately in the app and the value never enters this conversation. The reverse also has a tool: when the user needs to copy something you produced (a command for another machine, a config snippet, a message to paste elsewhere), call clave_offer_copy instead of printing it for terminal selection — a copy button appears in your tab's header and one click puts the exact bytes on their clipboard, formatting intact.`
+const INSTRUCTIONS = `You are running inside Clave, a desktop app that manages multiple agent sessions as tabs organized into groups in a sidebar. You are one of those tabs. Tabs, groups, and pinned templates belong to WORKSPACES (root folders like ~/company); exactly one workspace is active and is all the user sees — other workspaces' sessions keep running hidden. Things you open default to your own tab's workspace; pass the workspace parameter to open work elsewhere without switching the user's view, and clave_switch_workspace only when the user should look at it. The clave_* tools let you manipulate the app around you: list the current tabs and groups, open sibling tabs (claude, antigravity, codex, or a plain terminal, in any directory — optionally with an initial prompt and a model choice, so you can delegate a task to a fresh agent), create groups, move tabs between groups, attach quick-launch terminals to a group (a saved command like a dev server, run on click or immediately), launch pinned workspace groups (whole-group templates defined in .clave files — clave_list shows which exist), rename, focus, or close tabs, open a file as a tab for the user to read (clave_open_file — .html files render as a live page), attach a web view to a group (clave_set_group_view: a dev server URL or an .html file the user sees in the main pane when clicking the group — the way to surface a live dashboard, a preview, or a presentation right where its sessions live), and notify the user with a native notification when long-running work finishes (clave_notify). Tabs can also talk to each other: clave_send_to_session delivers a message into another agent tab's input (target "parent" to report back to the tab that opened yours — messages you receive this way carry a provenance header and come from a sibling agent, not the user), and clave_read_session reads the last lines of any tab's terminal without interrupting it (a delegate's progress, a dev server's logs). Clave also records the transport layer it mediates — cross-tab message deliveries with both endpoints' token usage, agent tab spawns, Task-subagent fan-outs, session state transitions and tab closes — into an append-only event store that the exos CLI lands into each workstream's record (exos workstream capture); read it there (exos workstream events, stats, log) — there is no live query tool. Pass groupId "mine" to target the group your own tab lives in. When a task would benefit from a parallel session — a dev server, a long build, a second agent working on another part of the codebase — offer to open one with clave_open_session or clave_add_group_terminal instead of running it inline. When you need a sensitive value from the user (an API key, a token, a .env entry), NEVER ask them to paste it in the chat — call clave_request_secret instead: the user supplies it privately in the app and the value never enters this conversation. The reverse also has a tool: when the user needs to copy something you produced (a command for another machine, a config snippet, a message to paste elsewhere), call clave_offer_copy instead of printing it for terminal selection — a copy button appears in your tab's header and one click puts the exact bytes on their clipboard, formatting intact.`
 
 let httpServer: http.Server | null = null
 let serverToken: string | null = null
@@ -268,7 +268,13 @@ function buildServer(callerSessionId: string | undefined): McpServer {
           .string()
           .optional()
           .describe(
-            'Declared dev-server URL (e.g. "http://localhost:3000") for commands that serve one. On toolbar server buttons this enables probe-first "ensure running, then open"; stored but inert for sidebar group terminals today.'
+            'Declared dev-server URL (e.g. "http://localhost:3000") for commands that serve one. On toolbar server buttons this enables probe-first "ensure running, then open"; with groupView it becomes the page shown when the user clicks the group.'
+          ),
+        groupView: z
+          .boolean()
+          .optional()
+          .describe(
+            "Requires serverUrl: also attach that URL as the group's web view — clicking the group then shows the served page in the main pane instead of the tiled sessions, with a start-server action bound to this terminal. Same binding as clave_set_group_view with a terminalId."
           ),
         launch: z
           .boolean()
@@ -277,6 +283,34 @@ function buildServer(callerSessionId: string | undefined): McpServer {
       }
     },
     (args) => runCommand('addGroupTerminal', { ...args, callerSessionId })
+  )
+
+  server.registerTool(
+    'clave_set_group_view',
+    {
+      description:
+        "Attach a web view to a Clave group: the page the user sees in the main pane when they click the group, instead of the tiled session mosaic. Point it at a local dev server (a live dashboard, a docs site, a design preview — e.g. a workstream viewer or a Slideless dev server) or at an absolute .html file path rendered in-app. Optionally link the group terminal that serves the URL (terminalId from clave_add_group_terminal) so a down server shows a one-click start action. Attaching never switches what the user is currently looking at — they see the view on their next group click. Pass url: null to detach. Returns { groupId, view }.",
+      inputSchema: {
+        groupId: z.string().describe('Target group: a group id, an exact group name, or "mine"'),
+        url: z
+          .string()
+          .nullable()
+          .describe(
+            'What the view shows: an http(s) URL (typically a localhost dev server) or an absolute path to an .html file. null detaches the view.'
+          ),
+        title: z
+          .string()
+          .optional()
+          .describe("Short label shown in the view's header (defaults to the group name)"),
+        terminalId: z
+          .string()
+          .optional()
+          .describe(
+            'Id of the group terminal whose command serves this URL — powers the "start server" action when the URL is down'
+          )
+      }
+    },
+    (args) => runCommand('setGroupView', { ...args, callerSessionId })
   )
 
   server.registerTool(
@@ -357,12 +391,18 @@ function buildServer(callerSessionId: string | undefined): McpServer {
     'clave_open_file',
     {
       description:
-        'Open a file as a tab in Clave for the user to read or edit — e.g. to present a document, plan, or report you produced. Idempotent: opening an already-open file focuses its existing tab. Text files render with editing; markdown renders formatted.',
+        'Open a file as a tab in Clave for the user to read or edit — e.g. to present a document, plan, report, or HTML page you produced. Idempotent: opening an already-open file focuses its existing tab. Text files render with editing; markdown renders formatted; .html files render as a live page by default (a Rendered ⇄ Source toggle sits in the tab header).',
       inputSchema: {
         path: z
           .string()
           .describe("File path — absolute, or relative to the calling tab's working directory"),
-        name: z.string().optional().describe('Display name for the tab (defaults to the file name)')
+        name: z.string().optional().describe('Display name for the tab (defaults to the file name)'),
+        view: z
+          .enum(['rendered', 'source'])
+          .optional()
+          .describe(
+            'How an .html/.htm file opens: "rendered" shows the live page (the default for HTML), "source" the code editor. Ignored for other file types.'
+          )
       }
     },
     (args) => runCommand('openFile', { ...args, callerSessionId })

--- a/src/main/preview-protocol.ts
+++ b/src/main/preview-protocol.ts
@@ -1,0 +1,130 @@
+import { protocol } from 'electron'
+import { randomBytes } from 'crypto'
+import * as path from 'path'
+import * as fs from 'fs'
+
+/**
+ * clave-preview:// — serves a registered HTML file and its sibling assets to
+ * the renderer's preview iframes (HTML file tabs, group web views).
+ *
+ * Agent-authored HTML is untrusted input, so the protocol is scoped hard:
+ * each registered entry file maps to a random token whose root is the file's
+ * own directory. `clave-preview://<token>/<relpath>` resolves inside that root
+ * only — traversal and symlink escapes are refused, unknown tokens 404. The
+ * token is the URL host (the scheme is "standard"), so the page's own relative
+ * asset references resolve naturally within its directory.
+ */
+
+const ROOT_BY_TOKEN = new Map<string, string>()
+const TOKEN_BY_FILE = new Map<string, string>()
+
+const MIME_BY_EXT: Record<string, string> = {
+  html: 'text/html',
+  htm: 'text/html',
+  css: 'text/css',
+  js: 'text/javascript',
+  mjs: 'text/javascript',
+  json: 'application/json',
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  svg: 'image/svg+xml',
+  webp: 'image/webp',
+  ico: 'image/x-icon',
+  avif: 'image/avif',
+  woff: 'font/woff',
+  woff2: 'font/woff2',
+  ttf: 'font/ttf',
+  otf: 'font/otf',
+  mp4: 'video/mp4',
+  webm: 'video/webm',
+  mp3: 'audio/mpeg',
+  wav: 'audio/wav',
+  pdf: 'application/pdf',
+  txt: 'text/plain',
+  md: 'text/plain',
+  xml: 'application/xml',
+  map: 'application/json',
+  wasm: 'application/wasm'
+}
+
+/** MUST run before app ready — grants the scheme URL semantics (host + relative
+ *  resolution) and fetch()-ability from the sandboxed preview frames. */
+export function registerPreviewScheme(): void {
+  protocol.registerSchemesAsPrivileged([
+    {
+      scheme: 'clave-preview',
+      privileges: { standard: true, supportFetchAPI: true, corsEnabled: true }
+    }
+  ])
+}
+
+/**
+ * Register an HTML file for preview and return its clave-preview URL.
+ * Idempotent per file path (same token across calls, so iframe reloads and
+ * tab dedup keep one origin per file).
+ */
+export function registerPreviewFile(filePath: string): { url: string } {
+  const abs = path.resolve(filePath)
+  const stat = fs.statSync(abs)
+  if (!stat.isFile()) throw new Error(`Not a file: ${abs}`)
+  let token = TOKEN_BY_FILE.get(abs)
+  if (!token) {
+    token = randomBytes(12).toString('hex')
+    TOKEN_BY_FILE.set(abs, token)
+    ROOT_BY_TOKEN.set(token, path.dirname(abs))
+  }
+  return { url: `clave-preview://${token}/${encodeURIComponent(path.basename(abs))}` }
+}
+
+function respond(status: number, body: string): Response {
+  return new Response(body, { status, headers: { 'Content-Type': 'text/plain' } })
+}
+
+/** Install the request handler. Call after app ready. */
+export function installPreviewProtocol(): void {
+  protocol.handle('clave-preview', async (request) => {
+    let url: URL
+    try {
+      url = new URL(request.url)
+    } catch {
+      return respond(400, 'Bad preview URL')
+    }
+    const root = ROOT_BY_TOKEN.get(url.host)
+    if (!root) return respond(404, 'Unknown preview')
+
+    const relPath = decodeURIComponent(url.pathname).replace(/^\/+/, '')
+    const target = path.normalize(path.join(root, relPath))
+    if (target !== root && !target.startsWith(root + path.sep)) {
+      return respond(403, 'Outside preview root')
+    }
+    try {
+      // realpath both sides so a symlink inside the root can't read outside it.
+      const [realTarget, realRoot] = await Promise.all([
+        fs.promises.realpath(target),
+        fs.promises.realpath(root)
+      ])
+      if (realTarget !== realRoot && !realTarget.startsWith(realRoot + path.sep)) {
+        return respond(403, 'Outside preview root')
+      }
+      const stat = await fs.promises.stat(realTarget)
+      if (!stat.isFile()) return respond(404, 'Not found')
+      const data = await fs.promises.readFile(realTarget)
+      const ext = path.extname(realTarget).slice(1).toLowerCase()
+      return new Response(data, {
+        status: 200,
+        headers: {
+          'Content-Type': MIME_BY_EXT[ext] ?? 'application/octet-stream',
+          // Opaque-origin frames (sandbox without allow-same-origin) fetch
+          // their assets cross-origin; the wildcard keeps those requests alive.
+          'Access-Control-Allow-Origin': '*',
+          // Files under active edit must never go stale in the frame.
+          'Cache-Control': 'no-cache'
+        }
+      })
+    } catch {
+      return respond(404, 'Not found')
+    }
+  })
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -400,6 +400,9 @@ export interface ElectronAPI {
    *  proves a server answers, not just that something bound the port. */
   probeServerUrl: (url: string, timeoutMs?: number) => Promise<boolean>
   openPath: (filePath: string) => Promise<string>
+  /** Register an HTML file with the clave-preview protocol; returns the URL an
+   *  in-app preview iframe loads it from (assets scoped to the file's directory). */
+  registerHtmlPreview: (filePath: string) => Promise<{ url: string }>
   openFolderDialog: (defaultPath?: string) => Promise<string | null>
   onUpdateAvailable: (callback: (version: string) => void) => () => void
   onUpdateDownloaded: (callback: (version: string) => void) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -158,6 +158,9 @@ const electronAPI = {
 
   openPath: (filePath: string) => ipcRenderer.invoke('shell:openPath', filePath),
 
+  registerHtmlPreview: (filePath: string) =>
+    ipcRenderer.invoke('preview:register', filePath) as Promise<{ url: string }>,
+
   openFolderDialog: (defaultPath?: string) => ipcRenderer.invoke('dialog:openFolder', defaultPath),
 
   onUpdateAvailable: (callback: (version: string) => void) =>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -5,7 +5,7 @@
     <title>Clave</title>
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' blob:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: file:; font-src 'self' data:"
+      content="default-src 'self'; script-src 'self' blob:; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: file:; font-src 'self' data:; frame-src clave-preview: http://localhost:* http://127.0.0.1:* https:"
     />
   </head>
 

--- a/src/renderer/src/components/files/FileContent.tsx
+++ b/src/renderer/src/components/files/FileContent.tsx
@@ -1,7 +1,8 @@
 import { CodeEditor } from './CodeEditor'
 import { MarkdownRenderer } from './MarkdownRenderer'
 import { MarkdownPageEditor } from './MarkdownPageEditor'
-import { formatSize, isMarkdownFile, type FileViewMode } from './file-types'
+import { HtmlPreviewFrame } from './HtmlPreviewFrame'
+import { formatSize, isHtmlFile, isMarkdownFile, type FileViewMode } from './file-types'
 import type { useFileEditor } from '../../hooks/use-file-editor'
 
 interface FileContentProps {
@@ -25,6 +26,7 @@ export function FileContent({
 }: FileContentProps): React.JSX.Element {
   const { fileData, filename, content, setContent, canEdit, isImage, loadError, save } = editor
   const isMarkdown = filePath ? isMarkdownFile(filename) : false
+  const isHtml = filePath ? isHtmlFile(filename) : false
 
   if (loadError) {
     return (
@@ -37,6 +39,18 @@ export function FileContent({
     return (
       <div className="p-4 flex items-center justify-center">
         <img src={src} alt={filename} className="max-w-full max-h-[50vh] object-contain rounded" />
+      </div>
+    )
+  }
+
+  // HTML, rendered as a live page — served by the clave-preview protocol, so
+  // this works for any size file (the 1MB editor cap below applies to source
+  // mode only, where the same editable buffer as any code file takes over).
+  if (isHtml && viewMode === 'rendered' && filePath) {
+    const abs = filePath.startsWith('/') ? filePath : `${cwd}/${filePath}`
+    return (
+      <div className="flex-1 min-h-0">
+        <HtmlPreviewFrame filePath={abs} />
       </div>
     )
   }

--- a/src/renderer/src/components/files/FilePreview.tsx
+++ b/src/renderer/src/components/files/FilePreview.tsx
@@ -5,7 +5,12 @@ import { FileContent } from './FileContent'
 import { ViewModeToggle } from './ViewModeToggle'
 import { useFileEditor } from '../../hooks/use-file-editor'
 import { useFileViewMode } from '../../hooks/use-file-view-mode'
-import { canOpenExternally as canOpenExternallyExt, formatSize, countLines } from './file-types'
+import {
+  canOpenExternally as canOpenExternallyExt,
+  formatSize,
+  countLines,
+  HTML_MODES
+} from './file-types'
 import {
   DocumentDuplicateIcon,
   ArrowTopRightOnSquareIcon,
@@ -34,7 +39,11 @@ export function FilePreview(): React.JSX.Element | null {
   const editor = useFileEditor({ cwd, filePath: previewFile, locationId: previewLocationId })
   const { fileData, filename, content, isDirty, canEdit, saving, saveError, loadError, save } =
     editor
-  const { isMarkdown, viewMode, setViewMode } = useFileViewMode(previewFile)
+  // Remote files can't be served by the local preview protocol — pin them to source.
+  const { isMarkdown, isHtml, viewMode, setViewMode } = useFileViewMode(
+    previewFile,
+    previewLocationId ? 'source' : undefined
+  )
 
   const canOpenExternally = canOpenExternallyExt(filename)
 
@@ -138,6 +147,9 @@ export function FilePreview(): React.JSX.Element | null {
         </div>
         <div className="flex items-center gap-1 flex-shrink-0 ml-2">
           {isMarkdown && <ViewModeToggle mode={viewMode} onChange={setViewMode} />}
+          {isHtml && !previewLocationId && (
+            <ViewModeToggle mode={viewMode} onChange={setViewMode} modes={HTML_MODES} />
+          )}
           {canEdit && (
             <button
               onClick={save}

--- a/src/renderer/src/components/files/FileViewer.tsx
+++ b/src/renderer/src/components/files/FileViewer.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import { useSessionStore, type FileTab } from '../../store/session-store'
 import { FileContentRenderer } from './FileContentRenderer'
 import { ViewModeToggle } from './ViewModeToggle'
+import { HTML_MODES } from './file-types'
 import { useFileEditor } from '../../hooks/use-file-editor'
 import { useFileViewMode } from '../../hooks/use-file-view-mode'
 import { DocumentTextIcon, CheckIcon } from '@heroicons/react/24/outline'
@@ -32,7 +33,10 @@ export function FileViewer({ fileTab }: FileViewerProps): React.JSX.Element {
 
   const editor = useFileEditor({ cwd, filePath: relativePath })
   const { isDirty, saving, canEdit, save } = editor
-  const { isMarkdown, viewMode, setViewMode } = useFileViewMode(fileTab.filePath)
+  const { isMarkdown, isHtml, viewMode, setViewMode } = useFileViewMode(
+    fileTab.filePath,
+    fileTab.view
+  )
 
   const handleCopyPath = useCallback(() => {
     navigator.clipboard.writeText(fileTab.filePath)
@@ -60,6 +64,7 @@ export function FileViewer({ fileTab }: FileViewerProps): React.JSX.Element {
           </span>
         </div>
         {isMarkdown && <ViewModeToggle mode={viewMode} onChange={setViewMode} />}
+        {isHtml && <ViewModeToggle mode={viewMode} onChange={setViewMode} modes={HTML_MODES} />}
         {canEdit &&
           (isDirty || saving ? (
             <button

--- a/src/renderer/src/components/files/HtmlPreviewFrame.tsx
+++ b/src/renderer/src/components/files/HtmlPreviewFrame.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Renders a local HTML file as a live page inside a sandboxed iframe.
+ *
+ * The file is served over the clave-preview protocol (main process), which
+ * scopes requests to the file's own directory — sibling CSS/JS/images load,
+ * anything outside the folder 404s. The sandbox runs scripts under an opaque
+ * origin with no same-origin grant: the page can never reach the preload
+ * bridge, the app's DOM, or navigate the app away. Link clicks that try to
+ * open windows are routed to the system browser by main's window-open handler.
+ */
+export function HtmlPreviewFrame({
+  filePath,
+  className,
+  reloadKey
+}: {
+  /** Absolute path of the .html file. */
+  filePath: string
+  className?: string
+  /** Bump to force a fresh load of the page. */
+  reloadKey?: number
+}): React.JSX.Element {
+  // Keyed by path so a file switch renders "Loading…" without a reset write.
+  const [result, setResult] = useState<{ forPath: string; url?: string; error?: string } | null>(
+    null
+  )
+
+  useEffect(() => {
+    let cancelled = false
+    window.electronAPI
+      .registerHtmlPreview(filePath)
+      .then(({ url }) => {
+        if (!cancelled) setResult({ forPath: filePath, url })
+      })
+      .catch((err: unknown) => {
+        if (!cancelled)
+          setResult({ forPath: filePath, error: err instanceof Error ? err.message : String(err) })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [filePath])
+
+  const current = result?.forPath === filePath ? result : null
+  const url = current?.url ?? null
+  const error = current?.error ?? null
+
+  if (error) {
+    return (
+      <div className="px-4 py-8 text-center text-sm text-text-tertiary">
+        Failed to render page
+        <div className="mt-1 text-xs">{error}</div>
+      </div>
+    )
+  }
+
+  if (!url) {
+    return <div className="px-4 py-8 text-center text-sm text-text-tertiary">Loading…</div>
+  }
+
+  return (
+    <iframe
+      key={`${url}#${reloadKey ?? 0}`}
+      src={url}
+      sandbox="allow-scripts"
+      className={`w-full h-full border-0 bg-white ${className ?? ''}`}
+      title={filePath.split('/').pop() ?? 'HTML preview'}
+    />
+  )
+}

--- a/src/renderer/src/components/files/ViewModeToggle.tsx
+++ b/src/renderer/src/components/files/ViewModeToggle.tsx
@@ -1,29 +1,33 @@
-import type { FileViewMode } from './file-types'
+import { MARKDOWN_MODES, type FileViewMode } from './file-types'
 
-const MODES: { key: FileViewMode; label: string }[] = [
-  { key: 'page', label: 'Page' },
-  { key: 'preview', label: 'Preview' },
-  { key: 'source', label: 'Source' }
-]
+const LABELS: Record<FileViewMode, string> = {
+  page: 'Page',
+  preview: 'Preview',
+  source: 'Source',
+  rendered: 'Rendered'
+}
 
-/** Segmented Page / Preview / Source switcher shown in file headers for markdown. */
+/** Segmented view-mode switcher shown in file headers — Page / Preview / Source
+ *  for markdown (default), Rendered / Source for HTML via `modes` (HTML_MODES). */
 export function ViewModeToggle({
   mode,
-  onChange
+  onChange,
+  modes = MARKDOWN_MODES
 }: {
   mode: FileViewMode
   onChange: (mode: FileViewMode) => void
+  modes?: FileViewMode[]
 }): React.JSX.Element {
   return (
     <div className="segmented flex-shrink-0">
-      {MODES.map(({ key, label }) => (
+      {modes.map((key) => (
         <button
           key={key}
           onClick={() => onChange(key)}
           data-active={mode === key}
           className="segmented-item"
         >
-          {label}
+          {LABELS[key]}
         </button>
       ))}
     </div>

--- a/src/renderer/src/components/files/file-types.ts
+++ b/src/renderer/src/components/files/file-types.ts
@@ -1,8 +1,14 @@
-/** Display modes for markdown files: document-style page (default), compact preview, raw source. */
-export type FileViewMode = 'page' | 'preview' | 'source'
+/** Display modes for file surfaces. Markdown uses page (document-style,
+ *  default) / preview (compact) / source; HTML uses rendered (live page,
+ *  default) / source. */
+export type FileViewMode = 'page' | 'preview' | 'source' | 'rendered'
+
+export const MARKDOWN_MODES: FileViewMode[] = ['page', 'preview', 'source']
+export const HTML_MODES: FileViewMode[] = ['rendered', 'source']
 
 export const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'bmp', 'ico'])
 export const MARKDOWN_EXTS = new Set(['md', 'mdx'])
+export const HTML_EXTS = new Set(['html', 'htm'])
 export const EXTERNAL_EXTS = new Set([
   'html',
   'htm',
@@ -25,6 +31,10 @@ export function isImageFile(filename: string): boolean {
 
 export function isMarkdownFile(filename: string): boolean {
   return MARKDOWN_EXTS.has(extOf(filename))
+}
+
+export function isHtmlFile(filename: string): boolean {
+  return HTML_EXTS.has(extOf(filename))
 }
 
 export function canOpenExternally(filename: string): boolean {

--- a/src/renderer/src/components/layout/GroupViewPanel.tsx
+++ b/src/renderer/src/components/layout/GroupViewPanel.tsx
@@ -1,0 +1,197 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ArrowPathIcon, ArrowTopRightOnSquareIcon, GlobeAltIcon } from '@heroicons/react/24/outline'
+import { useSessionStore, type SessionGroup } from '../../store/session-store'
+import { HtmlPreviewFrame } from '../files/HtmlPreviewFrame'
+import { ensureGroupTerminalRunning } from '../../lib/group-terminal'
+
+const PROBE_TIMEOUT_MS = 500
+const PROBE_INTERVAL_MS = 10_000
+const STARTING_PROBE_INTERVAL_MS = 2_000
+const STARTING_TIMEOUT_MS = 60_000
+
+type ProbeState = 'unknown' | 'up' | 'down' | 'starting'
+
+/**
+ * The rendered page a group carries (group.view) — fills the main pane in
+ * place of the tiled session mosaic when the group is clicked. An http(s) url
+ * (a dev server, a workstream dashboard) embeds live; an absolute .html path
+ * renders through the clave-preview protocol. For servers, an HTTP probe keeps
+ * the panel honest: a dead server shows a start action wired to the group
+ * terminal that serves it, not a broken frame.
+ */
+export function GroupViewPanel({ group }: { group: SessionGroup }): React.JSX.Element | null {
+  const setActiveGroupView = useSessionStore((s) => s.setActiveGroupView)
+  const view = group.view
+  const isFile = !!view && view.url.startsWith('/')
+  const [probe, setProbe] = useState<ProbeState>(isFile ? 'up' : 'unknown')
+  const [nonce, setNonce] = useState(0)
+  const probeRef = useRef(probe)
+  useEffect(() => {
+    probeRef.current = probe
+  }, [probe])
+  const startingSinceRef = useRef<number | null>(null)
+
+  const url = view?.url ?? ''
+
+  const probeNow = useCallback(async () => {
+    if (isFile || !url) return
+    const ok = await window.electronAPI.probeServerUrl(url, PROBE_TIMEOUT_MS)
+    if (probeRef.current === 'starting') {
+      if (ok) {
+        startingSinceRef.current = null
+        setProbe('up')
+        setNonce((n) => n + 1)
+      } else if (
+        startingSinceRef.current !== null &&
+        Date.now() - startingSinceRef.current > STARTING_TIMEOUT_MS
+      ) {
+        startingSinceRef.current = null
+        setProbe('down')
+      }
+      return
+    }
+    setProbe((prev) => {
+      if (ok && prev !== 'up') setNonce((n) => n + 1)
+      return ok ? 'up' : 'down'
+    })
+  }, [isFile, url])
+
+  // Probe on mount and keep the dot honest while the app is focused; the
+  // starting window polls faster so a booting server appears promptly.
+  useEffect(() => {
+    if (isFile) return
+    const initialProbe = setTimeout(() => void probeNow(), 0)
+    const interval = setInterval(() => {
+      if (probeRef.current !== 'starting' && !document.hasFocus()) return
+      void probeNow()
+    }, PROBE_INTERVAL_MS)
+    const fastInterval = setInterval(() => {
+      if (probeRef.current === 'starting') void probeNow()
+    }, STARTING_PROBE_INTERVAL_MS)
+    const onFocus = (): void => void probeNow()
+    window.addEventListener('focus', onFocus)
+    return () => {
+      clearTimeout(initialProbe)
+      clearInterval(interval)
+      clearInterval(fastInterval)
+      window.removeEventListener('focus', onFocus)
+    }
+  }, [isFile, probeNow])
+
+  const linkedTerminal = view?.terminalId
+    ? group.terminals.find((t) => t.id === view.terminalId)
+    : undefined
+
+  const handleStart = useCallback(() => {
+    if (!linkedTerminal) return
+    startingSinceRef.current = Date.now()
+    setProbe('starting')
+    ensureGroupTerminalRunning(group.id, linkedTerminal.id).catch(() => {
+      startingSinceRef.current = null
+      setProbe('down')
+    })
+  }, [group.id, linkedTerminal])
+
+  const handleRefresh = useCallback(() => {
+    setNonce((n) => n + 1)
+    if (!isFile) void probeNow()
+  }, [isFile, probeNow])
+
+  const handleOpenExternal = useCallback(() => {
+    if (isFile) window.electronAPI.openPath(url)
+    else window.electronAPI.openExternal(url)
+  }, [isFile, url])
+
+  if (!view) return null
+
+  const title = view.title || group.name
+  const showFrame = isFile || probe === 'up'
+
+  return (
+    <div className="h-full flex flex-col floating-card overflow-hidden">
+      {/* Header — title, source, and the way back to the session mosaic */}
+      <div className="flex items-center gap-2 px-4 py-2 border-b border-border-subtle flex-shrink-0 bg-surface-0">
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          <GlobeAltIcon className="w-4 h-4 text-text-tertiary flex-shrink-0" />
+          <span className="text-sm font-medium text-text-primary truncate flex-shrink-0 max-w-[40%]">
+            {title}
+          </span>
+          <span className="text-[11px] text-text-tertiary truncate hidden sm:inline flex-1 min-w-0">
+            {isFile ? url.replace(/^\/Users\/[^/]+/, '~') : url}
+          </span>
+          {!isFile && (
+            <span
+              className="inline-block w-1.5 h-1.5 rounded-full flex-shrink-0"
+              style={{
+                backgroundColor:
+                  probe === 'up' ? '#4cb782' : probe === 'starting' ? '#e8b931' : '#d45461'
+              }}
+              title={
+                probe === 'up' ? 'Server up' : probe === 'starting' ? 'Starting…' : 'Server down'
+              }
+            />
+          )}
+        </div>
+        <div className="segmented flex-shrink-0">
+          <button className="segmented-item" data-active={true}>
+            View
+          </button>
+          <button className="segmented-item" onClick={() => setActiveGroupView(null)}>
+            Sessions
+          </button>
+        </div>
+        <div className="flex items-center gap-1 flex-shrink-0">
+          <button onClick={handleRefresh} className="btn-icon" title="Reload">
+            <ArrowPathIcon className="w-4 h-4" />
+          </button>
+          <button
+            onClick={handleOpenExternal}
+            className="btn-icon"
+            title={isFile ? 'Open externally' : 'Open in browser'}
+          >
+            <ArrowTopRightOnSquareIcon className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 min-h-0 relative">
+        {isFile ? (
+          <HtmlPreviewFrame filePath={url} reloadKey={nonce} />
+        ) : showFrame ? (
+          <iframe
+            key={nonce}
+            src={url}
+            // Dev servers need scripts + their own origin (XHR, websockets for
+            // live reload); the frame stays cross-origin from the app, and
+            // window.open goes to the system browser via main's open handler.
+            sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+            className="w-full h-full border-0 bg-white"
+            title={title}
+          />
+        ) : (
+          <div className="absolute inset-0 flex items-center justify-center">
+            <div className="text-center max-w-sm px-6">
+              <div className="text-sm text-text-secondary mb-1">
+                {probe === 'starting' ? 'Starting server…' : 'Server not responding'}
+              </div>
+              <div className="text-xs text-text-tertiary mb-4 truncate">{url}</div>
+              {probe !== 'starting' && (
+                <div className="flex items-center justify-center gap-2">
+                  {linkedTerminal && (
+                    <button onClick={handleStart} className="btn-primary">
+                      Start {linkedTerminal.command || 'server'}
+                    </button>
+                  )}
+                  <button onClick={() => void probeNow()} className="btn-secondary">
+                    Retry
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/layout/Sidebar.tsx
+++ b/src/renderer/src/components/layout/Sidebar.tsx
@@ -49,7 +49,8 @@ import {
   ShieldExclamationIcon,
   ClipboardDocumentIcon,
   MagnifyingGlassIcon,
-  CubeTransparentIcon
+  CubeTransparentIcon,
+  GlobeAltIcon
 } from '@heroicons/react/24/outline'
 
 interface ContextMenuState {
@@ -121,6 +122,8 @@ export function Sidebar() {
   const deleteGroup = useSessionStore((s) => s.deleteGroup)
   const setGroupColor = useSessionStore((s) => s.setGroupColor)
   const toggleGroupCollapsed = useSessionStore((s) => s.toggleGroupCollapsed)
+  const setGroupView = useSessionStore((s) => s.setGroupView)
+  const setActiveGroupView = useSessionStore((s) => s.setActiveGroupView)
   const moveItems = useSessionStore((s) => s.moveItems)
   const addGroupTerminal = useSessionStore((s) => s.addGroupTerminal)
   const removeGroupTerminal = useSessionStore((s) => s.removeGroupTerminal)
@@ -662,6 +665,24 @@ export function Sidebar() {
             icon: <PencilSquareIcon className="w-3.5 h-3.5" />,
             onClick: () => setTerminalDialogState({ groupId, terminalId })
           },
+          // A terminal that declares a serverUrl can become the group's web
+          // view: clicking the group then shows the served page in the main pane.
+          ...(config.serverUrl
+            ? [
+                {
+                  label: 'Use as group view',
+                  icon: <GlobeAltIcon className="w-3.5 h-3.5" />,
+                  onClick: () => {
+                    setGroupView(groupId, {
+                      url: config.serverUrl!,
+                      title: config.command || undefined,
+                      terminalId
+                    })
+                    setActiveGroupView(groupId)
+                  }
+                }
+              ]
+            : []),
           {
             label: 'Delete',
             icon: <TrashIcon className="w-3.5 h-3.5" />,
@@ -676,7 +697,7 @@ export function Sidebar() {
         ]
       })
     },
-    [removeGroupTerminal]
+    [removeGroupTerminal, setGroupView, setActiveGroupView]
   )
 
   const hideAgentSession = useSessionStore((s) => s.hideAgentSession)
@@ -945,6 +966,20 @@ export function Sidebar() {
             icon: <CommandLineIcon className="w-3.5 h-3.5" />,
             onClick: () => setTerminalDialogState({ groupId, terminalId: null })
           },
+          group?.view
+            ? {
+                label: 'Show web view',
+                icon: <GlobeAltIcon className="w-3.5 h-3.5" />,
+                onClick: () => setActiveGroupView(groupId)
+              }
+            : null,
+          group?.view
+            ? {
+                label: 'Detach web view',
+                icon: <GlobeAltIcon className="w-3.5 h-3.5" />,
+                onClick: () => setGroupView(groupId, null)
+              }
+            : null,
           {
             label: 'Ungroup',
             icon: <FolderMinusIcon className="w-3.5 h-3.5" />,
@@ -959,7 +994,7 @@ export function Sidebar() {
         ].filter((item): item is NonNullable<typeof item> => item !== null)
       })
     },
-    [ungroupSessions, handleDeleteGroup, setGroupColor]
+    [ungroupSessions, handleDeleteGroup, setGroupColor, setGroupView, setActiveGroupView]
   )
 
   const handleFileTabContextMenu = useCallback(
@@ -1078,19 +1113,28 @@ export function Sidebar() {
           // Collapsed group: expand it and select
           toggleGroupCollapsed(group.id)
           selectSessions(group.sessionIds)
+          if (group.view) setActiveGroupView(group.id)
         } else if (allSelected) {
-          // Already selected and expanded: collapse it
-          toggleGroupCollapsed(group.id)
+          if (group.view && state.activeGroupViewId !== group.id) {
+            // Selected but showing the mosaic: bring the attached view back
+            // before any collapse.
+            selectSessions(group.sessionIds)
+            setActiveGroupView(group.id)
+          } else {
+            // Already selected and expanded: collapse it
+            toggleGroupCollapsed(group.id)
+          }
         } else {
-          // Not selected: select it
+          // Not selected: select it — a group carrying a view opens on it
           selectSessions(group.sessionIds)
+          if (group.view) setActiveGroupView(group.id)
         }
         if (group.sessionIds.length > 0) {
           selectionAnchorRef.current = group.sessionIds[0]
         }
       }
     },
-    [selectSessions, toggleGroupCollapsed]
+    [selectSessions, toggleGroupCollapsed, setActiveGroupView]
   )
 
   const clearRenaming = useCallback(() => setRenamingId(null), [])

--- a/src/renderer/src/components/layout/TerminalGrid.tsx
+++ b/src/renderer/src/components/layout/TerminalGrid.tsx
@@ -1,11 +1,18 @@
 import { useMemo } from 'react'
-import { useSessionStore, getDisplayOrder, isFileTabId } from '../../store/session-store'
+import {
+  useSessionStore,
+  getDisplayOrder,
+  isFileTabId,
+  inActiveWorkspace
+} from '../../store/session-store'
+import { useWorkspaceStore } from '../../store/workspace-store'
 import { TerminalPanel } from '../terminal/TerminalPanel'
 import { RemoteTerminalPanel } from '../terminal/RemoteTerminalPanel'
 import { TerminalErrorBoundary } from '../terminal/TerminalErrorBoundary'
 import { FileViewer } from '../files/FileViewer'
 import { DiffViewer } from '../files/DiffViewer'
 import { EmptyState } from '../ui/EmptyState'
+import { GroupViewPanel } from './GroupViewPanel'
 
 function computeGridLayout(count: number): { cols: number; rows: number } {
   if (count <= 1) return { cols: 1, rows: 1 }
@@ -21,6 +28,18 @@ export function TerminalGrid() {
   const fileTabs = useSessionStore((s) => s.fileTabs)
   const groups = useSessionStore((s) => s.groups)
   const displayOrder = useSessionStore((s) => s.displayOrder)
+  const activeGroupViewId = useSessionStore((s) => s.activeGroupViewId)
+  const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId)
+
+  // Re-validate the active group view — the id may be stale (group deleted,
+  // view detached, workspace switched); a stale id silently falls back to the grid.
+  const viewGroup =
+    (activeGroupViewId &&
+      groups.find(
+        (g) =>
+          g.id === activeGroupViewId && g.view && inActiveWorkspace(g, activeWorkspaceId)
+      )) ||
+    null
 
   const orderedSessions = useMemo(() => {
     const order = getDisplayOrder({ sessions, groups, displayOrder })
@@ -63,9 +82,17 @@ export function TerminalGrid() {
   return (
     <div className="flex-1 relative overflow-hidden">
       {/* "Select a session" overlay when nothing is selected */}
-      {!hasSelection && (
+      {!hasSelection && !viewGroup && (
         <div className="absolute inset-0 flex items-center justify-center text-text-tertiary text-sm z-10">
           Select a session
+        </div>
+      )}
+
+      {/* A group's attached web view replaces the mosaic; the grid below stays
+          mounted (hidden) so every terminal keeps running. */}
+      {viewGroup && (
+        <div className="absolute inset-0">
+          <GroupViewPanel group={viewGroup} />
         </div>
       )}
 
@@ -74,7 +101,8 @@ export function TerminalGrid() {
         className="h-full grid gap-2"
         style={{
           gridTemplateColumns: `repeat(${cols}, 1fr)`,
-          gridTemplateRows: `repeat(${rows}, 1fr)`
+          gridTemplateRows: `repeat(${rows}, 1fr)`,
+          ...(viewGroup ? { visibility: 'hidden' as const } : {})
         }}
       >
         {orderedSessions.map((session) => {

--- a/src/renderer/src/help/whats-new.json
+++ b/src/renderer/src/help/whats-new.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "1.67.0",
+    "title": "Groups open as live pages",
+    "description": "Attach a web view to a group — a dev server, a live dashboard, or an HTML file — and clicking the group shows the rendered page instead of the tiled terminals, with a Sessions switch one click away. HTML files also render as live pages in their own tabs now, with a Rendered ⇄ Source toggle. Agents can drive both: clave_set_group_view and clave_open_file's rendered view.",
+    "action": {
+      "type": "navigate",
+      "target": "side:help"
+    }
+  },
+  {
     "version": "1.64.0",
     "title": "Server buttons in the toolbar",
     "description": "Give a quick-launch terminal a serverUrl and its button becomes a service switch: one click starts the server if needed and opens it in your browser, with a live status dot showing up, starting, or down.",

--- a/src/renderer/src/hooks/use-file-view-mode.ts
+++ b/src/renderer/src/hooks/use-file-view-mode.ts
@@ -1,26 +1,50 @@
 import { useState } from 'react'
-import { isMarkdownFile, type FileViewMode } from '../components/files/file-types'
+import { isHtmlFile, isMarkdownFile, type FileViewMode } from '../components/files/file-types'
 
 interface UseFileViewMode {
   isMarkdown: boolean
+  isHtml: boolean
   viewMode: FileViewMode
   setViewMode: (mode: FileViewMode) => void
 }
 
+function defaultMode(filePath: string | null, initialMode?: FileViewMode): FileViewMode {
+  if (initialMode) return initialMode
+  const filename = filePath?.split('/').pop() ?? ''
+  return isHtmlFile(filename) ? 'rendered' : 'page'
+}
+
 /**
  * View-mode state for a file surface (file tab or preview panel). Markdown
- * opens as a page by default; resets whenever the underlying file changes.
+ * opens as a page, HTML as a rendered live page (unless `initialMode` pins it,
+ * e.g. an agent opening a file explicitly in source). Resets whenever the
+ * underlying file changes.
  */
-export function useFileViewMode(filePath: string | null): UseFileViewMode {
-  const [viewMode, setViewMode] = useState<FileViewMode>('page')
+export function useFileViewMode(
+  filePath: string | null,
+  initialMode?: FileViewMode
+): UseFileViewMode {
+  const [viewMode, setViewMode] = useState<FileViewMode>(defaultMode(filePath, initialMode))
 
-  // Reset to page whenever the file changes (derive, no effect)
+  // Reset to the file kind's default whenever the file changes (derive, no effect)
   const [prevFilePath, setPrevFilePath] = useState(filePath)
   if (filePath !== prevFilePath) {
     setPrevFilePath(filePath)
-    setViewMode('page')
+    setViewMode(defaultMode(filePath, initialMode))
+  }
+
+  // A changed pin (e.g. an agent re-opening the same tab in another mode) retargets it
+  const [prevInitialMode, setPrevInitialMode] = useState(initialMode)
+  if (initialMode !== prevInitialMode) {
+    setPrevInitialMode(initialMode)
+    if (initialMode) setViewMode(initialMode)
   }
 
   const filename = filePath?.split('/').pop() ?? ''
-  return { isMarkdown: !!filePath && isMarkdownFile(filename), viewMode, setViewMode }
+  return {
+    isMarkdown: !!filePath && isMarkdownFile(filename),
+    isHtml: !!filePath && isHtmlFile(filename),
+    viewMode,
+    setViewMode
+  }
 }

--- a/src/renderer/src/lib/group-terminal.ts
+++ b/src/renderer/src/lib/group-terminal.ts
@@ -1,0 +1,76 @@
+import { useSessionStore } from '../store/session-store'
+
+const RESTART_SIGINT_DELAY_MS = 150
+
+/**
+ * Make a group terminal's command run: restart in place when its session is
+ * alive (^C clears a wedged foreground or a half-typed prompt, scrollback
+ * survives), otherwise spawn a fresh linked session. Never changes the user's
+ * selection — callers decide what to look at (the group view panel keeps the
+ * view up while the server boots).
+ */
+export async function ensureGroupTerminalRunning(
+  groupId: string,
+  terminalId: string
+): Promise<void> {
+  const state = useSessionStore.getState()
+  const group = state.groups.find((g) => g.id === groupId)
+  if (!group) throw new Error('Group is gone')
+  const terminal = group.terminals.find((t) => t.id === terminalId)
+  if (!terminal) throw new Error('Group terminal is gone')
+
+  const live = terminal.sessionId
+    ? state.sessions.find((s) => s.id === terminal.sessionId && s.alive)
+    : undefined
+  if (live) {
+    window.electronAPI.writeSession(live.id, '\x03')
+    setTimeout(() => {
+      window.electronAPI.writeSession(live.id, (terminal.command || '') + '\r')
+    }, RESTART_SIGINT_DELAY_MS)
+    return
+  }
+
+  const cwd =
+    terminal.cwd ?? group.cwd ?? state.sessions.find((s) => group.sessionIds.includes(s.id))?.cwd
+  if (!cwd) throw new Error('Group has no working directory')
+
+  const info = await window.electronAPI.spawnSession(cwd, {
+    claudeMode: false,
+    initialCommand: terminal.command || undefined,
+    autoExecute: !!terminal.command && terminal.commandMode === 'auto',
+    workspaceId: group.workspaceId ?? undefined
+  })
+  // The PTY only actually spawns when something calls start() with a size —
+  // normally the terminal pane on first measure. This session stays unselected
+  // (display:none pane, zero size), so kick it explicitly or the command would
+  // not run until the user looks at the terminal. A later attach just resizes.
+  window.electronAPI.startSession(info.id, 120, 30)
+  useSessionStore.setState((current) => ({
+    sessions: [
+      ...current.sessions,
+      {
+        id: info.id,
+        cwd: info.cwd,
+        folderName: info.folderName,
+        name: info.folderName,
+        alive: info.alive,
+        activityStatus: 'idle' as const,
+        promptWaiting: null,
+        claudeMode: false,
+        antigravityMode: false,
+        codexMode: false,
+        dangerousMode: false,
+        claudeSessionId: info.claudeSessionId ?? null,
+        sessionType: 'local' as const,
+        detectedUrl: null,
+        serverStatus: null,
+        serverCommand: null,
+        hasUnseenActivity: false,
+        userRenamed: false,
+        planFilePath: null,
+        workspaceId: group.workspaceId
+      }
+    ]
+  }))
+  useSessionStore.getState().setGroupTerminalSessionId(group.id, terminalId, info.id)
+}

--- a/src/renderer/src/lib/mcp-dispatcher.ts
+++ b/src/renderer/src/lib/mcp-dispatcher.ts
@@ -6,7 +6,7 @@ import {
   type SessionMode
 } from './exchange-capture'
 import { useSessionStore, fileTabDedupKey, inActiveWorkspace } from '../store/session-store'
-import type { GroupTerminalConfig, Session, SessionGroup } from '../store/session-store'
+import type { GroupTerminalConfig, GroupViewConfig, Session, SessionGroup } from '../store/session-store'
 import { usePinnedStore, getPinnedState, togglePinnedGroup } from '../store/pinned-store'
 import type { PinnedGroupSession } from '../store/session-types'
 import { useWorkspaceStore, type Workspace } from '../store/workspace-store'
@@ -137,6 +137,7 @@ function handleList(payload: { callerSessionId?: string; workspace?: string }): 
     name: g.name,
     cwd: g.cwd,
     color: g.color ?? null,
+    view: g.view ?? null,
     sessionIds: g.sessionIds,
     workspaceId: g.workspaceId ?? null,
     workspaceName: workspaceNameOf(g.workspaceId),
@@ -448,12 +449,16 @@ async function handleAddGroupTerminal(payload: {
   icon?: string
   cwd?: string
   serverUrl?: string
+  groupView?: boolean
   launch?: boolean
   callerSessionId?: string
 }): Promise<unknown> {
   const state = useSessionStore.getState()
   const group = resolveGroup(state.groups, payload.groupId, payload.callerSessionId)
   const commandMode = payload.commandMode ?? 'auto'
+  if (payload.groupView && !payload.serverUrl) {
+    throw new Error('groupView requires a serverUrl — the group view shows that URL')
+  }
 
   const groupCwd =
     group.cwd ?? state.sessions.find((s) => group.sessionIds.includes(s.id))?.cwd ?? null
@@ -474,6 +479,16 @@ async function handleAddGroupTerminal(payload: {
     serverUrl: payload.serverUrl
   })
 
+  // groupView binds the served URL as the group's web view (what the user sees
+  // when clicking the group). Attach only — never steal the user's screen.
+  if (payload.groupView && payload.serverUrl) {
+    useSessionStore.getState().setGroupView(group.id, {
+      url: payload.serverUrl,
+      title: payload.command || undefined,
+      terminalId
+    })
+  }
+
   if (payload.launch === false) return { terminalId, groupId: group.id, sessionId: null }
 
   // Same flow as the sidebar's spawnGroupTerminal: the session is linked to the
@@ -485,6 +500,10 @@ async function handleAddGroupTerminal(payload: {
     // Group terminals live in their group's workspace, not the active one.
     workspaceId: group.workspaceId ?? undefined
   })
+  // PTYs spawn lazily on the first sized start() — normally the visible pane's
+  // measure. A terminal spawned into a hidden workspace (or behind an active
+  // group view) has no measured pane, so kick it or the command never runs.
+  window.electronAPI.startSession(info.id, 120, 30)
   const current = useSessionStore.getState()
   useSessionStore.setState({
     sessions: [
@@ -520,6 +539,51 @@ async function handleAddGroupTerminal(payload: {
   })
   current.setGroupTerminalSessionId(group.id, terminalId, info.id)
   return { terminalId, groupId: group.id, sessionId: info.id }
+}
+
+async function handleSetGroupView(payload: {
+  groupId: string
+  url: string | null
+  title?: string
+  terminalId?: string
+  callerSessionId?: string
+}): Promise<unknown> {
+  const state = useSessionStore.getState()
+  const group = resolveGroup(state.groups, payload.groupId, payload.callerSessionId)
+
+  if (payload.url === null) {
+    state.setGroupView(group.id, null)
+    return { groupId: group.id, view: null }
+  }
+
+  const url = payload.url.trim()
+  const isFile = url.startsWith('/')
+  if (isFile) {
+    if (!/\.html?$/i.test(url)) {
+      throw new Error('A file view must be an .html/.htm file (or pass an http(s) URL)')
+    }
+    const slash = url.lastIndexOf('/')
+    try {
+      const stat = await window.electronAPI.statFile(url.substring(0, slash) || '/', url.substring(slash + 1))
+      if (stat.type === 'directory') throw new Error('directory')
+    } catch {
+      throw new Error(`No file at "${url}"`)
+    }
+  } else if (!/^https?:\/\//i.test(url)) {
+    throw new Error('url must be an http(s) URL or an absolute .html file path')
+  }
+
+  if (payload.terminalId && !group.terminals.some((t) => t.id === payload.terminalId)) {
+    throw new Error(`Group has no terminal "${payload.terminalId}"`)
+  }
+
+  const view: GroupViewConfig = {
+    url,
+    title: payload.title,
+    terminalId: payload.terminalId ?? null
+  }
+  state.setGroupView(group.id, view)
+  return { groupId: group.id, view }
 }
 
 async function handleCloseSession(payload: {
@@ -570,6 +634,7 @@ function normalizePath(absPath: string): string {
 async function handleOpenFile(payload: {
   path: string
   name?: string
+  view?: 'rendered' | 'source'
   callerSessionId?: string
 }): Promise<unknown> {
   const state = useSessionStore.getState()
@@ -598,11 +663,17 @@ async function handleOpenFile(payload: {
     throw new Error(`"${abs}" is a directory — clave_open_file opens files only`)
   }
 
-  // addFileTab dedups by path: an already-open file just gets focused.
+  // The view pin only means something for HTML files (rendered is their
+  // default anyway; source pins the code editor). Other kinds ignore it.
+  const isHtml = /\.(html?|htm)$/i.test(fileName)
+
+  // addFileTab dedups by path: an already-open file just gets focused (and
+  // retargeted when an explicit view is requested).
   state.addFileTab({
     id: `file-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
     filePath: abs,
-    name: payload.name ?? fileName
+    name: payload.name ?? fileName,
+    ...(isHtml && payload.view ? { view: payload.view } : {})
   })
   const tab = useSessionStore.getState().fileTabs.find((f) => fileTabDedupKey(f) === `file:${abs}`)
   return { fileTabId: tab?.id ?? null, filePath: abs }
@@ -932,6 +1003,8 @@ async function execute(command: string, payload: unknown): Promise<unknown> {
       return handleLaunchGroup(payload as Parameters<typeof handleLaunchGroup>[0])
     case 'addGroupTerminal':
       return handleAddGroupTerminal(payload as Parameters<typeof handleAddGroupTerminal>[0])
+    case 'setGroupView':
+      return handleSetGroupView(payload as Parameters<typeof handleSetGroupView>[0])
     case 'closeSession':
       return handleCloseSession(payload as Parameters<typeof handleCloseSession>[0])
     case 'rename':

--- a/src/renderer/src/store/session-store.ts
+++ b/src/renderer/src/store/session-store.ts
@@ -7,6 +7,7 @@ import type {
   GroupTerminalConfig,
   GroupTerminalColor,
   GroupTerminalIcon,
+  GroupViewConfig,
   Session,
   SessionGroup,
   FileTab,
@@ -19,7 +20,7 @@ import type { Agent, AgentStatus } from '../../../shared/remote-types'
 import { useWorkspaceStore } from './workspace-store'
 
 // Re-export types and constants so existing imports continue to work
-export type { Theme, AppIcon, ActivityStatus, GroupTerminalConfig, GroupTerminalColor, GroupTerminalIcon, Session, SessionGroup, FileTab, ActiveView, SettingsSection, ExtensionsSection, SessionType }
+export type { Theme, AppIcon, ActivityStatus, GroupTerminalConfig, GroupTerminalColor, GroupTerminalIcon, GroupViewConfig, Session, SessionGroup, FileTab, ActiveView, SettingsSection, ExtensionsSection, SessionType }
 export { GROUP_TERMINAL_COLORS, GROUP_TERMINAL_ICONS, TERMINAL_COLOR_VALUES, resolveColorHex } from './session-types'
 
 /** THE visibility predicate — single source of truth for workspace scoping.
@@ -42,6 +43,10 @@ interface SessionState {
   selectedSessionIds: string[]
   groups: SessionGroup[]
   displayOrder: string[]
+  /** Group whose attached web view fills the main pane instead of the session
+   *  mosaic (set by clicking a group that has a view). Cleared by any explicit
+   *  tab selection. Stale ids are harmless — the grid re-validates. */
+  activeGroupViewId: string | null
   sidebarOpen: boolean
   sidebarWidth: number
   theme: Theme
@@ -106,6 +111,10 @@ interface SessionState {
   deleteGroup: (groupId: string) => void
   renameGroup: (groupId: string, name: string) => void
   toggleGroupCollapsed: (groupId: string) => void
+  /** Attach (or clear, with null) a group's web view. */
+  setGroupView: (groupId: string, view: GroupViewConfig | null) => void
+  /** Show (or hide, with null) a group's web view in the main pane. */
+  setActiveGroupView: (groupId: string | null) => void
   addGroupTerminal: (groupId: string, config: Omit<GroupTerminalConfig, 'sessionId'>) => void
   removeGroupTerminal: (groupId: string, terminalId: string) => void
   updateGroupTerminal: (groupId: string, terminalId: string, updates: Partial<Pick<GroupTerminalConfig, 'command' | 'commandMode' | 'color' | 'icon'>>) => void
@@ -341,6 +350,7 @@ export const useSessionStore = create<SessionState>((set) => ({
   selectedSessionIds: [],
   groups: [],
   displayOrder: [],
+  activeGroupViewId: null,
   sidebarOpen: true,
   sidebarWidth: 260,
   theme: (localStorage.getItem('clave-theme') as Theme) || 'light',
@@ -602,16 +612,17 @@ export const useSessionStore = create<SessionState>((set) => ({
           ? state.selectedSessionIds.filter((sid) => sid !== id)
           : [...state.selectedSessionIds, id]
         const focusedSessionId = isSelected ? (newSelected[0] ?? null) : id
-        return { sessions, selectedSessionIds: newSelected, focusedSessionId, activeView: targetView }
+        return { sessions, selectedSessionIds: newSelected, focusedSessionId, activeView: targetView, activeGroupViewId: null }
       }
-      return { sessions, selectedSessionIds: [id], focusedSessionId: id, activeView: targetView }
+      return { sessions, selectedSessionIds: [id], focusedSessionId: id, activeView: targetView, activeGroupViewId: null }
     }),
 
   selectSessions: (ids) =>
     set(() => ({
       selectedSessionIds: ids,
       focusedSessionId: ids[0] ?? null,
-      activeView: 'terminals' as ActiveView
+      activeView: 'terminals' as ActiveView,
+      activeGroupViewId: null
     })),
 
   setFocusedSession: (id) => set(() => ({ focusedSessionId: id })),
@@ -733,6 +744,17 @@ export const useSessionStore = create<SessionState>((set) => ({
     set((state) => ({
       groups: state.groups.map((g) => (g.id === groupId ? { ...g, collapsed: !g.collapsed } : g))
     })),
+
+  setGroupView: (groupId, view) =>
+    set((state) => ({
+      groups: state.groups.map((g) => (g.id === groupId ? { ...g, view } : g)),
+      // Clearing a view that is currently showing drops back to the mosaic.
+      ...(view === null && state.activeGroupViewId === groupId
+        ? { activeGroupViewId: null }
+        : {})
+    })),
+
+  setActiveGroupView: (groupId) => set(() => ({ activeGroupViewId: groupId })),
 
   addGroupTerminal: (groupId, config) =>
     set((state) => ({
@@ -1140,9 +1162,18 @@ export const useSessionStore = create<SessionState>((set) => ({
       const existing = state.fileTabs.find((f) => fileTabDedupKey(f) === key)
       if (existing) {
         return {
+          // A re-open with an explicit view mode retargets the existing tab.
+          ...(tab.view && tab.view !== existing.view
+            ? {
+                fileTabs: state.fileTabs.map((f) =>
+                  f.id === existing.id ? { ...f, view: tab.view } : f
+                )
+              }
+            : {}),
           selectedSessionIds: [existing.id],
           focusedSessionId: existing.id,
-          activeView: 'terminals' as ActiveView
+          activeView: 'terminals' as ActiveView,
+          activeGroupViewId: null
         }
       }
       return {
@@ -1150,7 +1181,8 @@ export const useSessionStore = create<SessionState>((set) => ({
         displayOrder: [...getDisplayOrder(state), tab.id],
         selectedSessionIds: [tab.id],
         focusedSessionId: tab.id,
-        activeView: 'terminals' as ActiveView
+        activeView: 'terminals' as ActiveView,
+        activeGroupViewId: null
       }
     }),
 

--- a/src/renderer/src/store/session-types.ts
+++ b/src/renderer/src/store/session-types.ts
@@ -171,6 +171,17 @@ export interface Session {
   workspaceId?: string
 }
 
+/** A web page attached to a group: clicking the group shows this rendered page
+ *  in the main pane instead of the tiled session mosaic. `url` is an http(s)
+ *  URL (a dev server, a workstream dashboard) or an absolute .html file path
+ *  (rendered via the clave-preview protocol). `terminalId` links the group
+ *  terminal that serves the URL, powering the down-state "start server" action. */
+export interface GroupViewConfig {
+  url: string
+  title?: string
+  terminalId?: string | null
+}
+
 export interface SessionGroup {
   id: string
   name: string
@@ -179,6 +190,8 @@ export interface SessionGroup {
   cwd: string | null
   terminals: GroupTerminalConfig[]
   color?: GroupTerminalColor | null
+  /** Attached web view — persists with the group (serialized whole). */
+  view?: GroupViewConfig | null
   /** Workspace this group belongs to (see Session.workspaceId). Persists via
    *  sidebar-layout.json since groups are serialized whole. */
   workspaceId?: string
@@ -199,6 +212,9 @@ export interface FileTab {
   name: string
   kind?: 'file' | 'diff'
   diff?: FileTabDiffInfo
+  /** Requested view mode for .html files (e.g. an agent opening one rendered
+   *  via clave_open_file). Undefined = the file kind's default. */
+  view?: 'rendered' | 'source'
 }
 
 export type ActiveView = 'terminals' | 'settings' | 'agents' | 'extensions'


### PR DESCRIPTION
Two features on one foundation.

## Foundation — `clave-preview://`
A privileged custom protocol in main serves a registered HTML file and its sibling assets. Each registered file gets a random token whose root is the file's own directory: relative CSS/JS/images resolve naturally, traversal and symlink escapes are refused, unknown tokens 404. Preview frames are sandboxed (`allow-scripts`, no `allow-same-origin`) — agent-authored HTML never sees the preload bridge or the app DOM. CSP gains `frame-src clave-preview: http://localhost:* http://127.0.0.1:* https:`.

## HTML file tabs (PRDCT-1504)
- `.html`/`.htm` file tabs render the live page by default, with a **Rendered ⇄ Source** toggle in the header (source is the same editable buffer as any code file; the 1MB editor cap applies to source only).
- The side file preview renders HTML too (local files; remote pins to source).
- `clave_open_file` gains a `view: rendered|source` parameter; re-opening an open tab with an explicit view retargets it.

## Group web views
- A group can carry a `view` — an http(s) URL (workstream dashboard, Slideless dev server, docs) or an absolute `.html` path. **Clicking the group shows the rendered page in the main pane instead of the session mosaic**, with a View ⇄ Sessions switch, reload, open-in-browser, and a probe-backed up/down dot. Terminals stay alive underneath.
- Down server → "Start …" action wired to the group terminal that serves it; the panel flips to the page when the probe comes up.
- Set from a session over MCP: new `clave_set_group_view` tool (url / file / null to detach, optional title + terminalId), or `groupView: true` on `clave_add_group_terminal` — the lane's eye terminal lights the group up in one call. Also from the UI: "Use as group view" on serverUrl terminals, "Show/Detach web view" on the group menu. Persists via sidebar-layout; `clave_list` reports it.

## Fix folded in
PTYs spawn lazily on the first sized `start()` (the visible pane's measure). Group terminals spawned without a visible pane — hidden workspace, or behind an active group view — never executed their command until viewed. Both agent-facing spawn paths now kick `startSession` explicitly.

## Verification
Playwright Electron driving the built app through its own MCP surface: **23/23 checks** — sibling CSS/image load, scripts run sandboxed, parent-directory fetch blocked (404), Rendered⇄Source round-trip with editing intact, open_file dedup, group click → live dev-server frame, Sessions toggle, re-click restore, down-state + start revival, file group view, detach, invalid-url refusal. Typecheck, eslint (new files clean), and the 14 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nn8C7wAN2oMEddvphSscqx