### PR TITLE
feat: spatial git panel — repos as the real folder tree, commit bar hidden by default (PRDCT-1235, PRDCT-1455, PRDCT-1674)

### DIFF
--- a/src/main/repo-index.ts
+++ b/src/main/repo-index.ts
@@ -194,7 +194,9 @@ class RepoIndexManager {
 
     await Promise.all(Array.from({ length: Math.min(DISCOVERY_CONCURRENCY, 64) }, () => worker()))
 
-    const repos = Array.from(found.values()).sort((a, b) => a.name.localeCompare(b.name))
+    // Path order, not name order: the renderer arranges repos spatially
+    // (PRDCT-1455), so siblings arrive grouped by their parent directory.
+    const repos = Array.from(found.values()).sort((a, b) => a.path.localeCompare(b.path))
 
     this.cache.set(root, { repos, complete: !truncated, scannedAt: Date.now() })
 

--- a/src/renderer/src/components/git/GitPanelControls.tsx
+++ b/src/renderer/src/components/git/GitPanelControls.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect } from 'react'
 import { useSessionStore } from '../../store/session-store'
-import { ListBulletIcon, Bars3BottomLeftIcon, ArrowPathIcon, ArrowDownIcon } from '@heroicons/react/24/outline'
+import { ListBulletIcon, Bars3BottomLeftIcon, ArrowPathIcon, ArrowDownIcon, PencilSquareIcon } from '@heroicons/react/24/outline'
 import { IconButton } from '../ui/tooltip'
 import type { MagicSyncStep, MagicPullStep } from '../../../../preload/index.d'
 
@@ -81,6 +81,20 @@ export function ViewModeToggle() {
       ) : (
         <Bars3BottomLeftIcon className="w-3 h-3" />
       )}
+    </IconButton>
+  )
+}
+
+export function CommitBarToggle(): React.JSX.Element {
+  const gitShowCommitBar = useSessionStore((s) => s.gitShowCommitBar)
+  const setGitShowCommitBar = useSessionStore((s) => s.setGitShowCommitBar)
+  return (
+    <IconButton
+      onClick={() => setGitShowCommitBar(!gitShowCommitBar)}
+      className={`btn-icon btn-icon-sm flex-shrink-0 ${gitShowCommitBar ? 'text-accent' : ''}`}
+      tooltip={gitShowCommitBar ? 'Hide commit bar' : 'Show commit bar'}
+    >
+      <PencilSquareIcon className="w-3 h-3" />
     </IconButton>
   )
 }

--- a/src/renderer/src/components/git/GitStatusPanel.tsx
+++ b/src/renderer/src/components/git/GitStatusPanel.tsx
@@ -5,8 +5,15 @@ import { ConfirmDialog } from '../ui/ConfirmDialog'
 import { ContextMenu } from '../ui/ContextMenu'
 import { Tooltip, TooltipTrigger, TooltipContent } from '../ui/tooltip'
 import { shortenPath } from '../../lib/utils'
-import { ArrowTopRightOnSquareIcon, ArrowUturnLeftIcon, PlusIcon, MinusIcon, InformationCircleIcon, ArrowPathIcon } from '@heroicons/react/24/outline'
+import { ArrowTopRightOnSquareIcon, ArrowUturnLeftIcon, PlusIcon, MinusIcon, InformationCircleIcon, ArrowPathIcon, FolderIcon } from '@heroicons/react/24/outline'
 import { buildGitTree, compactTree, collectAllDirPaths } from '../../lib/git-file-tree'
+import {
+  buildRepoTree,
+  flattenRepoTree,
+  collectRepoTreeDirPaths,
+  type FlatRepoRow,
+  type RepoTreeDir
+} from '../../lib/git-repo-tree'
 import { GitLogView } from './GitLogView'
 import { FileRow, GitTreeSection } from './GitFileRows'
 import { SectionHeader, ErrorBanner } from './GitPanelControls'
