### PR TITLE
feat: git states join the tree, and the sync arrows unfold what a pull or push will touch (PRDCT-1539, PRDCT-1678, PRDCT-1679)

### DIFF
--- a/src/main/git-manager.ts
+++ b/src/main/git-manager.ts
@@ -377,6 +377,62 @@ class GitManager {
     }
   }
 
+  /**
+   * Aggregate file list of a sync range (PRDCT-1539 / PRDCT-1679):
+   * incoming = what a pull will bring (`HEAD...origin/<branch>`, merge-base →
+   * remote), outgoing = what a push will send (`origin/<branch>...HEAD`).
+   * Fails soft (empty list) when there is no branch or no remote ref, like
+   * getIncomingCommits.
+   */
+  async getRangeFiles(cwd: string, direction: 'incoming' | 'outgoing'): Promise<GitCommitFileStatus[]> {
+    try {
+      const git = simpleGit(cwd)
+      const branch = (await git.status()).current
+      if (!branch) return []
+      const spec = direction === 'incoming' ? `HEAD...origin/${branch}` : `origin/${branch}...HEAD`
+      const numRaw = await git.raw(['diff', '--numstat', '--diff-filter=AMDRTC', spec])
+      const nameRaw = await git.raw(['diff', '--name-status', '--diff-filter=AMDRTC', spec])
+
+      const numLines = numRaw.trim().split('\n').filter(Boolean)
+      const nameLines = nameRaw.trim().split('\n').filter(Boolean)
+
+      const files: GitCommitFileStatus[] = []
+      for (let i = 0; i < nameLines.length; i++) {
+        const nameParts = nameLines[i].split('\t')
+        const statusChar = nameParts[0].charAt(0) as GitCommitFileStatus['status']
+        const filePath = nameParts[nameParts.length - 1]
+
+        let insertions = 0
+        let deletions = 0
+        if (numLines[i]) {
+          const numParts = numLines[i].split('\t')
+          insertions = numParts[0] === '-' ? 0 : parseInt(numParts[0], 10) || 0
+          deletions = numParts[1] === '-' ? 0 : parseInt(numParts[1], 10) || 0
+        }
+
+        files.push({ path: filePath, status: statusChar, insertions, deletions })
+      }
+      return files
+    } catch {
+      // Expected: no remote tracking branch
+      return []
+    }
+  }
+
+  /** Aggregate per-file diff of a sync range — the net effect, not per-commit. */
+  async getRangeDiff(cwd: string, direction: 'incoming' | 'outgoing', filePath: string): Promise<string> {
+    try {
+      const git = simpleGit(cwd)
+      const branch = (await git.status()).current
+      if (!branch) return ''
+      const spec = direction === 'incoming' ? `HEAD...origin/${branch}` : `origin/${branch}...HEAD`
+      return await git.raw(['diff', spec, '--', filePath])
+    } catch (err) {
+      console.warn('[git] getRangeDiff failed:', direction, filePath, (err as Error).message)
+      return ''
+    }
+  }
+
   async getCommitFiles(cwd: string, hash: string): Promise<GitCommitFileStatus[]> {
     try {
       const git = simpleGit(cwd)

--- a/src/main/git-manager.ts
+++ b/src/main/git-manager.ts
@@ -387,9 +387,12 @@ class GitManager {
   async getRangeFiles(cwd: string, direction: 'incoming' | 'outgoing'): Promise<GitCommitFileStatus[]> {
     try {
       const git = simpleGit(cwd)
-      const branch = (await git.status()).current
-      if (!branch) return []
-      const spec = direction === 'incoming' ? `HEAD...origin/${branch}` : `origin/${branch}...HEAD`
+      // The REAL tracking ref, not a guessed origin/<branch>: a branch can
+      // track a differently-named upstream, and the ahead/behind badges come
+      // from that tracking info — the range must agree with them.
+      const tracking = (await git.status()).tracking
+      if (!tracking) return []
+      const spec = direction === 'incoming' ? `HEAD...${tracking}` : `${tracking}...HEAD`
       const numRaw = await git.raw(['diff', '--numstat', '--diff-filter=AMDRTC', spec])
       const nameRaw = await git.raw(['diff', '--name-status', '--diff-filter=AMDRTC', spec])
 
@@ -423,9 +426,9 @@ class GitManager {
   async getRangeDiff(cwd: string, direction: 'incoming' | 'outgoing', filePath: string): Promise<string> {
     try {
       const git = simpleGit(cwd)
-      const branch = (await git.status()).current
-      if (!branch) return ''
-      const spec = direction === 'incoming' ? `HEAD...origin/${branch}` : `origin/${branch}...HEAD`
+      const tracking = (await git.status()).tracking
+      if (!tracking) return ''
+      const spec = direction === 'incoming' ? `HEAD...${tracking}` : `${tracking}...HEAD`
       return await git.raw(['diff', spec, '--', filePath])
     } catch (err) {
       console.warn('[git] getRangeDiff failed:', direction, filePath, (err as Error).message)

--- a/src/main/ipc-handlers/git-handlers.ts
+++ b/src/main/ipc-handlers/git-handlers.ts
@@ -49,6 +49,12 @@ export function registerGitHandlers(): void {
   ipcMain.handle('git:incoming-commits', (_event, cwd: string) =>
     gitManager.getIncomingCommits(cwd)
   )
+  ipcMain.handle('git:range-files', (_event, cwd: string, direction: 'incoming' | 'outgoing') =>
+    gitManager.getRangeFiles(cwd, direction)
+  )
+  ipcMain.handle('git:range-diff', (_event, cwd: string, direction: 'incoming' | 'outgoing', filePath: string) =>
+    gitManager.getRangeDiff(cwd, direction, filePath)
+  )
   ipcMain.handle('git:commit-files', (_event, cwd: string, hash: string) =>
     gitManager.getCommitFiles(cwd, hash)
   )

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -466,6 +466,8 @@ export interface ElectronAPI {
   gitLog: (cwd: string, maxCount?: number) => Promise<GitLogEntry[]>
   gitOutgoingCommits: (cwd: string) => Promise<GitLogEntry[]>
   gitIncomingCommits: (cwd: string) => Promise<GitLogEntry[]>
+  gitRangeFiles: (cwd: string, direction: 'incoming' | 'outgoing') => Promise<GitCommitFileStatus[]>
+  gitRangeDiff: (cwd: string, direction: 'incoming' | 'outgoing', filePath: string) => Promise<string>
   gitCommitFiles: (cwd: string, hash: string) => Promise<GitCommitFileStatus[]>
   gitCommitDiff: (cwd: string, hash: string, filePath: string) => Promise<string>
   gitGenerateCommitMessage: (cwd: string) => Promise<string>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -267,6 +267,10 @@ const electronAPI = {
   gitLog: (cwd: string, maxCount?: number) => ipcRenderer.invoke('git:log', cwd, maxCount),
   gitOutgoingCommits: (cwd: string) => ipcRenderer.invoke('git:outgoing-commits', cwd),
   gitIncomingCommits: (cwd: string) => ipcRenderer.invoke('git:incoming-commits', cwd),
+  gitRangeFiles: (cwd: string, direction: 'incoming' | 'outgoing') =>
+    ipcRenderer.invoke('git:range-files', cwd, direction),
+  gitRangeDiff: (cwd: string, direction: 'incoming' | 'outgoing', filePath: string) =>
+    ipcRenderer.invoke('git:range-diff', cwd, direction, filePath),
   gitCommitFiles: (cwd: string, hash: string) => ipcRenderer.invoke('git:commit-files', cwd, hash),
   gitCommitDiff: (cwd: string, hash: string, filePath: string) =>
     ipcRenderer.invoke('git:commit-diff', cwd, hash, filePath),

--- a/src/renderer/src/components/git/GitFileRows.tsx
+++ b/src/renderer/src/components/git/GitFileRows.tsx
@@ -292,28 +292,28 @@ export function GitTreeFileRow({
         </span>
       )}
       {!readOnly && (
-      <div className="ml-auto flex-shrink-0 flex items-center gap-0.5">
-        <button
-          className="btn-icon btn-icon-sm w-5 h-5 opacity-0 group-hover:opacity-100 hover:text-red-400 transition-opacity"
-          onClick={(e) => {
-            e.stopPropagation()
-            onDiscard?.()
-          }}
-          title="Discard changes"
-        >
-          <ArrowUturnLeftIcon className="w-3 h-3" />
-        </button>
-        <button
-          className="btn-icon btn-icon-sm w-5 h-5 opacity-0 group-hover:opacity-100 transition-opacity"
-          onClick={(e) => {
-            e.stopPropagation()
-            onStageToggle?.()
-          }}
-          title={isStaged ? 'Unstage' : 'Stage'}
-        >
-          {isStaged ? '\u2212' : '+'}
-        </button>
-      </div>
+        <div className="ml-auto flex-shrink-0 flex items-center gap-0.5">
+          <button
+            className="btn-icon btn-icon-sm w-5 h-5 opacity-0 group-hover:opacity-100 hover:text-red-400 transition-opacity"
+            onClick={(e) => {
+              e.stopPropagation()
+              onDiscard?.()
+            }}
+            title="Discard changes"
+          >
+            <ArrowUturnLeftIcon className="w-3 h-3" />
+          </button>
+          <button
+            className="btn-icon btn-icon-sm w-5 h-5 opacity-0 group-hover:opacity-100 transition-opacity"
+            onClick={(e) => {
+              e.stopPropagation()
+              onStageToggle?.()
+            }}
+            title={isStaged ? 'Unstage' : 'Stage'}
+          >
+            {isStaged ? '\u2212' : '+'}
+          </button>
+        </div>
       )}
     </div>
   )

--- a/src/renderer/src/components/git/GitFileRows.tsx
+++ b/src/renderer/src/components/git/GitFileRows.tsx
@@ -17,7 +17,8 @@ export function FileRow({
   onDiscard,
   onContextMenu,
   disabled,
-  selectedPaths
+  selectedPaths,
+  indentPx
 }: {
   file: GitFileStatus
   cwd: string
@@ -30,6 +31,8 @@ export function FileRow({
   onContextMenu?: (file: GitFileStatus, clientX: number, clientY: number) => void
   disabled?: boolean
   selectedPaths?: Set<string>
+  /** Left offset in px — sits the row one tree level under its section header (default 12 = px-3). */
+  indentPx?: number
 }) {
   const { name, dir } = splitPath(file.path)
   const isStaged = file.staged
@@ -72,9 +75,10 @@ export function FileRow({
 
   return (
     <div
-      className={`flex items-center gap-1.5 px-3 py-0.5 text-xs transition-colors cursor-pointer group ${
+      className={`flex items-center gap-1.5 pr-3 py-0.5 text-xs transition-colors cursor-pointer group ${
         disabled ? 'opacity-50 pointer-events-none' : isActiveDiff ? 'bg-accent/15 border-l-2 border-l-accent' : isSelected ? 'bg-surface-200 border-l-2 border-l-transparent' : 'hover:bg-surface-100 border-l-2 border-l-transparent'
       }`}
+      style={{ paddingLeft: indentPx ?? 12 }}
       onClick={handleClick}
       onContextMenu={handleContextMenu}
       draggable
@@ -118,13 +122,15 @@ export function GitTreeDirRow({
   cwd,
   isSelected,
   onToggle,
-  onSelect
+  onSelect,
+  baseIndentPx = 0
 }: {
   node: FlatGitTreeNode
   cwd: string
   isSelected?: boolean
   onToggle: (path: string) => void
   onSelect?: (path: string, metaKey: boolean) => void
+  baseIndentPx?: number
 }) {
   const handleClick = useCallback(
     (e: React.MouseEvent) => {
@@ -151,7 +157,7 @@ export function GitTreeDirRow({
       className={`flex items-center gap-1.5 py-0.5 text-xs transition-colors cursor-pointer pr-3 ${
         isSelected ? 'bg-surface-200' : 'hover:bg-surface-100'
       }`}
-      style={{ paddingLeft: `${8 + node.depth * 8}px` }}
+      style={{ paddingLeft: `${baseIndentPx + 8 + node.depth * 8}px` }}
       onClick={handleClick}
       draggable
       onDragStart={handleDragStart}
@@ -184,7 +190,8 @@ export function GitTreeFileRow({
   onDiscard,
   onContextMenu,
   disabled,
-  selectedPaths
+  selectedPaths,
+  baseIndentPx = 0
 }: {
   node: FlatGitTreeNode
   cwd: string
@@ -197,6 +204,7 @@ export function GitTreeFileRow({
   onContextMenu?: (file: GitFileStatus, clientX: number, clientY: number) => void
   disabled?: boolean
   selectedPaths?: Set<string>
+  baseIndentPx?: number
 }) {
   const file = node.file!
   const isStaged = file.staged
@@ -242,7 +250,7 @@ export function GitTreeFileRow({
       className={`flex items-center gap-1.5 py-0.5 text-xs transition-colors cursor-pointer group pr-3 ${
         disabled ? 'opacity-50 pointer-events-none' : isActiveDiff ? 'bg-accent/15 border-l-2 border-l-accent' : isSelected ? 'bg-surface-200 border-l-2 border-l-transparent' : 'hover:bg-surface-100 border-l-2 border-l-transparent'
       }`}
-      style={{ paddingLeft: `${8 + node.depth * 8}px` }}
+      style={{ paddingLeft: `${baseIndentPx + 8 + node.depth * 8}px` }}
       onClick={handleClick}
       onContextMenu={handleContextMenu}
       draggable
@@ -293,7 +301,8 @@ export function GitTreeSection({
   onStageToggle,
   onDiscard,
   onContextMenu,
-  disabled
+  disabled,
+  baseIndentPx = 0
 }: {
   files: GitFileStatus[]
   cwd: string
@@ -307,6 +316,8 @@ export function GitTreeSection({
   onDiscard: (file: GitFileStatus) => void
   onContextMenu?: (file: GitFileStatus, clientX: number, clientY: number) => void
   disabled?: boolean
+  /** Base left offset in px — sits the whole file tree under its section header. */
+  baseIndentPx?: number
 }) {
   const flatNodes = useMemo(() => {
     if (files.length === 0) return []
@@ -325,6 +336,7 @@ export function GitTreeSection({
             isSelected={selectedPaths.has(node.path)}
             onToggle={onToggleExpanded}
             onSelect={onSelect}
+            baseIndentPx={baseIndentPx}
           />
         ) : (
           <GitTreeFileRow
@@ -340,6 +352,7 @@ export function GitTreeSection({
             onContextMenu={onContextMenu}
             disabled={disabled}
             selectedPaths={selectedPaths}
+            baseIndentPx={baseIndentPx}
           />
         )
       )}

--- a/src/renderer/src/components/git/GitFileRows.tsx
+++ b/src/renderer/src/components/git/GitFileRows.tsx
@@ -18,7 +18,9 @@ export function FileRow({
   onContextMenu,
   disabled,
   selectedPaths,
-  indentPx
+  indentPx,
+  readOnly,
+  overlap
 }: {
   file: GitFileStatus
   cwd: string
@@ -33,6 +35,10 @@ export function FileRow({
   selectedPaths?: Set<string>
   /** Left offset in px — sits the row one tree level under its section header (default 12 = px-3). */
   indentPx?: number
+  /** Range-section rows (incoming/outgoing): no stage/discard affordances. */
+  readOnly?: boolean
+  /** The file also has local changes — the conflict heads-up before a pull. */
+  overlap?: boolean
 }) {
   const { name, dir } = splitPath(file.path)
   const isStaged = file.staged
@@ -91,28 +97,38 @@ export function FileRow({
         {name}
       </span>
       {dir && <span className="text-text-tertiary truncate text-[10px]">{dir}</span>}
-      <div className="ml-auto flex-shrink-0 flex items-center gap-0.5">
-        <button
-          className="btn-icon btn-icon-sm w-5 h-5 opacity-0 group-hover:opacity-100 hover:text-red-400 transition-opacity"
-          onClick={(e) => {
-            e.stopPropagation()
-            onDiscard?.()
-          }}
-          title="Discard changes"
+      {overlap && (
+        <span
+          className="text-orange-400 text-[10px] flex-shrink-0"
+          title="You also changed this file locally"
         >
-          <ArrowUturnLeftIcon className="w-3 h-3" />
-        </button>
-        <button
-          className="btn-icon btn-icon-sm w-5 h-5 opacity-0 group-hover:opacity-100 transition-opacity"
-          onClick={(e) => {
-            e.stopPropagation()
-            onStageToggle?.()
-          }}
-          title={isStaged ? 'Unstage' : 'Stage'}
-        >
-          {isStaged ? '\u2212' : '+'}
-        </button>
-      </div>
+          {'\u26a0'}
+        </span>
+      )}
+      {!readOnly && (
+        <div className="ml-auto flex-shrink-0 flex items-center gap-0.5">
+          <button
+            className="btn-icon btn-icon-sm w-5 h-5 opacity-0 group-hover:opacity-100 hover:text-red-400 transition-opacity"
+            onClick={(e) => {
+              e.stopPropagation()
+              onDiscard?.()
+            }}
+            title="Discard changes"
+          >
+            <ArrowUturnLeftIcon className="w-3 h-3" />
+          </button>
+          <button
+            className="btn-icon btn-icon-sm w-5 h-5 opacity-0 group-hover:opacity-100 transition-opacity"
+            onClick={(e) => {
+              e.stopPropagation()
+              onStageToggle?.()
+            }}
+            title={isStaged ? 'Unstage' : 'Stage'}
+          >
+            {isStaged ? '\u2212' : '+'}
+          </button>
+        </div>
+      )}
     </div>
   )
 }
@@ -191,7 +207,9 @@ export function GitTreeFileRow({
   onContextMenu,
   disabled,
   selectedPaths,
-  baseIndentPx = 0
+  baseIndentPx = 0,
+  readOnly,
+  overlap
 }: {
   node: FlatGitTreeNode
   cwd: string
@@ -205,6 +223,8 @@ export function GitTreeFileRow({
   disabled?: boolean
   selectedPaths?: Set<string>
   baseIndentPx?: number
+  readOnly?: boolean
+  overlap?: boolean
 }) {
   const file = node.file!
   const isStaged = file.staged
@@ -263,6 +283,15 @@ export function GitTreeFileRow({
       <span className="text-text-primary truncate hover:underline">
         {node.name}
       </span>
+      {overlap && (
+        <span
+          className="text-orange-400 text-[10px] flex-shrink-0"
+          title="You also changed this file locally"
+        >
+          {'\u26a0'}
+        </span>
+      )}
+      {!readOnly && (
       <div className="ml-auto flex-shrink-0 flex items-center gap-0.5">
         <button
           className="btn-icon btn-icon-sm w-5 h-5 opacity-0 group-hover:opacity-100 hover:text-red-400 transition-opacity"
@@ -285,6 +314,7 @@ export function GitTreeFileRow({
           {isStaged ? '\u2212' : '+'}
         </button>
       </div>
+      )}
     </div>
   )
 }
@@ -302,7 +332,9 @@ export function GitTreeSection({
   onDiscard,
   onContextMenu,
   disabled,
-  baseIndentPx = 0
+  baseIndentPx = 0,
+  readOnly,
+  overlapPaths
 }: {
   files: GitFileStatus[]
   cwd: string
@@ -318,6 +350,10 @@ export function GitTreeSection({
   disabled?: boolean
   /** Base left offset in px — sits the whole file tree under its section header. */
   baseIndentPx?: number
+  /** Range sections (incoming/outgoing): rows carry no stage/discard affordances. */
+  readOnly?: boolean
+  /** Files that also have local changes — flagged on their rows. */
+  overlapPaths?: Set<string>
 }) {
   const flatNodes = useMemo(() => {
     if (files.length === 0) return []
@@ -353,6 +389,8 @@ export function GitTreeSection({
             disabled={disabled}
             selectedPaths={selectedPaths}
             baseIndentPx={baseIndentPx}
+            readOnly={readOnly}
+            overlap={overlapPaths?.has(node.file?.path ?? node.path)}
           />
         )
       )}

--- a/src/renderer/src/components/git/GitPanelControls.tsx
+++ b/src/renderer/src/components/git/GitPanelControls.tsx
@@ -11,7 +11,8 @@ export function SectionHeader({
   onAction,
   discardAction,
   onDiscardAction,
-  disabled
+  disabled,
+  indentPx
 }: {
   label: string
   count: number
@@ -20,9 +21,11 @@ export function SectionHeader({
   discardAction?: string
   onDiscardAction?: () => void
   disabled?: boolean
+  /** Left offset in px — lets the header sit at its tree depth (default 12 = px-3). */
+  indentPx?: number
 }) {
   return (
-    <div className="flex items-center px-3 py-1.5">
+    <div className="flex items-center pr-3 py-1.5" style={{ paddingLeft: indentPx ?? 12 }}>
       <span className="text-[10px] font-semibold uppercase tracking-wider text-text-tertiary">
         {label} ({count})
       </span>

--- a/src/renderer/src/components/git/GitStatusPanel.tsx
+++ b/src/renderer/src/components/git/GitStatusPanel.tsx
@@ -50,6 +50,148 @@ function formatUpdatedAt(ts: number): string {
 }
 
 // ---------------------------------------------------------------------------
+// RangeSection — the aggregate file list of a sync range (PRDCT-1539/1679):
+// incoming = what a pull will bring, outgoing = what a push will send.
+// Rendered like the other sections (same indentation, list|tree toggle),
+// read-only rows, ⚠ on files that also have local changes.
+// ---------------------------------------------------------------------------
+
+// Range diffs report letter statuses; the row components speak the word union.
+const RANGE_STATUS_WORD: Record<string, GitFileStatus['status']> = {
+  A: 'staged',
+  M: 'modified',
+  D: 'deleted',
+  R: 'renamed',
+  T: 'modified',
+  C: 'staged'
+}
+
+function RangeSection({
+  cwd,
+  direction,
+  sectionIndentPx,
+  fileIndentPx,
+  treeBaseIndentPx,
+  localPaths,
+  refreshTick,
+  onSync,
+  operating
+}: {
+  cwd: string
+  direction: 'incoming' | 'outgoing'
+  sectionIndentPx: number
+  fileIndentPx: number
+  treeBaseIndentPx: number
+  /** Paths with local changes — flagged on overlapping range rows. */
+  localPaths: Set<string>
+  /** Bump to refetch — tied to ahead/behind so the list follows the fetch cycle. */
+  refreshTick: number
+  onSync: () => void
+  operating: boolean
+}): React.JSX.Element | null {
+  const gitViewMode = useSessionStore((s) => s.gitViewMode)
+  const setDiffPreview = useSessionStore((s) => s.setDiffPreview)
+  const diffPreview = useSessionStore((s) => s.diffPreview)
+  const [files, setFiles] = useState<GitFileStatus[] | null>(null)
+  const [treeExpanded, setTreeExpanded] = useState<Set<string>>(new Set())
+
+  useEffect(() => {
+    let cancelled = false
+    window.electronAPI.gitRangeFiles(cwd, direction).then((raw) => {
+      if (cancelled) return
+      const mapped: GitFileStatus[] = raw.map((f) => ({
+        path: f.path,
+        status: RANGE_STATUS_WORD[f.status] ?? 'modified',
+        staged: false
+      }))
+      setFiles(mapped)
+      setTreeExpanded(collectAllDirPaths(compactTree(buildGitTree(mapped))))
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [cwd, direction, refreshTick])
+
+  const openRangeDiff = useCallback(
+    (file: GitFileStatus, clickY?: number) => {
+      setDiffPreview({
+        file: file.path,
+        cwd,
+        type: direction,
+        staged: false,
+        fileStatus: file.status,
+        hash: null,
+        siblings: (files ?? []).map((f) => ({ file: f.path, staged: false, fileStatus: f.status })),
+        clickY
+      })
+    },
+    [setDiffPreview, cwd, direction, files]
+  )
+
+  const toggleTreeDir = useCallback((path: string) => {
+    setTreeExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(path)) next.delete(path)
+      else next.add(path)
+      return next
+    })
+  }, [])
+
+  if (!files || files.length === 0) return null
+  const activeDiffFile =
+    diffPreview && diffPreview.cwd === cwd && diffPreview.type === direction
+      ? diffPreview.file
+      : null
+
+  return (
+    <>
+      <SectionHeader
+        label={direction === 'incoming' ? 'Incoming' : 'Outgoing'}
+        indentPx={sectionIndentPx}
+        count={files.length}
+        action={direction === 'incoming' ? 'Pull' : 'Push'}
+        onAction={onSync}
+        disabled={operating}
+      />
+      {gitViewMode === 'tree' ? (
+        <GitTreeSection
+          baseIndentPx={treeBaseIndentPx}
+          files={files}
+          cwd={cwd}
+          selectedPaths={EMPTY_PATH_SET}
+          expandedPaths={treeExpanded}
+          activeDiffFile={activeDiffFile}
+          onToggleExpanded={toggleTreeDir}
+          onClickFile={openRangeDiff}
+          onSelect={() => {}}
+          onStageToggle={() => {}}
+          onDiscard={() => {}}
+          disabled={operating}
+          readOnly
+          overlapPaths={localPaths}
+        />
+      ) : (
+        files.map((f) => (
+          <FileRow
+            key={`${direction}-${f.path}`}
+            indentPx={fileIndentPx}
+            file={f}
+            cwd={cwd}
+            isActiveDiff={activeDiffFile === f.path}
+            onClickName={(clickY) => openRangeDiff(f, clickY)}
+            disabled={operating}
+            readOnly
+            overlap={localPaths.has(f.path)}
+          />
+        ))
+      )}
+    </>
+  )
+}
+
+const EMPTY_PATH_SET = new Set<string>()
+
+// ---------------------------------------------------------------------------
 // RepoSection — reusable file list + commit bar + diff view for a single repo
 // ---------------------------------------------------------------------------
 
@@ -59,7 +201,9 @@ function RepoSection({
   filterPrefix,
   refresh,
   fillHeight = true,
-  depth = 0
+  depth = 0,
+  showIncoming = false,
+  showOutgoing = false
 }: {
   cwd: string
   status: GitStatusResult
@@ -69,6 +213,10 @@ function RepoSection({
   /** Tree level of the section headers — files sit one level deeper, so the
    *  repo's content continues the spatial tree's indentation. */
   depth?: number
+  /** Unfold the aggregate pull preview (opened by the ↓ badge-button). */
+  showIncoming?: boolean
+  /** Unfold the aggregate push preview (opened by the ↑ badge-button). */
+  showOutgoing?: boolean
 }) {
   const sectionIndentPx = 12 + depth * TREE_INDENT_PX
   const fileIndentPx = sectionIndentPx + TREE_INDENT_PX
@@ -383,6 +531,41 @@ function RepoSection({
 
   const totalFiltered = staged.length + unstaged.length + untracked.length
 
+  const localPaths = useMemo(() => new Set(status.files.map((f) => f.path)), [status.files])
+
+  // The sync-range sections (aggregate pull/push previews), opened by the
+  // ↓/↑ badge-buttons; rendered in both the clean and the dirty layout.
+  const rangeSections = (
+    <>
+      {showIncoming && status.behind > 0 && (
+        <RangeSection
+          cwd={repoRoot}
+          direction="incoming"
+          sectionIndentPx={sectionIndentPx}
+          fileIndentPx={fileIndentPx}
+          treeBaseIndentPx={treeBaseIndentPx}
+          localPaths={localPaths}
+          refreshTick={status.behind}
+          onSync={() => runOperation(() => window.electronAPI.gitPull(cwd))}
+          operating={operating}
+        />
+      )}
+      {showOutgoing && status.ahead > 0 && (
+        <RangeSection
+          cwd={repoRoot}
+          direction="outgoing"
+          sectionIndentPx={sectionIndentPx}
+          fileIndentPx={fileIndentPx}
+          treeBaseIndentPx={treeBaseIndentPx}
+          localPaths={localPaths}
+          refreshTick={status.ahead}
+          onSync={() => runOperation(() => window.electronAPI.gitPush(cwd))}
+          operating={operating}
+        />
+      )}
+    </>
+  )
+
   // Clean state
   if (status.files.length === 0 || (relativeFilterPrefix && totalFiltered === 0)) {
     return (
@@ -393,6 +576,7 @@ function RepoSection({
             {relativeFilterPrefix ? 'No changes in this folder' : 'Working tree clean'}
           </span>
         </div>
+        {rangeSections}
         {gitShowCommitBar && (status.ahead > 0 || status.behind > 0 || (!status.hasUpstream && !!status.branch)) && (
           <CommitBar
             cwd={cwd}
@@ -567,6 +751,7 @@ function RepoSection({
             )}
           </>
         )}
+        {rangeSections}
       </div>
       {gitShowCommitBar && (
         <CommitBar
@@ -609,13 +794,18 @@ export function GitStatusPanel({
   isActive,
   filterPrefix,
   externalStatus,
-  externalRefresh
+  externalRefresh,
+  showIncoming = false,
+  showOutgoing = false
 }: {
   cwd: string | null
   isActive: boolean
   filterPrefix?: string | null
   externalStatus?: GitStatusResult | null
   externalRefresh?: () => void
+  /** Single-repo mode: the toolbar's ↓/↑ badge-buttons drive these. */
+  showIncoming?: boolean
+  showOutgoing?: boolean
 }) {
   const focusedSessionId = useSessionStore((s) => s.focusedSessionId)
   const gitPanelMode = useSessionStore((s) => s.gitPanelMode)
@@ -662,7 +852,15 @@ export function GitStatusPanel({
           behind={status.behind}
         />
       ) : (
-        <RepoSection cwd={cwd} status={status} filterPrefix={filterPrefix} refresh={refresh} fillHeight />
+        <RepoSection
+          cwd={cwd}
+          status={status}
+          filterPrefix={filterPrefix}
+          refresh={refresh}
+          fillHeight
+          showIncoming={showIncoming}
+          showOutgoing={showOutgoing}
+        />
       )}
     </div>
   )
@@ -707,7 +905,23 @@ function MultiRepoSection({
   const parentRepoName = isParentRepo ? status.repoRoot.split(/[\\/]/).pop() || status.repoRoot : ''
   const shouldExpand = hasChanges || hasRemoteChanges
   const [expanded, setExpanded] = useState(shouldExpand)
+  const [showIncoming, setShowIncoming] = useState(false)
+  const [showOutgoing, setShowOutgoing] = useState(false)
   const initializedRef = useRef(false)
+
+  // The ↓/↑ badges are buttons: they unfold the aggregate pull/push preview
+  // inside the repo's content (and open the repo if it was folded).
+  const toggleRange = useCallback(
+    (e: React.MouseEvent, direction: 'incoming' | 'outgoing') => {
+      e.stopPropagation()
+      const setter = direction === 'incoming' ? setShowIncoming : setShowOutgoing
+      setter((prev) => {
+        if (!prev) setExpanded(true)
+        return !prev
+      })
+    },
+    []
+  )
 
   // Update default expanded state when changes appear/disappear, but only on first load
   useEffect(() => {
@@ -792,15 +1006,33 @@ function MultiRepoSection({
         {/* Branch badge */}
         <span className="text-text-tertiary truncate">{status.branch}</span>
 
-        {/* Badges (right-aligned) */}
+        {/* Badges (right-aligned) — ↓/↑ are buttons opening the range sections */}
         <span className="ml-auto flex-shrink-0 flex items-center gap-1.5">
           {status.behind > 0 && (
-            <span className="text-[10px] font-medium text-orange-400">
+            <span
+              role="button"
+              title="Show what a pull will bring"
+              onClick={(e) => toggleRange(e, 'incoming')}
+              className={`text-[10px] font-medium text-orange-400 px-1 py-px rounded border cursor-pointer transition-colors ${
+                showIncoming
+                  ? 'border-orange-400/60 bg-orange-400/15'
+                  : 'border-orange-400/30 hover:bg-orange-400/15 hover:border-orange-400/60'
+              }`}
+            >
               {'\u2193'}{status.behind}
             </span>
           )}
           {status.ahead > 0 && (
-            <span className="text-[10px] font-medium text-green-400">
+            <span
+              role="button"
+              title="Show what a push will send"
+              onClick={(e) => toggleRange(e, 'outgoing')}
+              className={`text-[10px] font-medium text-green-400 px-1 py-px rounded border cursor-pointer transition-colors ${
+                showOutgoing
+                  ? 'border-green-400/60 bg-green-400/15'
+                  : 'border-green-400/30 hover:bg-green-400/15 hover:border-green-400/60'
+              }`}
+            >
               {'\u2191'}{status.ahead}
             </span>
           )}
@@ -847,6 +1079,8 @@ function MultiRepoSection({
               refresh={refresh}
               fillHeight={false}
               depth={depth + 1}
+              showIncoming={showIncoming}
+              showOutgoing={showOutgoing}
             />
           )}
         </div>

--- a/src/renderer/src/components/git/GitStatusPanel.tsx
+++ b/src/renderer/src/components/git/GitStatusPanel.tsx
@@ -74,7 +74,7 @@ function RangeSection({
   treeBaseIndentPx,
   localPaths,
   refreshTick,
-  onSync,
+  hasUpstream,
   operating
 }: {
   cwd: string
@@ -86,7 +86,8 @@ function RangeSection({
   localPaths: Set<string>
   /** Bump to refetch — tied to ahead/behind so the list follows the fetch cycle. */
   refreshTick: number
-  onSync: () => void
+  /** Names the honest empty state: no upstream means nothing to compare against. */
+  hasUpstream: boolean
   operating: boolean
 }): React.JSX.Element | null {
   const gitViewMode = useSessionStore((s) => s.gitViewMode)
@@ -137,23 +138,34 @@ function RangeSection({
     })
   }, [])
 
-  if (!files || files.length === 0) return null
+  // Still loading — the header lands on the next tick.
+  if (!files) return null
+
   const activeDiffFile =
     diffPreview && diffPreview.cwd === cwd && diffPreview.type === direction
       ? diffPreview.file
       : null
 
+  // View-only surface: no Pull/Push here (a click must never sync — the
+  // toolbar's sync buttons are the action path). An empty result renders an
+  // honest explanation instead of silence.
   return (
     <>
       <SectionHeader
         label={direction === 'incoming' ? 'Incoming' : 'Outgoing'}
         indentPx={sectionIndentPx}
         count={files.length}
-        action={direction === 'incoming' ? 'Pull' : 'Push'}
-        onAction={onSync}
         disabled={operating}
       />
-      {gitViewMode === 'tree' ? (
+      {files.length === 0 ? (
+        <div className="pr-3 py-1 text-[11px] text-text-tertiary" style={{ paddingLeft: fileIndentPx }}>
+          {hasUpstream
+            ? direction === 'incoming'
+              ? 'Nothing incoming — up to date with the remote.'
+              : 'Nothing to push.'
+            : 'This branch has no published counterpart to compare against yet.'}
+        </div>
+      ) : gitViewMode === 'tree' ? (
         <GitTreeSection
           baseIndentPx={treeBaseIndentPx}
           files={files}
@@ -546,7 +558,7 @@ function RepoSection({
           treeBaseIndentPx={treeBaseIndentPx}
           localPaths={localPaths}
           refreshTick={status.behind}
-          onSync={() => runOperation(() => window.electronAPI.gitPull(cwd))}
+          hasUpstream={status.hasUpstream}
           operating={operating}
         />
       )}
@@ -559,7 +571,7 @@ function RepoSection({
           treeBaseIndentPx={treeBaseIndentPx}
           localPaths={localPaths}
           refreshTick={status.ahead}
-          onSync={() => runOperation(() => window.electronAPI.gitPush(cwd))}
+          hasUpstream={status.hasUpstream}
           operating={operating}
         />
       )}

--- a/src/renderer/src/components/git/GitStatusPanel.tsx
+++ b/src/renderer/src/components/git/GitStatusPanel.tsx
@@ -583,12 +583,16 @@ function RepoSection({
     return (
       <>
         {error && <ErrorBanner message={error} />}
-        <div className={`${fillHeight ? 'flex-1' : ''} flex items-center justify-center px-3 py-4`}>
-          <span className="text-xs text-text-tertiary text-center">
-            {relativeFilterPrefix ? 'No changes in this folder' : 'Working tree clean'}
-          </span>
+        {/* Scroll container — a long range list must scroll here exactly as
+            it does in the dirty layout (verifier round 4, finding 1). */}
+        <div className={`${fillHeight ? 'flex-1 overflow-y-auto' : ''} flex flex-col`}>
+          <div className={`${fillHeight ? 'flex-1' : ''} flex items-center justify-center px-3 py-4`}>
+            <span className="text-xs text-text-tertiary text-center">
+              {relativeFilterPrefix ? 'No changes in this folder' : 'Working tree clean'}
+            </span>
+          </div>
+          {rangeSections}
         </div>
-        {rangeSections}
         {gitShowCommitBar && (status.ahead > 0 || status.behind > 0 || (!status.hasUpstream && !!status.branch)) && (
           <CommitBar
             cwd={cwd}
@@ -926,13 +930,19 @@ function MultiRepoSection({
   const toggleRange = useCallback(
     (e: React.MouseEvent, direction: 'incoming' | 'outgoing') => {
       e.stopPropagation()
+      const isOpen = direction === 'incoming' ? showIncoming : showOutgoing
       const setter = direction === 'incoming' ? setShowIncoming : setShowOutgoing
-      setter((prev) => {
-        if (!prev) setExpanded(true)
-        return !prev
-      })
+      if (!isOpen) {
+        setter(true)
+        setExpanded(true)
+      } else if (!expanded) {
+        // Section already on but the repo is folded: reveal, don't toggle off.
+        setExpanded(true)
+      } else {
+        setter(false)
+      }
     },
-    []
+    [showIncoming, showOutgoing, expanded]
   )
 
   // Update default expanded state when changes appear/disappear, but only on first load
@@ -1023,8 +1033,15 @@ function MultiRepoSection({
           {status.behind > 0 && (
             <span
               role="button"
+              tabIndex={0}
               title="Show what a pull will bring"
               onClick={(e) => toggleRange(e, 'incoming')}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  toggleRange(e as unknown as React.MouseEvent, 'incoming')
+                }
+              }}
               className={`text-[10px] font-medium text-orange-400 px-1 py-px rounded border cursor-pointer transition-colors ${
                 showIncoming
                   ? 'border-orange-400/60 bg-orange-400/15'
@@ -1037,8 +1054,15 @@ function MultiRepoSection({
           {status.ahead > 0 && (
             <span
               role="button"
+              tabIndex={0}
               title="Show what a push will send"
               onClick={(e) => toggleRange(e, 'outgoing')}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  toggleRange(e as unknown as React.MouseEvent, 'outgoing')
+                }
+              }}
               className={`text-[10px] font-medium text-green-400 px-1 py-px rounded border cursor-pointer transition-colors ${
                 showOutgoing
                   ? 'border-green-400/60 bg-green-400/15'

--- a/src/renderer/src/components/git/GitStatusPanel.tsx
+++ b/src/renderer/src/components/git/GitStatusPanel.tsx
@@ -1036,6 +1036,7 @@ function MultiRepoSection({
               tabIndex={0}
               title="Show what a pull will bring"
               onClick={(e) => toggleRange(e, 'incoming')}
+              onDoubleClick={(e) => e.stopPropagation()}
               onKeyDown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault()
@@ -1057,6 +1058,7 @@ function MultiRepoSection({
               tabIndex={0}
               title="Show what a push will send"
               onClick={(e) => toggleRange(e, 'outgoing')}
+              onDoubleClick={(e) => e.stopPropagation()}
               onKeyDown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault()

--- a/src/renderer/src/components/git/GitStatusPanel.tsx
+++ b/src/renderer/src/components/git/GitStatusPanel.tsx
@@ -58,14 +58,21 @@ function RepoSection({
   status,
   filterPrefix,
   refresh,
-  fillHeight = true
+  fillHeight = true,
+  depth = 0
 }: {
   cwd: string
   status: GitStatusResult
   filterPrefix?: string | null
   refresh: () => void
   fillHeight?: boolean
+  /** Tree level of the section headers — files sit one level deeper, so the
+   *  repo's content continues the spatial tree's indentation. */
+  depth?: number
 }) {
+  const sectionIndentPx = 12 + depth * TREE_INDENT_PX
+  const fileIndentPx = sectionIndentPx + TREE_INDENT_PX
+  const treeBaseIndentPx = (depth + 1) * TREE_INDENT_PX
   const gitViewMode = useSessionStore((s) => s.gitViewMode)
   const gitShowCommitBar = useSessionStore((s) => s.gitShowCommitBar)
   const setDiffPreview = useSessionStore((s) => s.setDiffPreview)
@@ -417,6 +424,7 @@ function RepoSection({
           <>
             <SectionHeader
               label="Staged"
+              indentPx={sectionIndentPx}
               count={staged.length}
               action="Unstage All"
               onAction={unstageAll}
@@ -426,6 +434,7 @@ function RepoSection({
             />
             {gitViewMode === 'tree' ? (
               <GitTreeSection
+                baseIndentPx={treeBaseIndentPx}
                 files={staged}
                 cwd={repoRoot}
                 selectedPaths={selectedPaths}
@@ -443,6 +452,7 @@ function RepoSection({
               staged.map((f) => (
                 <FileRow
                   key={`s-${f.path}`}
+                  indentPx={fileIndentPx}
                   file={f}
                   cwd={repoRoot}
                   isSelected={selectedPaths.has(f.path)}
@@ -463,6 +473,7 @@ function RepoSection({
           <>
             <SectionHeader
               label="Modified"
+              indentPx={sectionIndentPx}
               count={unstaged.length}
               action="Stage All"
               onAction={() => stageAll(unstaged)}
@@ -472,6 +483,7 @@ function RepoSection({
             />
             {gitViewMode === 'tree' ? (
               <GitTreeSection
+                baseIndentPx={treeBaseIndentPx}
                 files={unstaged}
                 cwd={repoRoot}
                 selectedPaths={selectedPaths}
@@ -489,6 +501,7 @@ function RepoSection({
               unstaged.map((f) => (
                 <FileRow
                   key={`u-${f.path}`}
+                  indentPx={fileIndentPx}
                   file={f}
                   cwd={repoRoot}
                   isSelected={selectedPaths.has(f.path)}
@@ -509,6 +522,7 @@ function RepoSection({
           <>
             <SectionHeader
               label="Untracked"
+              indentPx={sectionIndentPx}
               count={untracked.length}
               action="Stage All"
               onAction={() => stageAll(untracked)}
@@ -518,6 +532,7 @@ function RepoSection({
             />
             {gitViewMode === 'tree' ? (
               <GitTreeSection
+                baseIndentPx={treeBaseIndentPx}
                 files={untracked}
                 cwd={repoRoot}
                 selectedPaths={selectedPaths}
@@ -535,6 +550,7 @@ function RepoSection({
               untracked.map((f) => (
                 <FileRow
                   key={`t-${f.path}`}
+                  indentPx={fileIndentPx}
                   file={f}
                   cwd={repoRoot}
                   isSelected={selectedPaths.has(f.path)}
@@ -830,6 +846,7 @@ function MultiRepoSection({
               status={status}
               refresh={refresh}
               fillHeight={false}
+              depth={depth + 1}
             />
           )}
         </div>

--- a/src/renderer/src/components/git/SidePanel.tsx
+++ b/src/renderer/src/components/git/SidePanel.tsx
@@ -137,6 +137,10 @@ export function SidePanel() {
   const isSingleRepo = isGitTabActive && multiRepo.result.mode === 'single'
   const singleRepoGit = useGitStatus(isSingleRepo ? cwd : null, isSingleRepo)
 
+  // Single-repo range sections, driven by the toolbar's ↓/↑ badge-buttons
+  const [showIncomingSingle, setShowIncomingSingle] = useState(false)
+  const [showOutgoingSingle, setShowOutgoingSingle] = useState(false)
+
   // Compute repo paths for MagicSync across all git modes
   const allRepoPaths = useMemo(() => {
     if (multiRepo.result.mode === 'multi') return multiRepo.result.repos.map((r) => r.path)
@@ -430,10 +434,28 @@ export function SidePanel() {
               </svg>
               <span className="truncate">{singleRepoGit.status.branch}</span>
               {singleRepoGit.status.ahead > 0 && (
-                <span className="text-green-400 text-[10px] flex-shrink-0">{'\u2191'}{singleRepoGit.status.ahead}</span>
+                <span
+                  role="button"
+                  title="Show what a push will send"
+                  onClick={() => setShowOutgoingSingle((v) => !v)}
+                  className={`text-green-400 text-[10px] flex-shrink-0 px-1 py-px rounded border cursor-pointer transition-colors ${
+                    showOutgoingSingle
+                      ? 'border-green-400/60 bg-green-400/15'
+                      : 'border-green-400/30 hover:bg-green-400/15 hover:border-green-400/60'
+                  }`}
+                >{'\u2191'}{singleRepoGit.status.ahead}</span>
               )}
               {singleRepoGit.status.behind > 0 && (
-                <span className="text-orange-400 text-[10px] flex-shrink-0">{'\u2193'}{singleRepoGit.status.behind}</span>
+                <span
+                  role="button"
+                  title="Show what a pull will bring"
+                  onClick={() => setShowIncomingSingle((v) => !v)}
+                  className={`text-orange-400 text-[10px] flex-shrink-0 px-1 py-px rounded border cursor-pointer transition-colors ${
+                    showIncomingSingle
+                      ? 'border-orange-400/60 bg-orange-400/15'
+                      : 'border-orange-400/30 hover:bg-orange-400/15 hover:border-orange-400/60'
+                  }`}
+                >{'\u2193'}{singleRepoGit.status.behind}</span>
               )}
             </span>
           )}
@@ -514,6 +536,8 @@ export function SidePanel() {
                 filterPrefix={isNavigatedSubfolder ? cwd : null}
                 externalStatus={singleRepoGit.status}
                 externalRefresh={singleRepoGit.refresh}
+                showIncoming={showIncomingSingle}
+                showOutgoing={showOutgoingSingle}
               />
             )
           )}

--- a/src/renderer/src/components/git/SidePanel.tsx
+++ b/src/renderer/src/components/git/SidePanel.tsx
@@ -137,9 +137,16 @@ export function SidePanel() {
   const isSingleRepo = isGitTabActive && multiRepo.result.mode === 'single'
   const singleRepoGit = useGitStatus(isSingleRepo ? cwd : null, isSingleRepo)
 
-  // Single-repo range sections, driven by the toolbar's ↓/↑ badge-buttons
+  // Single-repo range sections, driven by the toolbar's ↓/↑ badge-buttons.
+  // Per-repo state: a folder switch resets it (guarded adjust-during-render).
   const [showIncomingSingle, setShowIncomingSingle] = useState(false)
   const [showOutgoingSingle, setShowOutgoingSingle] = useState(false)
+  const [prevRangeCwd, setPrevRangeCwd] = useState(cwd)
+  if (prevRangeCwd !== cwd) {
+    setPrevRangeCwd(cwd)
+    setShowIncomingSingle(false)
+    setShowOutgoingSingle(false)
+  }
 
   // Compute repo paths for MagicSync across all git modes
   const allRepoPaths = useMemo(() => {
@@ -436,8 +443,15 @@ export function SidePanel() {
               {singleRepoGit.status.ahead > 0 && (
                 <span
                   role="button"
+                  tabIndex={0}
                   title="Show what a push will send"
                   onClick={() => setShowOutgoingSingle((v) => !v)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      setShowOutgoingSingle((v) => !v)
+                    }
+                  }}
                   className={`text-green-400 text-[10px] flex-shrink-0 px-1 py-px rounded border cursor-pointer transition-colors ${
                     showOutgoingSingle
                       ? 'border-green-400/60 bg-green-400/15'
@@ -448,8 +462,15 @@ export function SidePanel() {
               {singleRepoGit.status.behind > 0 && (
                 <span
                   role="button"
+                  tabIndex={0}
                   title="Show what a pull will bring"
                   onClick={() => setShowIncomingSingle((v) => !v)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      setShowIncomingSingle((v) => !v)
+                    }
+                  }}
                   className={`text-orange-400 text-[10px] flex-shrink-0 px-1 py-px rounded border cursor-pointer transition-colors ${
                     showIncomingSingle
                       ? 'border-orange-400/60 bg-orange-400/15'

--- a/src/renderer/src/help/git.md
+++ b/src/renderer/src/help/git.md
@@ -39,7 +39,7 @@ Click any file in the git panel to see a side-by-side diff with syntax highlight
 
 ## Incoming and Outgoing
 
-The ↓ and ↑ counters on a repo are buttons: ↓ unfolds an **Incoming** section showing every file a pull will bring (all remote commits rolled into one list), ↑ an **Outgoing** section with what a push will send. Rows are read-only — click one to see the net diff — and a ⚠ marks files you also changed locally, your conflict heads-up before pulling. Each section header carries the matching Pull or Push action.
+The ↓ and ↑ counters on a repo are buttons: ↓ unfolds an **Incoming** section showing every file a pull will bring (all remote commits rolled into one list), ↑ an **Outgoing** section with what a push will send. Rows are read-only — click one to see the net diff — and a ⚠ marks files you also changed locally, your conflict heads-up before pulling. The sections are a pure viewing surface: syncing stays in the toolbar's pull and sync buttons.
 
 ## Push and Pull
 

--- a/src/renderer/src/help/git.md
+++ b/src/renderer/src/help/git.md
@@ -37,6 +37,10 @@ Click the sparkle icon next to the commit input to generate a commit message bas
 
 Click any file in the git panel to see a side-by-side diff with syntax highlighting.
 
+## Incoming and Outgoing
+
+The ↓ and ↑ counters on a repo are buttons: ↓ unfolds an **Incoming** section showing every file a pull will bring (all remote commits rolled into one list), ↑ an **Outgoing** section with what a push will send. Rows are read-only — click one to see the net diff — and a ⚠ marks files you also changed locally, your conflict heads-up before pulling. Each section header carries the matching Pull or Push action.
+
 ## Push and Pull
 
 - **Push**: Send your commits to the remote

--- a/src/renderer/src/help/whats-new.json
+++ b/src/renderer/src/help/whats-new.json
@@ -2,7 +2,7 @@
   {
     "version": "1.68.0",
     "title": "The git panel is your real folder tree",
-    "description": "Repos now sit exactly where they live on disk — nested under their real parent folders, single-child chains merged into one row, folders foldable with rolled-up change counts and ahead/behind badges so nothing hides while folded. And the commit bar is tucked away by default (agents do the committing) — the pencil icon in the git toolbar brings it back.",
+    "description": "Repos now sit exactly where they live on disk — nested under their real parent folders, single-child chains merged into one row, folders foldable with rolled-up change counts and ahead/behind badges. The ↓ and ↑ counters are buttons: they unfold Incoming and Outgoing sections — every file a pull will bring or a push will send, rolled into one read-only list with net diffs and a ⚠ on files you also changed locally. And the commit bar is tucked away by default (agents do the committing) — the pencil icon brings it back.",
     "action": {
       "type": "navigate",
       "target": "side:git"

--- a/src/renderer/src/hooks/use-diff.ts
+++ b/src/renderer/src/hooks/use-diff.ts
@@ -4,7 +4,7 @@ import { parseDiffLines, type DiffLine } from '../lib/diff-utils'
 export interface UseDiffArgs {
   cwd: string
   file: string
-  type: 'working' | 'commit'
+  type: 'working' | 'commit' | 'incoming' | 'outgoing'
   staged: boolean
   fileStatus: string
   hash: string | null
@@ -46,7 +46,9 @@ export function useDiff({
     const fetch = async (): Promise<void> => {
       try {
         let result: string
-        if (type === 'commit' && hash) {
+        if (type === 'incoming' || type === 'outgoing') {
+          result = await window.electronAPI.gitRangeDiff(cwd, type, file)
+        } else if (type === 'commit' && hash) {
           result = await window.electronAPI.gitCommitDiff(cwd, hash, file)
         } else {
           const isUntracked = fileStatus === 'untracked'

--- a/src/renderer/src/store/session-store.ts
+++ b/src/renderer/src/store/session-store.ts
@@ -68,7 +68,7 @@ interface SessionState {
   previewCwd: string | null
   previewSource: 'palette' | 'tree' | null
   previewLocationId: string | null
-  diffPreview: { file: string, cwd: string, type: 'working' | 'commit', staged: boolean, fileStatus: string, hash: string | null, siblings?: Array<{ file: string; staged: boolean; fileStatus: string }>, clickY?: number } | null
+  diffPreview: { file: string, cwd: string, type: 'working' | 'commit' | 'incoming' | 'outgoing', staged: boolean, fileStatus: string, hash: string | null, siblings?: Array<{ file: string; staged: boolean; fileStatus: string }>, clickY?: number } | null
   gitRefreshTrigger: number
   collapseAllTrigger: number
   activeView: ActiveView


### PR DESCRIPTION
## What

Second batch of the git-panel spatial workstream, driven live by Romain on the dev instance:

- **Tree-indented repo content** (PRDCT-1678): section headers sit one tree level under their repo row, files one under their header — the same 12px step as the folder tree, in list and tree view, at any depth.
- **Incoming/Outgoing sections** (PRDCT-1539 + PRDCT-1679): the ↓/↑ counters are buttons that unfold read-only aggregate file lists — everything a pull will bring or a push will send (net effect, `HEAD...<tracking>` / `<tracking>...HEAD` against the branch's REAL tracking ref), rendered like the other sections, ⚠ on files also changed locally, click → net diff. Pure viewing surface: no sync actions in the sections (deliberate, after live user testing); empty ranges explain themselves (up to date / branch not published). New `git:range-files`/`git:range-diff` IPC over fail-soft `getRangeFiles`/`getRangeDiff`.

## Verification

- 29/29 vitest, typecheck clean, zero new eslint errors per file vs dev.
- Live in the real app (Playwright Electron + Romain's own use): incoming set matches `git diff --name-status HEAD...origin/main` exactly; net-diff click; unpublished-branch empty state; no pull/push ever triggered by the badges (reflogs checked).
- Adversarial verifier rounds 4–5 (same independent agent as rounds 1–3): round 4 found 2 majors (no scroll in the clean single-repo layout; a mismatched-upstream repo told 'up to date' beside a ↓1 badge) — both fixed at the root and re-proved against live git repros in round 5, plus keyboard access, per-repo toggle reset, and toggle semantics. Final verdict: **merge-safe**. Declared post-verdict touch-ups in the last commit: a doc line + a dblclick stopPropagation.

## Follow-up filed

Panel polish ticket (Log-mode ranges still guess `origin/<branch>`; header row → `div role=button` so badges become real buttons; per-file rename diff; same-count force-push staleness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012G8LRM6oVjVrebMjDE5zR1