### PR TITLE
Updater: Retry downloads from scratch + logging + escape hatch (PRDCT-1702)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@xterm/xterm": "^6.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "electron-log": "^5.4.4",
         "electron-updater": "^6.7.3",
         "fast-glob": "^3.3.3",
         "framer-motion": "^12.34.0",
@@ -8926,6 +8927,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-log": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.4.4.tgz",
+      "integrity": "sha512-istWgaXjBfURBSS8LWVW9C3jsc6+ac+tY1lXrQEOTp0lVj+a4OlO1Tmqb36GgnEUDv92DGC9VI1HNXwJinWpgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/electron-publish": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@xterm/xterm": "^6.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "electron-log": "^5.4.4",
     "electron-updater": "^6.7.3",
     "fast-glob": "^3.3.3",
     "framer-motion": "^12.34.0",

--- a/src/main/auto-updater.test.ts
+++ b/src/main/auto-updater.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { downloadStrategy } from './auto-updater'
+
+/**
+ * The one rule worth pinning: a retry must not be the same request that just
+ * failed. It used to be — `handleRetry` called `startDownload()`, which called
+ * `autoUpdater.downloadUpdate()`, with nothing in between changing state or
+ * strategy. A deterministic failure was therefore unescapable, and because
+ * auto-update is Clave's whole distribution channel, a user who hit one stayed
+ * on their version indefinitely without knowing.
+ *
+ * Only `downloadStrategy` is exercised here. `startDownload` reaches into the
+ * electron-updater singleton and `initAutoUpdater` early-returns unless the app
+ * is packaged, so neither can be decided without a window — that belongs to the
+ * end-to-end specs, per this suite's pure-logic rule.
+ */
+describe('downloadStrategy', () => {
+  it('lets the first attempt take the fast differential path', () => {
+    expect(downloadStrategy('first')).toEqual({ disableDifferentialDownload: false })
+  })
+
+  it('drops differential on a retry, so the request differs from the one that failed', () => {
+    expect(downloadStrategy('retry')).toEqual({ disableDifferentialDownload: true })
+  })
+
+  it('never returns the same strategy for both attempts', () => {
+    // The regression guard proper: whatever the strategy grows into, a retry
+    // that resolves to the first attempt's plan is the bug this fixed.
+    expect(downloadStrategy('retry')).not.toEqual(downloadStrategy('first'))
+  })
+})

--- a/src/main/auto-updater.ts
+++ b/src/main/auto-updater.ts
@@ -1,10 +1,49 @@
-import { app } from 'electron'
+import { app, shell } from 'electron'
 import { autoUpdater, CancellationToken } from 'electron-updater'
+import log from 'electron-log/main'
 import { getMainWindow } from './window-utils'
 
 const CHECK_INTERVAL = 30 * 60 * 1000 // 30 minutes
 const INITIAL_DELAY = 5000
 const RETRY_DELAY = 60 * 1000 // 1 minute
+
+/** Where a user is sent when the updater cannot help itself. */
+export const RELEASES_URL = 'https://github.com/codika-io/clave/releases/latest'
+
+/**
+ * Which try this is. Not a counter — the only distinction that changes what we
+ * ask electron-updater to do is "first" vs "the user pressed Retry".
+ */
+export type DownloadAttempt = 'first' | 'retry'
+
+export interface DownloadStrategy {
+  /** Passed straight to `autoUpdater.disableDifferentialDownload`. */
+  disableDifferentialDownload: boolean
+}
+
+/**
+ * The first attempt takes the fast path: a differential download reads the
+ * previous version's zip out of the updater cache and fetches only the blocks
+ * that changed, which is the difference between a few MB and 220.
+ *
+ * A retry gives that up on purpose. We do not know why the first attempt
+ * failed — electron-updater surfaces the download error verbatim, and
+ * `net::ERR_FAILED` says only that an HTTP request did not complete — so the
+ * retry's job is to remove variables rather than repeat the attempt. A full
+ * download talks to one URL and reads nothing off disk. Before this existed,
+ * Retry re-issued the identical call and a deterministic failure was
+ * unescapable: auto-update is the whole distribution channel, so a user who hit
+ * one stayed on their version indefinitely with no way to know.
+ *
+ * Disabling differential is enough on its own — MacUpdater checks the flag in
+ * `canDifferentialDownload()` before it looks at the cached zip, so the retry
+ * never touches the cache. We deliberately do NOT delete the cache: it would
+ * only cost the *next* update its differential download, and removing a
+ * directory in a shipped app is not a trade worth making for no gain.
+ */
+export function downloadStrategy(attempt: DownloadAttempt): DownloadStrategy {
+  return { disableDifferentialDownload: attempt === 'retry' }
+}
 
 let cancellationToken: CancellationToken | null = null
 let downloadCancelled = false