@@ -646,6 +653,10 @@ export function GitStatusPanel({
 // MultiRepoGitPanel — multi-repo collapsible view with minimize/dock
 // ---------------------------------------------------------------------------
 
+// Indent per tree level — header rows only; expanded repo content stays
+// full-width so file rows keep their room in the narrow panel.
+const TREE_INDENT_PX = 12
+
 function MultiRepoSection({
   name,
   repoPath,
@@ -653,7 +664,8 @@ function MultiRepoSection({
   refresh,
   isSelected,
   onSelect,
-  selectedRepoPaths
+  selectedRepoPaths,
+  depth = 0
 }: {
   name: string
   repoPath: string
@@ -662,6 +674,7 @@ function MultiRepoSection({
   isSelected?: boolean
   onSelect?: (path: string, metaKey: boolean) => void
   selectedRepoPaths?: Set<string>
+  depth?: number
 }) {
   const gitPanelMode = useSessionStore((s) => s.gitPanelMode)
   const openJourneyPanel = useSessionStore((s) => s.openJourneyPanel)
@@ -722,9 +735,10 @@ function MultiRepoSection({
     <div className="border-b border-border-subtle">
       {/* Collapsible header */}
       <button
-        className={`w-full flex items-center gap-1.5 px-3 py-1.5 text-xs transition-colors ${
+        className={`w-full flex items-center gap-1.5 pr-3 py-1.5 text-xs transition-colors ${
           isSelected ? 'bg-surface-200' : 'hover:bg-surface-100'
         }`}
+        style={{ paddingLeft: 12 + depth * TREE_INDENT_PX }}
         onClick={handleClick}
         onDoubleClick={(e) => {
           e.stopPropagation()
@@ -781,7 +795,10 @@ function MultiRepoSection({
 
       {/* Parent-repo notice — the opened folder isn't a repo; changes come from above */}
       {isParentRepo && (
-        <div className="flex items-center gap-1 px-3 pb-1.5 text-[10px] text-text-tertiary">
+        <div
+          className="flex items-center gap-1 pr-3 pb-1.5 text-[10px] text-text-tertiary"
+          style={{ paddingLeft: 12 + depth * TREE_INDENT_PX }}
+        >
           <InformationCircleIcon className="w-3 h-3 flex-shrink-0" />
           <Tooltip delayDuration={300}>
             <TooltipTrigger asChild>
@@ -819,9 +836,91 @@ function MultiRepoSection({
   )
 }
 
+// ---------------------------------------------------------------------------
+// Spatial repo tree (PRDCT-1235 / PRDCT-1455) — repos render at their real
+// place on disk instead of one alphabetical list. Directory rows collapse;
+// a collapsed folder rolls its subtree's counts up so nothing hides.
+// ---------------------------------------------------------------------------
+
+// Per-basePath collapsed-dir cache — survives unmount/remount, same idiom as
+// expandedCacheMap above. Default is fully expanded, so the cache stores the
+// folders the user folded.
+const collapsedDirsCacheMap = new Map<string, Set<string>>()
+
+function RepoDirRow({
+  node,
+  depth,
+  collapsed,
+  onToggle,
+  statusByPath
+}: {
+  node: RepoTreeDir
+  depth: number
+  collapsed: boolean
+  onToggle: () => void
+  statusByPath: Map<string, GitStatusResult>
+}): React.JSX.Element {
+  // Subtree roll-up — shown only while folded; expanded children carry their own.
+  const rollup = useMemo(() => {
+    let changes = 0
+    let ahead = 0
+    let behind = 0
+    for (const p of node.repoPaths) {
+      const s = statusByPath.get(p)
+      if (!s) continue
+      changes += s.files.length
+      ahead += s.ahead
+      behind += s.behind
+    }
+    return { changes, ahead, behind }
+  }, [node, statusByPath])
+
+  return (
+    <button
+      className="w-full flex items-center gap-1.5 pr-3 py-1 text-xs hover:bg-surface-100 transition-colors"
+      style={{ paddingLeft: 12 + depth * TREE_INDENT_PX }}
+      onClick={onToggle}
+    >
+      <svg
+        width="10"
+        height="10"
+        viewBox="0 0 10 10"
+        fill="none"
+        className={`text-text-tertiary flex-shrink-0 transition-transform duration-150 ${
+          collapsed ? '' : 'rotate-90'
+        }`}
+      >
+        <path d="M3 1.5l4 3.5-4 3.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+      <FolderIcon className="w-3.5 h-3.5 text-text-tertiary flex-shrink-0" />
+      <span className="text-text-secondary font-medium truncate">{node.name}</span>
+      {collapsed && (
+        <span className="ml-auto flex-shrink-0 flex items-center gap-1.5">
+          {rollup.behind > 0 && (
+            <span className="text-[10px] font-medium text-orange-400">
+              {'↓'}{rollup.behind}
+            </span>
+          )}
+          {rollup.ahead > 0 && (
+            <span className="text-[10px] font-medium text-green-400">
+              {'↑'}{rollup.ahead}
+            </span>
+          )}
+          {rollup.changes > 0 && (
+            <span className="badge bg-surface-200 text-text-secondary min-w-[18px] text-center">
+              {rollup.changes}
+            </span>
+          )}
+        </span>
+      )}
+    </button>
+  )
+}
+
 export function MultiRepoGitPanel({
   repos,
   rootPath,
+  basePath,
   refresh,
   truncated = false,
   live = true,
@@ -830,6 +929,8 @@ export function MultiRepoGitPanel({
 }: {
   repos: Array<{ name: string; path: string; status: GitStatusResult }>
   rootPath?: string | null
+  /** The panel's folder — the tree's root. Falls back to a flat list when null. */
+  basePath?: string | null
   refresh: () => void
   truncated?: boolean
   live?: boolean
@@ -856,13 +957,105 @@ export function MultiRepoGitPanel({
   )
 
   const rootRepo = rootPath ? repos.find((r) => r.path === rootPath) ?? null : null
-  const nestedRepos = rootPath ? repos.filter((r) => r.path !== rootPath) : repos
+  const nestedRepos = useMemo(
+    () => (rootPath ? repos.filter((r) => r.path !== rootPath) : repos),
+    [repos, rootPath]
+  )
   const hasRoot = rootRepo !== null
 
   const nestedChangeCount = useMemo(
     () => nestedRepos.reduce((sum, r) => sum + r.status.files.length, 0),
     [nestedRepos]
   )
+
+  const statusByPath = useMemo(
+    () => new Map(repos.map((r) => [r.path, r.status])),
+    [repos]
+  )
+
+  // The spatial tree of the (nested) repos, rooted at the panel's folder.
+  const repoTree = useMemo(
+    () =>
+      basePath
+        ? buildRepoTree(
+            basePath,
+            nestedRepos.map((r) => ({ name: r.name, path: r.path }))
+          )
+        : null,
+    [basePath, nestedRepos]
+  )
+
+  // Folded directories, persisted per basePath (default: fully expanded).
+  const cacheKey = basePath ?? ''
+  const [collapsedDirs, _setCollapsedDirs] = useState<Set<string>>(
+    () => collapsedDirsCacheMap.get(cacheKey) ?? new Set()
+  )
+  const prevCacheKeyRef = useRef(cacheKey)
+  useEffect(() => {
+    if (prevCacheKeyRef.current !== cacheKey) {
+      prevCacheKeyRef.current = cacheKey
+      _setCollapsedDirs(collapsedDirsCacheMap.get(cacheKey) ?? new Set())
+    }
+  }, [cacheKey])
+
+  const toggleDir = useCallback(
+    (dirPath: string) => {
+      _setCollapsedDirs((prev) => {
+        const next = new Set(prev)
+        if (next.has(dirPath)) next.delete(dirPath)
+        else next.add(dirPath)
+        collapsedDirsCacheMap.set(cacheKey, next)
+        return next
+      })
+    },
+    [cacheKey]
+  )
+
+  // Collapse-all folds every directory too (repo sections handle themselves).
+  const collapseAllTrigger = useSessionStore((s) => s.collapseAllTrigger)
+  useEffect(() => {
+    if (collapseAllTrigger > 0 && repoTree) {
+      const all = collectRepoTreeDirPaths(repoTree)
+      collapsedDirsCacheMap.set(cacheKey, all)
+      _setCollapsedDirs(all)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [collapseAllTrigger])
+
+  const treeRows = useMemo(
+    () => (repoTree ? flattenRepoTree(repoTree, collapsedDirs) : null),
+    [repoTree, collapsedDirs]
+  )
+
+  const renderTreeRow = (row: FlatRepoRow): React.JSX.Element | null => {
+    if (row.node.type === 'dir') {
+      return (
+        <RepoDirRow
+          key={`dir:${row.node.path}`}
+          node={row.node}
+          depth={row.depth}
+          collapsed={row.collapsed}
+          onToggle={() => toggleDir(row.node.path)}
+          statusByPath={statusByPath}
+        />
+      )
+    }
+    const status = statusByPath.get(row.node.path)
+    if (!status) return null
+    return (
+      <MultiRepoSection
+        key={row.node.path}
+        name={row.node.name}
+        repoPath={row.node.path}
+        status={status}
+        refresh={refresh}
+        isSelected={selectedRepoPaths.has(row.node.path)}
+        onSelect={handleRepoSelect}
+        selectedRepoPaths={selectedRepoPaths}
+        depth={row.depth}
+      />
+    )
+  }
 
   return (
     <div className="flex-1 flex flex-col min-h-0">
@@ -918,36 +1111,23 @@ export function MultiRepoGitPanel({
           </div>
         )}
 
-        {/* Nested repos (when root exists) — visible when not docked */}
-        {hasRoot &&
-          !nestedDocked &&
-          nestedRepos.map((repo) => (
-            <MultiRepoSection
-              key={repo.path}
-              name={repo.name}
-              repoPath={repo.path}
-              status={repo.status}
-              refresh={refresh}
-              isSelected={selectedRepoPaths.has(repo.path)}
-              onSelect={handleRepoSelect}
-              selectedRepoPaths={selectedRepoPaths}
-            />
-          ))}
-
-        {/* All repos flat when CWD is not itself a repo (no root) */}
-        {!hasRoot &&
-          repos.map((repo) => (
-            <MultiRepoSection
-              key={repo.path}
-              name={repo.name}
-              repoPath={repo.path}
-              status={repo.status}
-              refresh={refresh}
-              isSelected={selectedRepoPaths.has(repo.path)}
-              onSelect={handleRepoSelect}
-              selectedRepoPaths={selectedRepoPaths}
-            />
-          ))}
+        {/* Nested repos as the spatial tree (flat fallback without a basePath) —
+            hidden when docked */}
+        {!(hasRoot && nestedDocked) &&
+          (treeRows
+            ? treeRows.map(renderTreeRow)
+            : nestedRepos.map((repo) => (
+                <MultiRepoSection
+                  key={repo.path}
+                  name={repo.name}
+                  repoPath={repo.path}
+                  status={repo.status}
+                  refresh={refresh}
+                  isSelected={selectedRepoPaths.has(repo.path)}
+                  onSelect={handleRepoSelect}
+                  selectedRepoPaths={selectedRepoPaths}
+                />
+              )))}
       </div>
 
       {/* Bottom dock tab for nested repos */}

--- a/src/renderer/src/components/git/GitStatusPanel.tsx
+++ b/src/renderer/src/components/git/GitStatusPanel.tsx
@@ -67,6 +67,7 @@ function RepoSection({
   fillHeight?: boolean
 }) {
   const gitViewMode = useSessionStore((s) => s.gitViewMode)
+  const gitShowCommitBar = useSessionStore((s) => s.gitShowCommitBar)
   const setDiffPreview = useSessionStore((s) => s.setDiffPreview)
   const diffPreview = useSessionStore((s) => s.diffPreview)
   const addFileTab = useSessionStore((s) => s.addFileTab)
@@ -385,7 +386,7 @@ function RepoSection({
             {relativeFilterPrefix ? 'No changes in this folder' : 'Working tree clean'}
           </span>
         </div>
-        {(status.ahead > 0 || status.behind > 0 || (!status.hasUpstream && !!status.branch)) && (
+        {gitShowCommitBar && (status.ahead > 0 || status.behind > 0 || (!status.hasUpstream && !!status.branch)) && (
           <CommitBar
             cwd={cwd}
             stagedCount={0}
@@ -551,17 +552,19 @@ function RepoSection({
           </>
         )}
       </div>
-      <CommitBar
-        cwd={cwd}
-        stagedCount={staged.length}
-        totalFileCount={staged.length + unstaged.length + untracked.length}
-        unstagedFilePaths={[...unstaged, ...untracked].map((f) => f.path)}
-        ahead={status.ahead}
-        behind={status.behind}
-        hasUpstream={status.hasUpstream}
-        operating={operating}
-        onOperation={runOperation}
-      />
+      {gitShowCommitBar && (
+        <CommitBar
+          cwd={cwd}
+          stagedCount={staged.length}
+          totalFileCount={staged.length + unstaged.length + untracked.length}
+          unstagedFilePaths={[...unstaged, ...untracked].map((f) => f.path)}
+          ahead={status.ahead}
+          behind={status.behind}
+          hasUpstream={status.hasUpstream}
+          operating={operating}
+          onOperation={runOperation}
+        />
+      )}
       <ConfirmDialog
         isOpen={confirmDiscard !== null}
         title="Discard changes"

--- a/src/renderer/src/components/git/GitStatusPanel.tsx
+++ b/src/renderer/src/components/git/GitStatusPanel.tsx
@@ -990,37 +990,40 @@ export function MultiRepoGitPanel({
   const [collapsedDirs, _setCollapsedDirs] = useState<Set<string>>(
     () => collapsedDirsCacheMap.get(cacheKey) ?? new Set()
   )
-  const prevCacheKeyRef = useRef(cacheKey)
-  useEffect(() => {
-    if (prevCacheKeyRef.current !== cacheKey) {
-      prevCacheKeyRef.current = cacheKey
-      _setCollapsedDirs(collapsedDirsCacheMap.get(cacheKey) ?? new Set())
-    }
-  }, [cacheKey])
 
-  const toggleDir = useCallback(
-    (dirPath: string) => {
-      _setCollapsedDirs((prev) => {
-        const next = new Set(prev)
-        if (next.has(dirPath)) next.delete(dirPath)
-        else next.add(dirPath)
-        collapsedDirsCacheMap.set(cacheKey, next)
-        return next
-      })
-    },
-    [cacheKey]
-  )
-
-  // Collapse-all folds every directory too (repo sections handle themselves).
+  // Guarded adjust-during-render instead of sync effects: a basePath switch
+  // re-reads that folder's cache, and a NEW collapse-all press folds every
+  // directory. Initializing the prev-trigger to the current value is what
+  // keeps an old press from re-folding (and clobbering the cache) on
+  // remount — the trigger is a monotonic global counter that never resets.
   const collapseAllTrigger = useSessionStore((s) => s.collapseAllTrigger)
-  useEffect(() => {
-    if (collapseAllTrigger > 0 && repoTree) {
-      const all = collectRepoTreeDirPaths(repoTree)
-      collapsedDirsCacheMap.set(cacheKey, all)
-      _setCollapsedDirs(all)
+  const [prevCacheKey, setPrevCacheKey] = useState(cacheKey)
+  const [prevCollapseAll, setPrevCollapseAll] = useState(collapseAllTrigger)
+  if (prevCacheKey !== cacheKey) {
+    setPrevCacheKey(cacheKey)
+    _setCollapsedDirs(collapsedDirsCacheMap.get(cacheKey) ?? new Set())
+  }
+  if (prevCollapseAll !== collapseAllTrigger) {
+    setPrevCollapseAll(collapseAllTrigger)
+    if (repoTree) {
+      _setCollapsedDirs(collectRepoTreeDirPaths(repoTree))
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [collapseAllTrigger])
+  }
+
+  // Mirror the fold state into the per-basePath cache so it survives
+  // unmount (the cache write lives here, outside render, on purpose).
+  useEffect(() => {
+    collapsedDirsCacheMap.set(cacheKey, collapsedDirs)
+  }, [cacheKey, collapsedDirs])
+
+  const toggleDir = useCallback((dirPath: string) => {
+    _setCollapsedDirs((prev) => {
+      const next = new Set(prev)
+      if (next.has(dirPath)) next.delete(dirPath)
+      else next.add(dirPath)
+      return next
+    })
+  }, [])
 
   const treeRows = useMemo(
     () => (repoTree ? flattenRepoTree(repoTree, collapsedDirs) : null),

--- a/src/renderer/src/components/git/SidePanel.tsx
+++ b/src/renderer/src/components/git/SidePanel.tsx
@@ -495,6 +495,7 @@ export function SidePanel() {
               <MultiRepoGitPanel
                 repos={multiRepo.result.repos}
                 rootPath={multiRepo.hasNestedRepos ? cwd : null}
+                basePath={cwd}
                 refresh={multiRepo.refresh}
                 truncated={multiRepo.result.truncated}
                 live={multiRepo.result.live}

--- a/src/renderer/src/components/git/SidePanel.tsx
+++ b/src/renderer/src/components/git/SidePanel.tsx
@@ -5,7 +5,7 @@ import { useLocationStore } from '../../store/location-store'
 import { FileTree } from '../files/FileTree'
 import { RemoteFileTree } from '../files/RemoteFileTree'
 import { GitStatusPanel, MultiRepoGitPanel } from './GitStatusPanel'
-import { MagicPullButton, MagicSyncButton, ViewModeToggle, PanelModeToggle, CollapseAllButton, JourneyButton } from './GitPanelControls'
+import { MagicPullButton, MagicSyncButton, ViewModeToggle, PanelModeToggle, CollapseAllButton, CommitBarToggle, JourneyButton } from './GitPanelControls'
 import { useMultiRepoStatus } from '../../hooks/use-multi-repo-status'
 import { useGitStatus } from '../../hooks/use-git-status'
 import { shortenPath } from '../../lib/utils'
@@ -463,6 +463,7 @@ export function SidePanel() {
           {isSingleRepo && cwd && (
             <JourneyButton cwd={cwd} repoName={cwd.split('/').pop() ?? cwd} />
           )}
+          <CommitBarToggle />
           <PanelModeToggle />
           <ViewModeToggle />
           <CollapseAllButton />

--- a/src/renderer/src/help/git.md
+++ b/src/renderer/src/help/git.md
@@ -22,6 +22,8 @@ Switch between **list** (flat file list) and **tree** (directory tree) views usi
 
 ## Staging and Committing
 
+The commit bar (message input, Commit, Push/Pull) is **hidden by default** — most commits are made by your agents. Click the pencil icon in the git toolbar to show it; the choice is remembered.
+
 1. Files appear in three sections: **Staged**, **Unstaged**, and **Untracked**
 2. Click the **+** icon on a file to stage it (or **-** to unstage)
 3. Write a commit message in the input at the bottom

--- a/src/renderer/src/help/git.md
+++ b/src/renderer/src/help/git.md
@@ -51,3 +51,9 @@ Click the journey icon in the git panel toolbar to visualize your commit history
 ## Multi-Repo Support
 
 If your workspace contains multiple git repos (e.g., a monorepo with nested repositories), the panel auto-detects them and shows each repo as a collapsible section.
+
+Repos are arranged as your real folder structure, not an alphabetical list: each repo sits under its parent directories, so you find it exactly where you know it lives on disk. Folder chains with nothing else in them are merged into one row (e.g. `labs/products`) to keep the panel compact.
+
+- Click a folder row to fold or unfold that whole area — the fold state is remembered per folder.
+- A folded folder rolls up what's inside it: total modified files, plus commits ahead (↑) and behind (↓) across its repos, so nothing hides while folded.
+- **Collapse all** in the toolbar folds every folder and repo at once.

--- a/src/renderer/src/help/whats-new.json
+++ b/src/renderer/src/help/whats-new.json
@@ -1,6 +1,15 @@
 [
   {
     "version": "1.68.0",
+    "title": "The git panel is your real folder tree",
+    "description": "Repos now sit exactly where they live on disk — nested under their real parent folders, single-child chains merged into one row, folders foldable with rolled-up change counts and ahead/behind badges so nothing hides while folded. And the commit bar is tucked away by default (agents do the committing) — the pencil icon in the git toolbar brings it back.",
+    "action": {
+      "type": "navigate",
+      "target": "side:git"
+    }
+  },
+  {
+    "version": "1.68.0",
     "title": "Groups open as live pages",
     "description": "Attach a web view to a group — a dev server, a live dashboard, or an HTML file — and clicking the group shows the rendered page instead of the tiled terminals, with a Sessions switch one click away. HTML files also render as live pages in their own tabs now, with a Rendered ⇄ Source toggle. Agents can drive both: clave_set_group_view and clave_open_file's rendered view.",
     "action": {

--- a/src/renderer/src/lib/git-repo-tree.test.ts
+++ b/src/renderer/src/lib/git-repo-tree.test.ts
@@ -1,0 +1,142 @@
+/**
+ * The spatial repo tree behind the multi-repo git panel: relativization
+ * against the panel folder, single-child chain compaction, Finder ordering,
+ * collapse-aware flattening, and the repoPaths roll-up sets the badges sum.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  buildRepoTree,
+  flattenRepoTree,
+  collectRepoTreeDirPaths,
+  type RepoTreeDir,
+  type RepoTreeNode
+} from './git-repo-tree'
+
+const WS = '/Users/u/ws'
+
+function names(nodes: RepoTreeNode[]): string[] {
+  return nodes.map((n) => `${n.type}:${n.name}`)
+}
+
+describe('buildRepoTree', () => {
+  it('places repos under their real parent directories', () => {
+    const tree = buildRepoTree(WS, [
+      { name: 'app', path: `${WS}/labs/app` },
+      { name: 'site', path: `${WS}/labs/site` },
+      { name: 'brand', path: `${WS}/company/brand` }
+    ])
+    expect(names(tree)).toEqual(['dir:company', 'dir:labs'])
+    const labs = tree[1] as RepoTreeDir
+    expect(names(labs.children)).toEqual(['repo:app', 'repo:site'])
+  })
+
+  it('repos directly under the base stay a flat list — no dir rows', () => {
+    const tree = buildRepoTree(WS, [
+      { name: 'b', path: `${WS}/b` },
+      { name: 'a', path: `${WS}/a` }
+    ])
+    expect(names(tree)).toEqual(['repo:a', 'repo:b'])
+  })
+
+  it('compacts single-child directory chains into one node', () => {
+    const tree = buildRepoTree(WS, [
+      { name: 'clave-app', path: `${WS}/labs/products/clave/clave-app` },
+      { name: 'clave-os', path: `${WS}/labs/products/clave/clave-os` }
+    ])
+    // labs → products → clave all have one dir child: one compacted row.
+    expect(names(tree)).toEqual(['dir:labs/products/clave'])
+    const dir = tree[0] as RepoTreeDir
+    expect(dir.path).toBe(`${WS}/labs/products/clave`)
+    expect(names(dir.children)).toEqual(['repo:clave-app', 'repo:clave-os'])
+  })
+
+  it('stops compaction where the tree branches', () => {
+    const tree = buildRepoTree(WS, [
+      { name: 'hub', path: `${WS}/labs/products/ant/hub` },
+      { name: 'clave-app', path: `${WS}/labs/products/clave/clave-app` },
+      { name: 'sched', path: `${WS}/labs/services/sched` }
+    ])
+    // labs branches (products, services); products branches (ant, clave).
+    expect(names(tree)).toEqual(['dir:labs'])
+    const labs = tree[0] as RepoTreeDir
+    expect(names(labs.children)).toEqual(['dir:products', 'dir:services'])
+    const products = labs.children[0] as RepoTreeDir
+    expect(names(products.children)).toEqual(['dir:ant', 'dir:clave'])
+  })
+
+  it('sorts each level alphabetically, dirs and repos interleaved (Finder order)', () => {
+    const tree = buildRepoTree(WS, [
+      { name: 'zeta', path: `${WS}/zeta` },
+      { name: 'app', path: `${WS}/beta/app` },
+      { name: 'alpha', path: `${WS}/alpha` }
+    ])
+    expect(names(tree)).toEqual(['repo:alpha', 'dir:beta', 'repo:zeta'])
+  })
+
+  it('rolls up repoPaths at every level of the subtree', () => {
+    const tree = buildRepoTree(WS, [
+      { name: 'a', path: `${WS}/labs/x/a` },
+      { name: 'b', path: `${WS}/labs/y/b` },
+      { name: 'c', path: `${WS}/labs/y/c` }
+    ])
+    const labs = tree[0] as RepoTreeDir
+    expect(labs.repoPaths.sort()).toEqual([`${WS}/labs/x/a`, `${WS}/labs/y/b`, `${WS}/labs/y/c`])
+    const y = labs.children.find((n) => n.name === 'y') as RepoTreeDir
+    expect(y.repoPaths.sort()).toEqual([`${WS}/labs/y/b`, `${WS}/labs/y/c`])
+  })
+
+  it('a repo outside the base becomes a defensive top-level leaf', () => {
+    const tree = buildRepoTree(WS, [{ name: 'stray', path: '/elsewhere/stray' }])
+    expect(names(tree)).toEqual(['repo:stray'])
+  })
+
+  it('tolerates a trailing slash on the base and a "/" base', () => {
+    const slashed = buildRepoTree(`${WS}/`, [{ name: 'a', path: `${WS}/labs/a` }])
+    expect(names(slashed)).toEqual(['dir:labs'])
+    const rootBase = buildRepoTree('/', [{ name: 'a', path: '/labs/a' }])
+    expect(names(rootBase)).toEqual(['dir:labs'])
+  })
+})
+
+describe('flattenRepoTree', () => {
+  const tree = buildRepoTree(WS, [
+    { name: 'hub', path: `${WS}/labs/ant/hub` },
+    { name: 'app', path: `${WS}/labs/clave/app` },
+    { name: 'brand', path: `${WS}/company/brand` }
+  ])
+
+  it('expanded: every node appears with its depth', () => {
+    const rows = flattenRepoTree(tree, new Set())
+    expect(rows.map((r) => `${r.depth}:${r.node.type}:${r.node.name}`)).toEqual([
+      '0:dir:company',
+      '1:repo:brand',
+      '0:dir:labs',
+      '1:dir:ant',
+      '2:repo:hub',
+      '1:dir:clave',
+      '2:repo:app'
+    ])
+  })
+
+  it('a collapsed dir keeps its row but hides its subtree', () => {
+    const rows = flattenRepoTree(tree, new Set([`${WS}/labs`]))
+    expect(rows.map((r) => `${r.node.name}${r.collapsed ? '(collapsed)' : ''}`)).toEqual([
+      'company',
+      'brand',
+      'labs(collapsed)'
+    ])
+  })
+})
+
+describe('collectRepoTreeDirPaths', () => {
+  it('returns every directory path, compacted chains by their deepest path', () => {
+    const tree = buildRepoTree(WS, [
+      { name: 'a', path: `${WS}/labs/products/x/a` },
+      { name: 'b', path: `${WS}/company/b` }
+    ])
+    expect(collectRepoTreeDirPaths(tree)).toEqual(
+      new Set([`${WS}/company`, `${WS}/labs/products/x`])
+    )
+  })
+})

--- a/src/renderer/src/lib/git-repo-tree.test.ts
+++ b/src/renderer/src/lib/git-repo-tree.test.ts
@@ -91,6 +91,38 @@ describe('buildRepoTree', () => {
     expect(names(tree)).toEqual(['repo:stray'])
   })
 
+  it('compacts chains below the top level too', () => {
+    // Verifier gap M11: labs branches, but the chain under services must
+    // still merge into one node.
+    const tree = buildRepoTree(WS, [
+      { name: 'hub', path: `${WS}/labs/ant/hub` },
+      { name: 'sched', path: `${WS}/labs/services/deep/chain/sched` }
+    ])
+    const labs = tree[0] as RepoTreeDir
+    expect(names(labs.children)).toEqual(['dir:ant', 'dir:services/deep/chain'])
+    const chain = labs.children[1] as RepoTreeDir
+    expect(chain.path).toBe(`${WS}/labs/services/deep/chain`)
+    expect(names(chain.children)).toEqual(['repo:sched'])
+  })
+
+  it('a sibling folder sharing the base as a string prefix is NOT inside it', () => {
+    // Verifier gap M10: /Users/u/ws-old shares the prefix "/Users/u/ws" as a
+    // string but is a sibling on disk — it must become a top-level leaf, not
+    // an invented "-old" directory.
+    const tree = buildRepoTree(WS, [{ name: 'a', path: `${WS}-old/a` }])
+    expect(names(tree)).toEqual(['repo:a'])
+  })
+
+  it('tolerates trailing and doubled separators on repo paths', () => {
+    // Verifier gap M12: empty segments must never become directory nodes.
+    const trailing = buildRepoTree(WS, [{ name: 'a', path: `${WS}/d/a/` }])
+    expect(names(trailing)).toEqual(['dir:d'])
+    expect(names((trailing[0] as RepoTreeDir).children)).toEqual(['repo:a'])
+    const doubled = buildRepoTree(WS, [{ name: 'a', path: `${WS}//d/a` }])
+    expect(names(doubled)).toEqual(['dir:d'])
+    expect(names((doubled[0] as RepoTreeDir).children)).toEqual(['repo:a'])
+  })
+
   it('tolerates a trailing slash on the base and a "/" base', () => {
     const slashed = buildRepoTree(`${WS}/`, [{ name: 'a', path: `${WS}/labs/a` }])
     expect(names(slashed)).toEqual(['dir:labs'])
@@ -137,6 +169,18 @@ describe('collectRepoTreeDirPaths', () => {
     ])
     expect(collectRepoTreeDirPaths(tree)).toEqual(
       new Set([`${WS}/company`, `${WS}/labs/products/x`])
+    )
+  })
+
+  it('recurses into nested directories', () => {
+    // Verifier gap M9: dirs below the top level must be collected too, or
+    // collapse-all misses them.
+    const tree = buildRepoTree(WS, [
+      { name: 'r1', path: `${WS}/labs/a/r1` },
+      { name: 'r2', path: `${WS}/labs/b/r2` }
+    ])
+    expect(collectRepoTreeDirPaths(tree)).toEqual(
+      new Set([`${WS}/labs`, `${WS}/labs/a`, `${WS}/labs/b`])
     )
   })
 })

--- a/src/renderer/src/lib/git-repo-tree.ts
+++ b/src/renderer/src/lib/git-repo-tree.ts
@@ -1,0 +1,147 @@
+/**
+ * Spatial repo tree for the multi-repo git panel (PRDCT-1235 / PRDCT-1455).
+ *
+ * Turns the flat repo list from discovery into the tree the user already has
+ * in their head: repos sit under their real parent directories, relative to
+ * the panel's folder. Single-child directory chains are compacted into one
+ * node ("labs/products" when nothing else branches) so pass-through folders
+ * never burn a row — the same idiom compactTree applies to file trees inside
+ * a repo (git-file-tree.ts).
+ *
+ * Pure data — no fs, no path module — so it is unit-testable and shared-safe.
+ */
+
+export interface RepoRef {
+  name: string
+  /** Absolute path of the repo root */
+  path: string
+}
+
+export interface RepoTreeDir {
+  type: 'dir'
+  /** Display label — a compacted chain like "labs/products" */
+  name: string
+  /** Absolute path of the deepest directory in the compacted chain */
+  path: string
+  children: RepoTreeNode[]
+  /** Absolute paths of every repo in this subtree, for badge roll-ups */
+  repoPaths: string[]
+}
+
+export interface RepoTreeLeaf {
+  type: 'repo'
+  name: string
+  path: string
+}
+
+export type RepoTreeNode = RepoTreeDir | RepoTreeLeaf
+
+export interface FlatRepoRow {
+  node: RepoTreeNode
+  depth: number
+  /** Directories only — true when the row is folded */
+  collapsed: boolean
+}
+
+/**
+ * Build the directory tree of `repos` relative to `basePath`.
+ * A repo not under basePath (defensive — discovery never returns one) becomes
+ * a top-level leaf. Each level sorts alphabetically, directories and repos
+ * interleaved, matching Finder.
+ */
+export function buildRepoTree(basePath: string, repos: RepoRef[]): RepoTreeNode[] {
+  const base = basePath === '/' ? '/' : basePath.replace(/\/+$/, '')
+  const prefix = base === '/' ? '/' : base + '/'
+
+  const root: RepoTreeDir = { type: 'dir', name: '', path: base, children: [], repoPaths: [] }
+
+  for (const repo of repos) {
+    if (!repo.path.startsWith(prefix) || repo.path === base) {
+      root.children.push({ type: 'repo', name: repo.name, path: repo.path })
+      root.repoPaths.push(repo.path)
+      continue
+    }
+    const segments = repo.path.slice(prefix.length).split('/').filter(Boolean)
+    let current = root
+    root.repoPaths.push(repo.path)
+    // Intermediate segments are directories; the last one is the repo itself.
+    for (let i = 0; i < segments.length - 1; i++) {
+      const dirPath = current.path === '/' ? '/' + segments[i] : current.path + '/' + segments[i]
+      let dir = current.children.find(
+        (c): c is RepoTreeDir => c.type === 'dir' && c.path === dirPath
+      )
+      if (!dir) {
+        dir = { type: 'dir', name: segments[i], path: dirPath, children: [], repoPaths: [] }
+        current.children.push(dir)
+      }
+      dir.repoPaths.push(repo.path)
+      current = dir
+    }
+    current.children.push({ type: 'repo', name: repo.name, path: repo.path })
+  }
+
+  const compacted = compactRepoTree(root.children)
+  sortRepoTree(compacted)
+  return compacted
+}
+
+/** Merge single-child directory chains into one node ("labs/products"). */
+function compactRepoTree(nodes: RepoTreeNode[]): RepoTreeNode[] {
+  return nodes.map((node) => {
+    if (node.type !== 'dir') return node
+    let current = node
+    while (current.children.length === 1 && current.children[0].type === 'dir') {
+      const child = current.children[0] as RepoTreeDir
+      current = {
+        type: 'dir',
+        name: current.name + '/' + child.name,
+        path: child.path,
+        children: child.children,
+        repoPaths: current.repoPaths
+      }
+    }
+    return { ...current, children: compactRepoTree(current.children) }
+  })
+}
+
+function sortRepoTree(nodes: RepoTreeNode[]): void {
+  nodes.sort((a, b) => a.name.localeCompare(b.name))
+  for (const node of nodes) {
+    if (node.type === 'dir') sortRepoTree(node.children)
+  }
+}
+
+/**
+ * Flatten for rendering. A directory in `collapsedPaths` keeps its row but
+ * its subtree is not descended — its badges roll up instead.
+ */
+export function flattenRepoTree(
+  nodes: RepoTreeNode[],
+  collapsedPaths: Set<string>,
+  depth = 0
+): FlatRepoRow[] {
+  const rows: FlatRepoRow[] = []
+  for (const node of nodes) {
+    const collapsed = node.type === 'dir' && collapsedPaths.has(node.path)
+    rows.push({ node, depth, collapsed })
+    if (node.type === 'dir' && !collapsed) {
+      rows.push(...flattenRepoTree(node.children, collapsedPaths, depth + 1))
+    }
+  }
+  return rows
+}
+
+/** Every directory path in the tree — the "collapse all" set. */
+export function collectRepoTreeDirPaths(nodes: RepoTreeNode[]): Set<string> {
+  const paths = new Set<string>()
+  const walk = (ns: RepoTreeNode[]): void => {
+    for (const n of ns) {
+      if (n.type === 'dir') {
+        paths.add(n.path)
+        walk(n.children)
+      }
+    }
+  }
+  walk(nodes)
+  return paths
+}

--- a/src/renderer/src/store/session-store.ts
+++ b/src/renderer/src/store/session-store.ts
@@ -77,6 +77,9 @@ interface SessionState {
   sidePanelTab: 'files' | 'git' | 'help'
   gitViewMode: 'list' | 'tree'
   gitPanelMode: 'changes' | 'log'
+  /** Per-repo commit bar (message box, commit, push/pull). Hidden by default —
+   *  agents commit and push; the panel is for reading state. */
+  gitShowCommitBar: boolean
   /** Above this many repos, the multi-repo git panel stops auto-polling and
    *  switches to event-driven + manual refresh (see use-multi-repo-status). */
   gitLivePollLimit: number
@@ -166,6 +169,7 @@ interface SessionState {
   setSidePanelTab: (tab: 'files' | 'git' | 'help') => void
   setGitViewMode: (mode: 'list' | 'tree') => void
   setGitPanelMode: (mode: 'changes' | 'log') => void
+  setGitShowCommitBar: (show: boolean) => void
   setGitLivePollLimit: (limit: number) => void
   setGitLivePollAlways: (always: boolean) => void
   openJourneyPanel: (cwd: string, repoName: string) => void
@@ -379,6 +383,7 @@ export const useSessionStore = create<SessionState>((set) => ({
   sidePanelTab: 'files' as const,
   gitViewMode: (localStorage.getItem('clave-git-view-mode') === 'tree' ? 'tree' : 'list') as 'list' | 'tree',
   gitPanelMode: 'changes' as const,
+  gitShowCommitBar: localStorage.getItem('clave-git-commit-bar') === 'show',
   gitLivePollLimit: (() => {
     const raw = Number(localStorage.getItem('clave-git-live-poll-limit'))
     return Number.isFinite(raw) && raw > 0 ? raw : 50
@@ -1112,6 +1117,11 @@ export const useSessionStore = create<SessionState>((set) => ({
   },
 
   setGitPanelMode: (mode) => set({ gitPanelMode: mode }),
+
+  setGitShowCommitBar: (show) => {
+    localStorage.setItem('clave-git-commit-bar', show ? 'show' : 'hide')
+    set({ gitShowCommitBar: show })
+  },
 
   setGitLivePollLimit: (limit) => {
     const clamped = Math.max(1, Math.round(limit))

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,11 @@ import { defineConfig } from 'vitest/config'
  */
 export default defineConfig({
   test: {
-    include: ['src/main/exchange-capture/**/*.test.ts', 'src/shared/**/*.test.ts'],
+    include: [
+      'src/main/exchange-capture/**/*.test.ts',
+      'src/shared/**/*.test.ts',
+      'src/renderer/src/lib/**/*.test.ts'
+    ],
     environment: 'node'
   }
 })


### PR DESCRIPTION
## What

The multi-repo git panel arranges repos as the real filesystem tree instead of one alphabetical list (PRDCT-1235 + PRDCT-1455): repos at their real depth under their parent directories, single-child folder chains compacted into one row, folders fold/unfold with per-folder persisted state, folded folders roll up summed dirty counts and ahead/behind badges, collapse-all folds directories too, main-process discovery sorts by path. Pure tree lib (`git-repo-tree.ts`) with a 15-test vitest suite (vitest include extended to renderer libs).

The per-repo commit bar is hidden by default (PRDCT-1674) — agents commit and push; a new pencil toggle in the git toolbar reveals it, persisted like `gitViewMode`. Whats-new entry rides 1.68.0.

## Verification

- 29/29 vitest, typecheck clean, zero new eslint errors vs dev (per-file deltas checked).
- Playwright Electron on the real workspace (~80 repos): tree renders at real positions, `tools/slideless` compaction, fold roll-ups sum exactly, fold state survives Files↔Git remount, commit bar absent by default / 7 bars on toggle.
- Independent adversarial verification, three rounds (fresh Opus subagent, kept across rounds): differential fuzz of the tree lib vs an independent reference (36k+ cases, 0 mismatches), 20 mutations (lib mutation-tight; component/store gaps are the repo's deliberate no-DOM-runner scope), React-semantics modelling of the remount fix across nine scenarios + StrictMode. Final verdict: whole branch merge-safe.

## Follow-ups filed

- PRDCT-1672 — pre-existing: repo sections obey a stale collapse-all press on mount.
- PRDCT-1676 — publishing a fresh local branch: MagicSync's bare push fails without an upstream and the Publish button now sits behind the hidden-by-default bar.
- PRDCT-1675 — worktrees as first-class rows + hover focuses the working group (future).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012G8LRM6oVjVrebMjDE5zR1