@@ -18,24 +57,33 @@ function sendToRenderer(channel: string, ...args: unknown[]): void {
 export function initAutoUpdater(): void {
   if (!app.isPackaged) return
 
+  // electron-updater logs the entire download path through this logger — which
+  // URL it fetched, whether it fell back from differential to full, why a
+  // download aborted. Without it a packaged build writes to a console nobody
+  // can read, which is why the 1.68.0 -> 1.69.0 `net::ERR_FAILED` could not be
+  // traced: the only Clave files under ~/Library/Logs were crash reports.
+  log.initialize()
+  log.transports.file.level = 'info'
+  autoUpdater.logger = log
+
   autoUpdater.autoDownload = false
   autoUpdater.autoInstallOnAppQuit = true
 
   autoUpdater.on('checking-for-update', () => {
-    console.log('[updater] Checking for update...')
+    log.info('[updater] Checking for update...')
   })
 
   autoUpdater.on('update-available', (info) => {
-    console.log(`[updater] Update available: ${info.version}`)
+    log.info(`[updater] Update available: ${info.version}`)
     sendToRenderer('updater:update-available', info.version)
   })
 
   autoUpdater.on('update-not-available', () => {
-    console.log('[updater] App is up to date')
+    log.info('[updater] App is up to date')
   })
 
   autoUpdater.on('download-progress', (progress) => {
-    console.log(`[updater] Download: ${Math.round(progress.percent)}%`)
+    log.info(`[updater] Download: ${Math.round(progress.percent)}%`)
     sendToRenderer('updater:download-progress', {
       percent: progress.percent,
       bytesPerSecond: progress.bytesPerSecond,
@@ -45,13 +93,13 @@ export function initAutoUpdater(): void {
   })
 
   autoUpdater.on('update-downloaded', (info) => {
-    console.log(`[updater] Update downloaded: ${info.version}`)
+    log.info(`[updater] Update downloaded: ${info.version}`)
     isDownloading = false
     sendToRenderer('updater:update-downloaded', info.version)
   })
 
   autoUpdater.on('error', (err) => {
-    console.error('[updater] Error:', err.message)
+    log.error('[updater] Error:', err.message)
     // Only forward errors to renderer if a download was in progress.
     // checkForUpdates() errors should not trigger the download-error overlay.
     if (isDownloading && !downloadCancelled) {
@@ -63,10 +111,10 @@ export function initAutoUpdater(): void {
 
   const check = (): void => {
     autoUpdater.checkForUpdates().catch((err) => {
-      console.error('[updater] Check failed:', err?.message)
+      log.error('[updater] Check failed:', err?.message)
       setTimeout(() => {
         autoUpdater.checkForUpdates().catch((retryErr) => {
-          console.error('[updater] Retry failed:', retryErr?.message)
+          log.error('[updater] Retry failed:', retryErr?.message)
         })
       }, RETRY_DELAY)
     })
@@ -76,13 +124,22 @@ export function initAutoUpdater(): void {
   checkInterval = setInterval(check, CHECK_INTERVAL)
 }
 
-export function startDownload(): void {
+export function startDownload(attempt: DownloadAttempt = 'first'): void {
+  const strategy = downloadStrategy(attempt)
+  // Set on every attempt, not just the retry: the flag lives on the shared
+  // autoUpdater singleton, so a retry that is not reset would quietly make
+  // every later update a full download.
+  autoUpdater.disableDifferentialDownload = strategy.disableDifferentialDownload
+  log.info(
+    `[updater] Starting download (attempt=${attempt}, differential=${!strategy.disableDifferentialDownload})`
+  )
+
   downloadCancelled = false
   isDownloading = true
   cancellationToken = new CancellationToken()
   autoUpdater.downloadUpdate(cancellationToken).catch((err) => {
     if (!downloadCancelled) {
-      console.error('[updater] Download failed:', err?.message)
+      log.error('[updater] Download failed:', err?.message)
     }
     isDownloading = false
   })
@@ -102,6 +159,15 @@ export function cleanupAutoUpdater(): void {
     clearInterval(checkInterval)
     checkInterval = null
   }
+}
+
+/**
+ * Open the log file the updater writes to. The escape hatch's escape hatch:
+ * when an update fails for a reason the UI cannot explain, this is the thing a
+ * user can actually send us.
+ */
+export function openUpdaterLog(): Promise<string> {
+  return shell.openPath(log.transports.file.getFile().path)
 }
 
 export function installUpdate(): void {

--- a/src/main/ipc-handlers/updater-handlers.ts
+++ b/src/main/ipc-handlers/updater-handlers.ts
@@ -1,8 +1,17 @@
 import { ipcMain } from 'electron'
-import { installUpdate, startDownload, cancelDownload } from '../auto-updater'
+import {
+  installUpdate,
+  startDownload,
+  cancelDownload,
+  openUpdaterLog,
+  type DownloadAttempt
+} from '../auto-updater'
 
 export function registerUpdaterHandlers(): void {
   ipcMain.handle('updater:install', () => installUpdate())
-  ipcMain.handle('updater:start-download', () => startDownload())
+  ipcMain.handle('updater:start-download', (_event, attempt?: DownloadAttempt) =>
+    startDownload(attempt === 'retry' ? 'retry' : 'first')
+  )
   ipcMain.handle('updater:cancel-download', () => cancelDownload())
+  ipcMain.handle('updater:open-log', () => openUpdaterLog())
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -428,7 +428,8 @@ export interface ElectronAPI {
   getUsername: () => Promise<string | null>
   getAppVersion: () => Promise<string>
   installUpdate: () => Promise<void>
-  startDownload: () => Promise<void>
+  startDownload: (attempt?: 'first' | 'retry') => Promise<void>
+  openUpdaterLog: () => Promise<string>
   cancelDownload: () => Promise<void>
   getPathForFile: (file: File) => string
   persistDroppedFile: (sourcePath: string) => Promise<string | null>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -202,7 +202,9 @@ const electronAPI = {
   getAppVersion: () => ipcRenderer.invoke('app:get-version') as Promise<string>,
 
   installUpdate: () => ipcRenderer.invoke('updater:install'),
-  startDownload: () => ipcRenderer.invoke('updater:start-download'),
+  startDownload: (attempt?: 'first' | 'retry') =>
+    ipcRenderer.invoke('updater:start-download', attempt),
+  openUpdaterLog: () => ipcRenderer.invoke('updater:open-log'),
   cancelDownload: () => ipcRenderer.invoke('updater:cancel-download'),
 
   getPathForFile: (file: File) => webUtils.getPathForFile(file),

--- a/src/renderer/src/components/ui/UpdateOverlay.tsx
+++ b/src/renderer/src/components/ui/UpdateOverlay.tsx
@@ -69,7 +69,18 @@ export function UpdateOverlay() {
 
   const handleRetry = () => {
     setDownloading()
-    window.electronAPI?.startDownload()
+    // 'retry' tells the main process to drop the differential download and
+    // fetch the whole file. Retrying the identical request is what made a
+    // failed update unescapable — see downloadStrategy() in auto-updater.ts.
+    window.electronAPI?.startDownload('retry')
+  }
+
+  const handleOpenReleases = (): void => {
+    window.electronAPI?.openExternal('https://github.com/codika-io/clave/releases/latest')
+  }
+
+  const handleOpenLog = (): void => {
+    window.electronAPI?.openUpdaterLog()
   }
 
   const visible = phase === 'downloading' || phase === 'downloaded' || phase === 'error'
@@ -138,6 +149,25 @@ export function UpdateOverlay() {
                   <p className="text-[13px] text-text-tertiary mt-1 max-w-[280px]">
                     {errorMessage || 'An unexpected error occurred'}
                   </p>
+                  {/* Auto-update is the only distribution channel — no App Store,
+                      no package manager. Without these two links a user whose
+                      update keeps failing has no way to get the new version and
+                      nothing to send us about why. */}
+                  <div className="flex items-center justify-center gap-3 mt-3 text-[12px]">
+                    <button
+                      onClick={handleOpenReleases}
+                      className="text-text-tertiary hover:text-text-primary underline underline-offset-2 transition-colors"
+                    >
+                      Download from GitHub
+                    </button>
+                    <span className="text-text-tertiary">·</span>
+                    <button
+                      onClick={handleOpenLog}
+                      className="text-text-tertiary hover:text-text-primary underline underline-offset-2 transition-colors"
+                    >
+                      Open log
+                    </button>
+                  </div>
                 </>
               )}
             </div>


### PR DESCRIPTION
Retry was the identical call that just failed — now it forces a full download (differential off), while first attempts stay differential. electron-log wired as autoUpdater.logger so packaged builds write updater logs to disk. Error state gets 'Download from GitHub' and 'Open log' links. Tests: strategy pinned (mutation-checked), 79/79, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qEE2CJ2HDcC8tn64fFQ1p