### PR TITLE
Multi-window core: WindowRegistry, per-window teardown, per-workspace sidebar layout

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -47,10 +47,13 @@ registerPreviewScheme()
  *    hosted by OTHER windows are never touched; ssh and OpenClaw stay up.
  *  - the LAST window closing is today's behavior verbatim.
  */
+let quitting = false
+
 function onWindowClosed(windowId: number): void {
-  const remaining = BrowserWindow.getAllWindows().filter(
-    (w) => !w.isDestroyed() && w.id !== windowId
-  )
+  // Only CLAVE windows count (the registry's), never a stray BrowserWindow a
+  // dialog or a picker might own — or the final close would skip the app's
+  // shutdown.
+  const remaining = windowRegistry.listWindows().filter((w) => w.id !== windowId)
   if (remaining.length === 0) {
     ptyManager.killAll()
     sshManager.disconnectAll()
@@ -61,6 +64,9 @@ function onWindowClosed(windowId: number): void {
   const hosted = windowRegistry.getSessionsForWindow(windowId)
   for (const id of hosted) ptyManager.kill(id, false)
   windowRegistry.unregisterWindow(windowId)
+  // Windows closing one after another inside a quit re-home nothing: the
+  // survivor is about to close too, and the last one runs the full teardown.
+  if (quitting) return
   const host = windowRegistry.getPrimaryWindow()
   if (host && hosted.length > 0) host.webContents.send('session:rehome', hosted)
   broadcastIdentities()
@@ -221,6 +227,7 @@ app.whenReady().then(() => {
 })
 
 app.on('before-quit', () => {
+  quitting = true
   cleanupClaveWatchers()
   cleanupAutoUpdater()
   cleanupTelemetry()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -7,6 +7,7 @@ import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import { registerIpcHandlers } from './ipc-handlers'
 import { applyPersistedIcon } from './ipc-handlers/app-handlers'
 import { cleanupDroppedFiles } from './ipc-handlers/dropped-file-handlers'
+import { registerWindowHandlers, broadcastIdentities } from './ipc-handlers/window-handlers'
 import { ptyManager, preloadLoginShellEnv } from './pty-manager'
 import { initAutoUpdater, cleanupAutoUpdater } from './auto-updater'
 import { buildAppMenu } from './app-menu'
@@ -16,6 +17,8 @@ import { sshManager } from './ssh-manager'
 import { locationManager } from './location-manager'
 import { openclawClient, buildOpenclawWsUrl } from './openclaw-client'
 import { preferencesManager } from './preferences-manager'
+import { workspaceManager } from './workspace-manager'
+import { windowRegistry } from './window-registry'
 import {
   initMissionControl,
   cleanupMissionControl,
@@ -29,11 +32,45 @@ import { registerPreviewScheme, installPreviewProtocol } from './preview-protoco
 // Scheme privileges must be declared before app ready.
 registerPreviewScheme()
 
-function createWindow(): void {
+/**
+ * The teardown ladder (PRDCT-1703). One window closing used to run the whole
+ * app's shutdown — every session in every window received pty:exit and went
+ * dead. Now:
+ *
+ *  - a NON-LAST window closing touches only the sessions IT hosts: each is
+ *    detached (`kill(id, false)` — a tmux-backed session keeps running in the
+ *    tmux server with its record intact; a plain one dies exactly as it did
+ *    on close before, its record stays restorable), its binding dropped, the
+ *    window forgotten, the primary re-elected if it was the primary, and the
+ *    new host told which sessions to re-home (`session:rehome`, the record
+ *    ids — the renderer's adoption of them is the re-homing half). Sessions
+ *    hosted by OTHER windows are never touched; ssh and OpenClaw stay up.
+ *  - the LAST window closing is today's behavior verbatim.
+ */
+function onWindowClosed(windowId: number): void {
+  const remaining = BrowserWindow.getAllWindows().filter(
+    (w) => !w.isDestroyed() && w.id !== windowId
+  )
+  if (remaining.length === 0) {
+    ptyManager.killAll()
+    sshManager.disconnectAll()
+    openclawClient.disconnectAll()
+    windowRegistry.unregisterWindow(windowId)
+    return
+  }
+  const hosted = windowRegistry.getSessionsForWindow(windowId)
+  for (const id of hosted) ptyManager.kill(id, false)
+  windowRegistry.unregisterWindow(windowId)
+  const host = windowRegistry.getPrimaryWindow()
+  if (host && hosted.length > 0) host.webContents.send('session:rehome', hosted)
+  broadcastIdentities()
+}
+
+function createWindow(workspaceId: string | null): BrowserWindow {
   const savedIcon = preferencesManager.get('appIcon')
   const icon = nativeImage.createFromPath(join(__dirname, `../../resources/icon-${savedIcon}.png`))
 
-  const mainWindow = new BrowserWindow({
+  const win = new BrowserWindow({
     width: 1400,
     height: 900,
     minWidth: 800,
@@ -53,6 +90,10 @@ function createWindow(): void {
     }
   })
 
+  // Registered before load so the renderer's very first `window:identity`
+  // finds it. The registry, not the state file, is what the window shows.
+  windowRegistry.registerWindow(win, workspaceId)
+
   // In dev mode, set dock icon from PNG. In packaged mode, let macOS
   // render from the .icon bundle (which supports Tahoe glass effect).
   // applyPersistedIcon() handles copying the right .icon bundle on startup.
@@ -60,19 +101,16 @@ function createWindow(): void {
     app.dock?.setIcon(icon)
   }
 
-  mainWindow.on('ready-to-show', () => {
-    mainWindow.show()
+  win.on('ready-to-show', () => {
+    win.show()
   })
 
-  attachMissionControlWindow(mainWindow)
+  attachMissionControlWindow(win)
 
-  mainWindow.on('closed', () => {
-    ptyManager.killAll()
-    sshManager.disconnectAll()
-    openclawClient.disconnectAll()
-  })
+  const windowId = win.id
+  win.on('closed', () => onWindowClosed(windowId))
 
-  mainWindow.webContents.on('will-navigate', (event, url) => {
+  win.webContents.on('will-navigate', (event, url) => {
     if (url.startsWith('clave://')) {
       event.preventDefault()
       return
@@ -86,7 +124,7 @@ function createWindow(): void {
     event.preventDefault()
   })
 
-  mainWindow.webContents.setWindowOpenHandler((details) => {
+  win.webContents.setWindowOpenHandler((details) => {
     if (details.url.startsWith('clave://')) {
       return { action: 'deny' }
     }
@@ -98,10 +136,34 @@ function createWindow(): void {
   })
 
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
-    mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL'])
+    win.loadURL(process.env['ELECTRON_RENDERER_URL'])
   } else {
-    mainWindow.loadFile(join(__dirname, '../renderer/index.html'))
+    win.loadFile(join(__dirname, '../renderer/index.html'))
   }
+  return win
+}
+
+/** Show a workspace in a window of its own. A workspace already shown in a
+ *  window is never duplicated (mirroring is out of scope): that window is
+ *  brought forward instead. Otherwise a new window opens on it, and it
+ *  becomes the last-active workspace — what the first window of the next
+ *  run opens on. */
+export function openWorkspaceWindow(workspaceId: string): {
+  windowId: number
+  focusedExisting: boolean
+} {
+  const shown = windowRegistry.getWindowForWorkspace(workspaceId)
+  if (shown) {
+    if (shown.isMinimized()) shown.restore()
+    shown.show()
+    shown.focus()
+    return { windowId: shown.id, focusedExisting: true }
+  }
+  const win = createWindow(workspaceId)
+  workspaceManager.setLastActive(workspaceId)
+  // The primary's hosted set just shrank by this workspace.
+  broadcastIdentities()
+  return { windowId: win.id, focusedExisting: false }
 }
 
 app.whenReady().then(() => {
@@ -115,6 +177,7 @@ app.whenReady().then(() => {
   })
 
   registerIpcHandlers()
+  registerWindowHandlers({ openWorkspaceWindow })
   installPreviewProtocol()
   // MCP failure must not break the app — spawns just omit the --mcp-config flag.
   void startMcpServer().catch((err) => console.error('[mcp] failed to start', err))
@@ -122,7 +185,9 @@ app.whenReady().then(() => {
   cleanupDroppedFiles()
   initNotificationManager()
   applyPersistedIcon()
-  createWindow()
+  // The first window opens on the last-active workspace (else the first
+  // registered one, else the no-workspace onboarding state).
+  createWindow(workspaceManager.resolveInitialWorkspaceId())
   buildAppMenu()
   initAutoUpdater()
   initTelemetry()
@@ -149,7 +214,9 @@ app.whenReady().then(() => {
   }
 
   app.on('activate', () => {
-    if (BrowserWindow.getAllWindows().length === 0) createWindow()
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow(workspaceManager.resolveInitialWorkspaceId())
+    }
   })
 })
 
@@ -166,4 +233,3 @@ app.on('window-all-closed', () => {
     app.quit()
   }
 })
-

--- a/src/main/ipc-handlers/pty-handlers.ts
+++ b/src/main/ipc-handlers/pty-handlers.ts
@@ -2,6 +2,7 @@ import { ipcMain, BrowserWindow } from 'electron'
 import { ptyManager, isTmuxAvailable, type PtySpawnOptions } from '../pty-manager'
 import { getPreference } from './clave-file-handlers'
 import { workspaceManager } from '../workspace-manager'
+import { windowRegistry } from '../window-registry'
 import * as titleGenerator from '../title-generator'
 import { startWatching as startAgentStateWatching, clearState as clearAgentState } from '../agent-state-manager'
 
@@ -17,16 +18,26 @@ export function registerPtyHandlers(): void {
   })
 
   ipcMain.handle('pty:spawn', (_event, cwd: string, options?: PtySpawnOptions) => {
+    const win = BrowserWindow.fromWebContents(_event.sender)
     // tmux mode is a global app setting, ON by default. Honour it unless a
     // caller overrides per-spawn or the user explicitly turned it off. (When
     // tmux isn't installed the spawn transparently falls back to a plain shell.)
     const tmuxMode = options?.tmuxMode ?? getPreference('tmuxMode') !== false
-    // Central workspace stamp: every spawn defaults to the active workspace so
-    // renderer call sites don't have to thread it through. Explicit values win
-    // (pin launches into a hidden workspace, MCP caller inheritance, adoption).
-    const workspaceId = options?.workspaceId ?? workspaceManager.getActiveWorkspaceId() ?? undefined
+    // Central workspace stamp: every spawn defaults to the workspace of the
+    // WINDOW that asked (the registry's truth, never the state file — another
+    // window may have switched or written last). Explicit values win (pin
+    // launches into a hidden workspace, MCP caller inheritance, adoption); the
+    // persisted last-active workspace survives only for a windowless caller.
+    const workspaceId =
+      options?.workspaceId ??
+      (win ? windowRegistry.getWorkspaceForWindow(win.id) : null) ??
+      workspaceManager.getLastActiveWorkspaceId() ??
+      undefined
     const session = ptyManager.spawn(cwd, { ...options, tmuxMode, workspaceId })
-    const win = BrowserWindow.fromWebContents(_event.sender)
+    // The sender hosts the session from now on: its renderer holds the xterm
+    // and receives pty:data. Adoption and re-homing rebind through this same
+    // path (the adopting window is the sender).
+    if (win) windowRegistry.bindSession(session.id, win.id)
     const isClaudeMode = options?.claudeMode !== false && !options?.antigravityMode && !options?.codexMode && !options?.claudeAgentsMode
     const isResumed = !!options?.resumeSessionId
 
@@ -48,6 +59,7 @@ export function registerPtyHandlers(): void {
         titleGenerator.cleanup(session.id)
         inputBuffers.delete(session.id)
         clearAgentState(session.id)
+        windowRegistry.unbindSession(session.id)
         if (win && !win.isDestroyed()) {
           win.webContents.send(`pty:exit:${session.id}`, exitCode)
         }
@@ -105,6 +117,8 @@ export function registerPtyHandlers(): void {
 
   ipcMain.handle('pty:kill', (_event, id: string) => {
     ptyManager.kill(id)
+    // A session that never started has no exit event to unbind it.
+    windowRegistry.unbindSession(id)
   })
 
   ipcMain.handle('pty:list', () => {
@@ -154,8 +168,13 @@ export function registerPtyHandlers(): void {
   // On launch the renderer asks which sessions survived a previous run — live
   // tmux survivors to reattach silently, dead records (plain or post-reboot
   // tmux) to offer behind the restore prompt. Also prunes stale records.
-  ipcMain.handle('records:list-adoptable', () => {
-    return ptyManager.listAdoptableSessions()
+  // With a workspaceId only that workspace's records come back: a secondary
+  // window adopts and prompts for its own workspace, never for everyone's.
+  // Unfiltered (the primary at boot) is today's behavior.
+  ipcMain.handle('records:list-adoptable', (_event, workspaceId?: unknown) => {
+    const all = ptyManager.listAdoptableSessions()
+    if (typeof workspaceId !== 'string') return all
+    return all.filter((r) => r.workspaceId === workspaceId)
   })
 
   // User declined to bring a survivor back → destroy it (record + tmux session).

--- a/src/main/ipc-handlers/sidebar-layout-handlers.ts
+++ b/src/main/ipc-handlers/sidebar-layout-handlers.ts
@@ -1,9 +1,109 @@
-import { ipcMain } from 'electron'
-import { sidebarLayoutManager, type SidebarLayout } from '../sidebar-layout-manager'
+import { ipcMain, BrowserWindow } from 'electron'
+import * as fs from 'fs'
+import * as path from 'path'
+import {
+  sidebarLayoutManager,
+  isValidLayoutKey,
+  type LayoutKey,
+  type SidebarLayout
+} from '../sidebar-layout-manager'
+import { windowRegistry } from '../window-registry'
+import { workspaceManager } from '../workspace-manager'
+import { sessionRecordsDir } from '../pty-manager'
+
+/** Session id → workspace, read straight from the session records on disk:
+ *  the migration places a bare session id in `displayOrder` by the workspace
+ *  its record carries (stamped at spawn), else by its cwd against the
+ *  registered roots. Records are small JSON files; a malformed one is skipped. */
+function sessionWorkspaceResolver(): (sessionId: string) => string | null {
+  const byId = new Map<string, string | null>()
+  try {
+    const dir = sessionRecordsDir()
+    for (const file of fs.readdirSync(dir).filter((f) => f.endsWith('.json'))) {
+      try {
+        const meta = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf-8')) as {
+          id?: unknown
+          workspaceId?: unknown
+          cwd?: unknown
+        }
+        if (typeof meta.id !== 'string') continue
+        byId.set(
+          meta.id,
+          typeof meta.workspaceId === 'string'
+            ? meta.workspaceId
+            : typeof meta.cwd === 'string'
+              ? workspaceManager.resolveWorkspaceForCwd(meta.cwd)
+              : null
+        )
+      } catch {
+        /* skip malformed record */
+      }
+    }
+  } catch {
+    /* no records dir yet */
+  }
+  return (id) => byId.get(id) ?? null
+}
+
+/** The one-time legacy migration, attempted before every load: it is a no-op
+ *  the moment the legacy file is gone, and it needs the registry to exist —
+ *  the first load with a registered workspace is exactly "first post-update
+ *  load" for the file that matters. */
+function migrateLegacyIfNeeded(): void {
+  const workspaceIds = workspaceManager.getWorkspaces().map((w) => w.id)
+  if (workspaceIds.length === 0) return
+  const fallback = workspaceManager.resolveInitialWorkspaceId() ?? workspaceIds[0]
+  try {
+    sidebarLayoutManager.migrateLegacy({
+      workspaceIds,
+      fallbackWorkspaceId: fallback,
+      resolveWorkspaceForCwd: (cwd) => workspaceManager.resolveWorkspaceForCwd(cwd),
+      resolveWorkspaceForSession: sessionWorkspaceResolver()
+    })
+  } catch (err) {
+    console.error('[sidebar-layout] legacy migration failed:', err)
+  }
+}
+
+function normalizeKeys(keys: unknown): LayoutKey[] {
+  if (!Array.isArray(keys)) return [null]
+  const out: LayoutKey[] = []
+  for (const k of keys) {
+    if (k === null || isValidLayoutKey(k)) out.push(k)
+  }
+  return out
+}
 
 export function registerSidebarLayoutHandlers(): void {
-  ipcMain.handle('sidebar-layout:load', () => sidebarLayoutManager.load())
-  ipcMain.handle('sidebar-layout:save', (_event, data: SidebarLayout) =>
-    sidebarLayoutManager.save(data)
-  )
+  // Load the layouts of the workspaces this window hosts, concatenated. The
+  // null key is the unscoped (no-workspace mode) layout.
+  ipcMain.handle('sidebar-layout:load', (_event, keys: unknown) => {
+    migrateLegacyIfNeeded()
+    return sidebarLayoutManager.load(normalizeKeys(keys))
+  })
+
+  // Write ownership, enforced here (the hosting rule): a window may write a
+  // workspace's layout iff it SHOWS that workspace, or it is the primary and
+  // no window shows it. A refused write is loud and writes nothing — two
+  // windows silently overwriting one file is the defect this replaces.
+  ipcMain.handle('sidebar-layout:save', (event, key: unknown, data: SidebarLayout) => {
+    const sender = BrowserWindow.fromWebContents(event.sender)
+    const layoutKey: LayoutKey | undefined =
+      key === null ? null : isValidLayoutKey(key) ? key : undefined
+    if (layoutKey === undefined) {
+      console.error(`[sidebar-layout] refused: invalid layout key ${JSON.stringify(key)}`)
+      return { ok: false as const, reason: 'invalid-key' as const }
+    }
+    if (!sender || !windowRegistry.canWriteWorkspace(sender.id, layoutKey)) {
+      const host = layoutKey
+        ? windowRegistry.getHostWindowForWorkspace(layoutKey)
+        : windowRegistry.getPrimaryWindow()
+      console.error(
+        `[sidebar-layout] refused: window ${sender?.id ?? '?'} may not write workspace ${layoutKey ?? '(unscoped)'} — it is hosted by window ${host?.id ?? '?'}`
+      )
+      return { ok: false as const, reason: 'not-host' as const, hostWindowId: host?.id ?? null }
+    }
+    sidebarLayoutManager.save(layoutKey, data)
+    return { ok: true as const }
+  })
 }

--- a/src/main/ipc-handlers/window-handlers.ts
+++ b/src/main/ipc-handlers/window-handlers.ts
@@ -1,0 +1,82 @@
+import { ipcMain, BrowserWindow } from 'electron'
+import { windowRegistry, type WindowIdentity } from '../window-registry'
+import { workspaceManager } from '../workspace-manager'
+
+/** What a renderer learns about itself, and only itself: its window id, the
+ *  workspace it shows, whether it is the primary, and the workspaces it
+ *  hosts (may write for). Pushed again as `window:workspace-changed` every
+ *  time hosting moves — a window opened, closed, or switched, a workspace
+ *  registered or removed. */
+export function identityFor(windowId: number): WindowIdentity | null {
+  return windowRegistry.identityOf(
+    windowId,
+    workspaceManager.getWorkspaces().map((w) => w.id)
+  )
+}
+
+export function pushIdentity(win: BrowserWindow): void {
+  if (win.isDestroyed()) return
+  const identity = identityFor(win.id)
+  if (identity) win.webContents.send('window:workspace-changed', identity)
+}
+
+export function broadcastIdentities(): void {
+  for (const win of windowRegistry.listWindows()) pushIdentity(win)
+}
+
+export interface WindowHandlerDeps {
+  /** Open (or focus) the window showing a workspace — lives in main/index.ts
+   *  next to createWindow; injected so this module never imports the entry. */
+  openWorkspaceWindow: (workspaceId: string) => { windowId: number; focusedExisting: boolean }
+}
+
+export type SetWorkspaceResult =
+  | { ok: true }
+  | { ok: false; reason: 'shown-elsewhere'; shownIn: number }
+  | { ok: false; reason: 'unknown-workspace' | 'no-window' }
+
+export function registerWindowHandlers(deps: WindowHandlerDeps): void {
+  ipcMain.handle('window:identity', (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    return win ? identityFor(win.id) : null
+  })
+
+  // A renderer switching its workspace asks main FIRST. The guard that keeps
+  // mirroring out of scope lives here: a workspace another window shows is
+  // never switched to — that window is brought forward instead, and the
+  // caller keeps its view. On success the sender's hosting moves and every
+  // window learns its new hosted set.
+  ipcMain.handle(
+    'window:set-workspace',
+    (event, workspaceId: string | null): SetWorkspaceResult => {
+      const win = BrowserWindow.fromWebContents(event.sender)
+      if (!win) return { ok: false, reason: 'no-window' }
+      const target = typeof workspaceId === 'string' ? workspaceId : null
+      if (target !== null && !workspaceManager.isRegistered(target)) {
+        return { ok: false, reason: 'unknown-workspace' }
+      }
+      if (target !== null) {
+        const shown = windowRegistry.getWindowForWorkspace(target)
+        if (shown && shown.id !== win.id) {
+          if (shown.isMinimized()) shown.restore()
+          shown.show()
+          shown.focus()
+          return { ok: false, reason: 'shown-elsewhere', shownIn: shown.id }
+        }
+      }
+      windowRegistry.setWindowWorkspace(win.id, target)
+      broadcastIdentities()
+      return { ok: true }
+    }
+  )
+
+  // The single reach for "show workspace W in a window": the File menu and
+  // the picker (slice 3), clave_open_window (slice 4), and the end-to-end
+  // harness all come through here.
+  ipcMain.handle('window:open', (_event, workspaceId: string) => {
+    if (typeof workspaceId !== 'string' || !workspaceManager.isRegistered(workspaceId)) {
+      throw new Error(`No registered workspace with id "${String(workspaceId)}"`)
+    }
+    return deps.openWorkspaceWindow(workspaceId)
+  })
+}

--- a/src/main/ipc-handlers/window-handlers.ts
+++ b/src/main/ipc-handlers/window-handlers.ts
@@ -1,6 +1,9 @@
 import { ipcMain, BrowserWindow } from 'electron'
+import * as fs from 'fs'
+import * as path from 'path'
 import { windowRegistry, type WindowIdentity } from '../window-registry'
 import { workspaceManager } from '../workspace-manager'
+import { ptyManager, sessionRecordsDir } from '../pty-manager'
 
 /** What a renderer learns about itself, and only itself: its window id, the
  *  workspace it shows, whether it is the primary, and the workspaces it
@@ -35,6 +38,46 @@ export type SetWorkspaceResult =
   | { ok: false; reason: 'shown-elsewhere'; shownIn: number }
   | { ok: false; reason: 'unknown-workspace' | 'no-window' }
 
+/** Session ids of `workspaceIds` that are LIVE in this app and hosted by a
+ *  window other than the asker. A window taking over a workspace's layout
+ *  must not prune the groups of sessions that merely live elsewhere — the
+ *  records carry each session's workspace; adoption keeps the record's id,
+ *  so a live session is found by that id. */
+function liveSessionsElsewhere(askerWindowId: number, workspaceIds: string[]): string[] {
+  const wanted = new Set(workspaceIds)
+  const out: string[] = []
+  let files: string[] = []
+  try {
+    files = fs.readdirSync(sessionRecordsDir()).filter((f) => f.endsWith('.json'))
+  } catch {
+    return out
+  }
+  for (const file of files) {
+    try {
+      const meta = JSON.parse(fs.readFileSync(path.join(sessionRecordsDir(), file), 'utf-8')) as {
+        id?: unknown
+        workspaceId?: unknown
+        cwd?: unknown
+      }
+      if (typeof meta.id !== 'string') continue
+      const ws =
+        typeof meta.workspaceId === 'string'
+          ? meta.workspaceId
+          : typeof meta.cwd === 'string'
+            ? workspaceManager.resolveWorkspaceForCwd(meta.cwd)
+            : null
+      if (!ws || !wanted.has(ws)) continue
+      if (!ptyManager.getSession(meta.id)) continue
+      const host = windowRegistry.getWindowForSession(meta.id)
+      if (host && host.id === askerWindowId) continue
+      out.push(meta.id)
+    } catch {
+      /* skip malformed record */
+    }
+  }
+  return out
+}
+
 export function registerWindowHandlers(deps: WindowHandlerDeps): void {
   ipcMain.handle('window:identity', (event) => {
     const win = BrowserWindow.fromWebContents(event.sender)
@@ -43,12 +86,13 @@ export function registerWindowHandlers(deps: WindowHandlerDeps): void {
 
   // A renderer switching its workspace asks main FIRST. The guard that keeps
   // mirroring out of scope lives here: a workspace another window shows is
-  // never switched to — that window is brought forward instead, and the
-  // caller keeps its view. On success the sender's hosting moves and every
-  // window learns its new hosted set.
+  // never switched to — that window is brought forward instead (unless the
+  // caller is only probing, `focus: false`), and the caller keeps its view.
+  // On success the sender's hosting moves and every window learns its new
+  // hosted set.
   ipcMain.handle(
     'window:set-workspace',
-    (event, workspaceId: string | null): SetWorkspaceResult => {
+    (event, workspaceId: unknown, options?: { focus?: unknown }): SetWorkspaceResult => {
       const win = BrowserWindow.fromWebContents(event.sender)
       if (!win) return { ok: false, reason: 'no-window' }
       const target = typeof workspaceId === 'string' ? workspaceId : null
@@ -58,9 +102,11 @@ export function registerWindowHandlers(deps: WindowHandlerDeps): void {
       if (target !== null) {
         const shown = windowRegistry.getWindowForWorkspace(target)
         if (shown && shown.id !== win.id) {
-          if (shown.isMinimized()) shown.restore()
-          shown.show()
-          shown.focus()
+          if (options?.focus !== false) {
+            if (shown.isMinimized()) shown.restore()
+            shown.show()
+            shown.focus()
+          }
           return { ok: false, reason: 'shown-elsewhere', shownIn: shown.id }
         }
       }
@@ -73,10 +119,19 @@ export function registerWindowHandlers(deps: WindowHandlerDeps): void {
   // The single reach for "show workspace W in a window": the File menu and
   // the picker (slice 3), clave_open_window (slice 4), and the end-to-end
   // harness all come through here.
-  ipcMain.handle('window:open', (_event, workspaceId: string) => {
+  ipcMain.handle('window:open', (_event, workspaceId: unknown) => {
     if (typeof workspaceId !== 'string' || !workspaceManager.isRegistered(workspaceId)) {
       throw new Error(`No registered workspace with id "${String(workspaceId)}"`)
     }
     return deps.openWorkspaceWindow(workspaceId)
+  })
+
+  ipcMain.handle('sessions:live-elsewhere', (event, workspaceIds: unknown) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    if (!win || !Array.isArray(workspaceIds)) return []
+    return liveSessionsElsewhere(
+      win.id,
+      workspaceIds.filter((w): w is string => typeof w === 'string')
+    )
   })
 }

--- a/src/main/ipc-handlers/workspace-handlers.ts
+++ b/src/main/ipc-handlers/workspace-handlers.ts
@@ -1,6 +1,7 @@
 import { ipcMain, BrowserWindow } from 'electron'
 import { workspaceManager } from '../workspace-manager'
 import { windowRegistry } from '../window-registry'
+import { isValidLayoutKey } from '../sidebar-layout-manager'
 import type { Workspace } from '../../shared/workspace-types'
 import { broadcastIdentities } from './window-handlers'
 
@@ -9,10 +10,26 @@ import { broadcastIdentities } from './window-handlers'
  *  already has the state; sending it back would race its next mutation. */
 function broadcastStateChanged(sender: Electron.WebContents): void {
   const { workspaces, pins } = workspaceManager.load()
-  for (const win of BrowserWindow.getAllWindows()) {
-    if (win.isDestroyed() || win.webContents.id === sender.id) continue
+  for (const win of windowRegistry.listWindows()) {
+    if (win.webContents.id === sender.id) continue
     win.webContents.send('workspace:state-changed', { workspaces, pins })
   }
+}
+
+/** A renderer can send anything; a registry entry that is not a workspace
+ *  would take down every path that reads `rootDir` (session restore among
+ *  them). Reject the whole write rather than store one bad entry. */
+function isWorkspace(x: unknown): x is Workspace {
+  if (typeof x !== 'object' || x === null) return false
+  const w = x as Record<string, unknown>
+  return (
+    isValidLayoutKey(w.id) &&
+    typeof w.name === 'string' &&
+    typeof w.rootDir === 'string' &&
+    w.rootDir.length > 0 &&
+    (w.profileFile === null || typeof w.profileFile === 'string') &&
+    typeof w.createdAt === 'number'
+  )
 }
 
 /** The workspace state file, written field by field: the renderer owns the
@@ -25,7 +42,11 @@ export function registerWorkspaceHandlers(): void {
     return workspaceManager.load()
   })
 
-  ipcMain.handle('workspace:update-registry', (event, workspaces: Workspace[]) => {
+  ipcMain.handle('workspace:update-registry', (event, workspaces: unknown) => {
+    if (!Array.isArray(workspaces) || !workspaces.every(isWorkspace)) {
+      console.error('[workspace] refused: update-registry payload is not a list of workspaces')
+      return { ok: false as const, reason: 'invalid' as const }
+    }
     workspaceManager.updateRegistry(workspaces)
     broadcastStateChanged(event.sender)
     // A workspace added or removed changes what the primary hosts.
@@ -35,34 +56,37 @@ export function registerWorkspaceHandlers(): void {
 
   // The hosting rule applies to pins too: a window writes the pins of a
   // workspace it hosts. 'all' (the one-time localStorage import) is the
-  // primary's alone.
-  ipcMain.handle(
-    'workspace:update-pins',
-    (event, scope: string | null | 'all', pins: unknown[]) => {
-      const sender = BrowserWindow.fromWebContents(event.sender)
-      const allowed =
-        !!sender &&
-        (scope === 'all'
-          ? windowRegistry.isPrimary(sender.id)
-          : windowRegistry.canWriteWorkspace(sender.id, scope))
-      if (!allowed) {
-        const host =
-          scope && scope !== 'all'
-            ? windowRegistry.getHostWindowForWorkspace(scope)
-            : windowRegistry.getPrimaryWindow()
-        console.error(
-          `[workspace] refused: window ${sender?.id ?? '?'} may not write pins of workspace ${scope ?? '(unscoped)'} — hosted by window ${host?.id ?? '?'}`
-        )
-        return { ok: false as const, reason: 'not-host' as const, hostWindowId: host?.id ?? null }
-      }
-      workspaceManager.updatePins(scope, pins)
-      broadcastStateChanged(event.sender)
-      return { ok: true as const }
+  // primary's alone. The scope is a partition key and is validated as one.
+  ipcMain.handle('workspace:update-pins', (event, scope: unknown, pins: unknown) => {
+    const sender = BrowserWindow.fromWebContents(event.sender)
+    const key: string | null | 'all' | undefined =
+      scope === 'all' || scope === null ? scope : isValidLayoutKey(scope) ? scope : undefined
+    if (key === undefined || !Array.isArray(pins)) {
+      console.error(`[workspace] refused: invalid pins scope ${JSON.stringify(scope)}`)
+      return { ok: false as const, reason: 'invalid-key' as const }
     }
-  )
+    const allowed =
+      !!sender &&
+      (key === 'all'
+        ? windowRegistry.isPrimary(sender.id)
+        : windowRegistry.canWriteWorkspace(sender.id, key))
+    if (!allowed) {
+      const host =
+        key && key !== 'all'
+          ? windowRegistry.getHostWindowForWorkspace(key)
+          : windowRegistry.getPrimaryWindow()
+      console.error(
+        `[workspace] refused: window ${sender?.id ?? '?'} may not write pins of workspace ${key ?? '(unscoped)'} — hosted by window ${host?.id ?? '?'}`
+      )
+      return { ok: false as const, reason: 'not-host' as const, hostWindowId: host?.id ?? null }
+    }
+    workspaceManager.updatePins(key, pins)
+    broadcastStateChanged(event.sender)
+    return { ok: true as const }
+  })
 
-  ipcMain.handle('workspace:set-last-active', (_event, workspaceId: string | null) => {
-    workspaceManager.setLastActive(typeof workspaceId === 'string' ? workspaceId : null)
+  ipcMain.handle('workspace:set-last-active', (_event, workspaceId: unknown) => {
+    workspaceManager.setLastActive(isValidLayoutKey(workspaceId) ? workspaceId : null)
     return { ok: true as const }
   })
 }

--- a/src/main/ipc-handlers/workspace-handlers.ts
+++ b/src/main/ipc-handlers/workspace-handlers.ts
@@ -1,17 +1,68 @@
-import { ipcMain } from 'electron'
+import { ipcMain, BrowserWindow } from 'electron'
 import { workspaceManager } from '../workspace-manager'
-import type { WorkspaceStateFile } from '../../shared/workspace-types'
+import { windowRegistry } from '../window-registry'
+import type { Workspace } from '../../shared/workspace-types'
+import { broadcastIdentities } from './window-handlers'
 
-/** Deliberately dumb load/save of the whole workspace state file, mirroring
- *  sidebar-layout: the renderer owns the state during a run and persists every
- *  mutation; main keeps a synchronous cache so the PTY layer can stamp spawns
- *  with the active workspace without an async hop. */
+/** Registry/pin changes reach every OTHER window, which folds them into its
+ *  stores (registry and pins only — never groups or sessions). The sender
+ *  already has the state; sending it back would race its next mutation. */
+function broadcastStateChanged(sender: Electron.WebContents): void {
+  const { workspaces, pins } = workspaceManager.load()
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (win.isDestroyed() || win.webContents.id === sender.id) continue
+    win.webContents.send('workspace:state-changed', { workspaces, pins })
+  }
+}
+
+/** The workspace state file, written field by field: the renderer owns the
+ *  state during a run and persists every mutation through the channel for
+ *  the field it changed; main keeps a synchronous cache so the PTY layer can
+ *  stamp spawns without an async hop. The whole-file `workspace:save` is
+ *  gone — with several windows it was last-writer-wins on every field. */
 export function registerWorkspaceHandlers(): void {
   ipcMain.handle('workspace:load', () => {
     return workspaceManager.load()
   })
 
-  ipcMain.handle('workspace:save', (_event, data: WorkspaceStateFile) => {
-    workspaceManager.save(data)
+  ipcMain.handle('workspace:update-registry', (event, workspaces: Workspace[]) => {
+    workspaceManager.updateRegistry(workspaces)
+    broadcastStateChanged(event.sender)
+    // A workspace added or removed changes what the primary hosts.
+    broadcastIdentities()
+    return { ok: true as const }
+  })
+
+  // The hosting rule applies to pins too: a window writes the pins of a
+  // workspace it hosts. 'all' (the one-time localStorage import) is the
+  // primary's alone.
+  ipcMain.handle(
+    'workspace:update-pins',
+    (event, scope: string | null | 'all', pins: unknown[]) => {
+      const sender = BrowserWindow.fromWebContents(event.sender)
+      const allowed =
+        !!sender &&
+        (scope === 'all'
+          ? windowRegistry.isPrimary(sender.id)
+          : windowRegistry.canWriteWorkspace(sender.id, scope))
+      if (!allowed) {
+        const host =
+          scope && scope !== 'all'
+            ? windowRegistry.getHostWindowForWorkspace(scope)
+            : windowRegistry.getPrimaryWindow()
+        console.error(
+          `[workspace] refused: window ${sender?.id ?? '?'} may not write pins of workspace ${scope ?? '(unscoped)'} — hosted by window ${host?.id ?? '?'}`
+        )
+        return { ok: false as const, reason: 'not-host' as const, hostWindowId: host?.id ?? null }
+      }
+      workspaceManager.updatePins(scope, pins)
+      broadcastStateChanged(event.sender)
+      return { ok: true as const }
+    }
+  )
+
+  ipcMain.handle('workspace:set-last-active', (_event, workspaceId: string | null) => {
+    workspaceManager.setLastActive(typeof workspaceId === 'string' ? workspaceId : null)
+    return { ok: true as const }
   })
 }

--- a/src/main/sidebar-layout-manager.ts
+++ b/src/main/sidebar-layout-manager.ts
@@ -114,7 +114,12 @@ class SidebarLayoutManager {
     if (legacy) {
       for (const [ws, partition] of partitionLegacyLayout(legacy, ctx)) {
         const file = this.fileFor(ws)
-        if (!file) continue
+        if (!file) {
+          console.error(
+            `[sidebar-layout] migration: ${partition.groups.length} group(s) for an invalid workspace key ${JSON.stringify(ws)} stay only in the backup`
+          )
+          continue
+        }
         const existing = this.readFile(file)
         this.writeFile(file, existing ? mergeLayouts(existing, partition) : partition)
         written.push(ws)

--- a/src/main/sidebar-layout-manager.ts
+++ b/src/main/sidebar-layout-manager.ts
@@ -1,49 +1,132 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import { app } from 'electron'
+import {
+  concatLayouts,
+  mergeLayouts,
+  partitionLegacyLayout,
+  type PartitionContext,
+  type SidebarLayoutData
+} from './sidebar-layout-migration'
 
 /** Persisted sidebar layout: the session groups and the top-level display
  *  order that nests them. Sessions themselves survive via tmux sidecars; this
  *  is the group metadata (names, colors, terminals, ordering) that organizes
  *  them, written from the main process so it survives a hard kill (Ctrl+C /
- *  crash) the way Chromium's lazily-flushed localStorage does not. */
-export interface SidebarLayout {
-  groups: unknown[]
-  displayOrder: string[]
+ *  crash) the way Chromium's lazily-flushed localStorage does not.
+ *
+ *  Keyed PER WORKSPACE since multi-window (PRDCT-1703): a window shows one
+ *  workspace, so two windows writing one global file erased each other on
+ *  every change. Each workspace's layout lives in
+ *  `sidebar-layouts/<workspaceId>.json`; the null key — no-workspace mode,
+ *  where nothing is stamped — keeps using the legacy `sidebar-layout.json`
+ *  exactly as before. The legacy file is migrated the first time a load
+ *  happens with at least one registered workspace (see `migrateLegacy`). */
+export type SidebarLayout = SidebarLayoutData
+
+/** A layout key: a workspace id, or null for the unscoped (no-workspace) layout. */
+export type LayoutKey = string | null
+
+export const LEGACY_LAYOUT_FILE = 'sidebar-layout.json'
+export const LAYOUTS_DIR = 'sidebar-layouts'
+export const MIGRATED_BACKUP_SUFFIX = '.migrated-backup'
+
+/** Keys become file names: only the id alphabet the registry mints (uuids)
+ *  is accepted, so a malformed key can never escape the layouts directory. */
+export function isValidLayoutKey(key: unknown): key is string {
+  return typeof key === 'string' && /^[A-Za-z0-9_-]{1,128}$/.test(key)
+}
+
+function normalize(data: unknown): SidebarLayout {
+  const d = data as Partial<SidebarLayout> | null
+  return {
+    groups: Array.isArray(d?.groups) ? d!.groups : [],
+    displayOrder: Array.isArray(d?.displayOrder) ? d!.displayOrder : []
+  }
 }
 
 class SidebarLayoutManager {
-  private filePath: string
+  private readonly legacyPath: string
+  private readonly dir: string
 
   constructor() {
-    this.filePath = path.join(app.getPath('userData'), 'sidebar-layout.json')
+    const userData = app.getPath('userData')
+    this.legacyPath = path.join(userData, LEGACY_LAYOUT_FILE)
+    this.dir = path.join(userData, LAYOUTS_DIR)
   }
 
-  load(): SidebarLayout {
+  fileFor(key: LayoutKey): string | null {
+    if (key === null) return this.legacyPath
+    return isValidLayoutKey(key) ? path.join(this.dir, `${key}.json`) : null
+  }
+
+  private readFile(file: string): SidebarLayout | null {
     try {
-      const data = JSON.parse(fs.readFileSync(this.filePath, 'utf-8')) as SidebarLayout
-      return {
-        groups: Array.isArray(data.groups) ? data.groups : [],
-        displayOrder: Array.isArray(data.displayOrder) ? data.displayOrder : []
-      }
+      return normalize(JSON.parse(fs.readFileSync(file, 'utf-8')))
     } catch {
-      return { groups: [], displayOrder: [] }
+      return null
     }
   }
 
-  save(data: SidebarLayout): void {
-    const payload = JSON.stringify(
-      {
-        groups: Array.isArray(data?.groups) ? data.groups : [],
-        displayOrder: Array.isArray(data?.displayOrder) ? data.displayOrder : []
-      },
-      null,
-      2
-    )
+  private writeFile(file: string, data: SidebarLayout): void {
+    const payload = JSON.stringify(normalize(data), null, 2)
+    fs.mkdirSync(path.dirname(file), { recursive: true })
     // Write-then-rename so a kill mid-write can never leave a truncated file.
-    const tmp = `${this.filePath}.tmp`
+    const tmp = `${file}.tmp`
     fs.writeFileSync(tmp, payload, 'utf-8')
-    fs.renameSync(tmp, this.filePath)
+    fs.renameSync(tmp, file)
+  }
+
+  loadOne(key: LayoutKey): SidebarLayout {
+    const file = this.fileFor(key)
+    return (file ? this.readFile(file) : null) ?? { groups: [], displayOrder: [] }
+  }
+
+  /** The layouts of several workspaces, concatenated in the given order —
+   *  what a window holds in memory: everything it hosts (the primary at boot
+   *  hosts every workspace; a secondary window hosts its own). */
+  load(keys: LayoutKey[]): SidebarLayout {
+    return concatLayouts(keys.map((k) => this.loadOne(k)))
+  }
+
+  save(key: LayoutKey, data: SidebarLayout): boolean {
+    const file = this.fileFor(key)
+    if (!file) return false
+    this.writeFile(file, data)
+    return true
+  }
+
+  /**
+   * One-time migration off the single legacy file. Runs only when the legacy
+   * file exists AND at least one workspace is registered (in no-workspace
+   * mode the legacy file IS the null-key layout and stays in place). Each
+   * partition is merged into a per-workspace file that may already exist —
+   * a workspace registered mid-run wrote one before this ran — then the
+   * legacy file is RENAMED to `sidebar-layout.json.migrated-backup`, never
+   * deleted. Idempotent: the second call finds no legacy file and does
+   * nothing. Returns the workspaces written, or null when nothing ran.
+   */
+  migrateLegacy(ctx: PartitionContext): string[] | null {
+    if (ctx.workspaceIds.length === 0) return null
+    if (!fs.existsSync(this.legacyPath)) return null
+    const legacy = this.readFile(this.legacyPath)
+    const written: string[] = []
+    if (legacy) {
+      for (const [ws, partition] of partitionLegacyLayout(legacy, ctx)) {
+        const file = this.fileFor(ws)
+        if (!file) continue
+        const existing = this.readFile(file)
+        this.writeFile(file, existing ? mergeLayouts(existing, partition) : partition)
+        written.push(ws)
+      }
+    }
+    // Unreadable legacy file: still parked as the backup so it is never
+    // re-attempted (and never lost) — there is nothing to partition.
+    fs.renameSync(this.legacyPath, `${this.legacyPath}${MIGRATED_BACKUP_SUFFIX}`)
+    console.log(
+      `[sidebar-layout] migrated ${LEGACY_LAYOUT_FILE} into ${written.length} per-workspace file(s); legacy kept as ${LEGACY_LAYOUT_FILE}${MIGRATED_BACKUP_SUFFIX}`
+    )
+    return written
   }
 }
 

--- a/src/main/sidebar-layout-migration.test.ts
+++ b/src/main/sidebar-layout-migration.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest'
+import {
+  partitionLegacyLayout,
+  mergeLayouts,
+  concatLayouts,
+  type PartitionContext
+} from './sidebar-layout-migration'
+
+const A = 'aaaaaaaa-0000-4000-8000-00000000000a'
+const B = 'bbbbbbbb-0000-4000-8000-00000000000b'
+
+const ctx = (over: Partial<PartitionContext> = {}): PartitionContext => ({
+  workspaceIds: [A, B],
+  fallbackWorkspaceId: A,
+  resolveWorkspaceForCwd: (cwd: string) =>
+    cwd.startsWith('/roots/b') ? B : cwd.startsWith('/roots/a') ? A : null,
+  resolveWorkspaceForSession: (id: string) => (id === 'sess-b' ? B : id === 'sess-a' ? A : null),
+  ...over
+})
+
+const group = (id: string, extra: Record<string, unknown> = {}): Record<string, unknown> => ({
+  id,
+  name: id,
+  sessionIds: [],
+  collapsed: false,
+  cwd: null,
+  terminals: [],
+  ...extra
+})
+
+describe('partitionLegacyLayout — where each group lands', () => {
+  it('a stamped group goes to its workspace', () => {
+    const out = partitionLegacyLayout(
+      { groups: [group('g1', { workspaceId: B })], displayOrder: ['g1'] },
+      ctx()
+    )
+    expect([...out.keys()]).toEqual([B])
+    expect(out.get(B)!.groups).toHaveLength(1)
+    expect(out.get(B)!.displayOrder).toEqual(['g1'])
+  })
+
+  it('an unstamped group with a cwd goes to the workspace whose root contains it', () => {
+    const out = partitionLegacyLayout(
+      { groups: [group('g1', { cwd: '/roots/b/repo' })], displayOrder: ['g1'] },
+      ctx()
+    )
+    expect(out.get(B)!.groups.map((g) => (g as { id: string }).id)).toEqual(['g1'])
+    expect(out.has(A)).toBe(false)
+  })
+
+  it('an unstamped group whose cwd is under no root goes to the fallback', () => {
+    const out = partitionLegacyLayout(
+      { groups: [group('g1', { cwd: '/elsewhere' })], displayOrder: ['g1'] },
+      ctx({ fallbackWorkspaceId: B })
+    )
+    expect(out.get(B)!.groups).toHaveLength(1)
+  })
+
+  it('an unstamped group with no cwd goes to the fallback', () => {
+    const out = partitionLegacyLayout({ groups: [group('g1')], displayOrder: ['g1'] }, ctx())
+    expect(out.get(A)!.groups).toHaveLength(1)
+  })
+
+  it('a group stamped with an UNREGISTERED workspace is re-placed by cwd, then fallback', () => {
+    const out = partitionLegacyLayout(
+      {
+        groups: [
+          group('g1', { workspaceId: 'gone', cwd: '/roots/b/x' }),
+          group('g2', { workspaceId: 'gone' })
+        ],
+        displayOrder: ['g1', 'g2']
+      },
+      ctx()
+    )
+    expect(out.get(B)!.groups.map((g) => (g as { id: string }).id)).toEqual(['g1'])
+    expect(out.get(A)!.groups.map((g) => (g as { id: string }).id)).toEqual(['g2'])
+  })
+
+  it('every group is stamped with the workspace it landed in', () => {
+    const out = partitionLegacyLayout(
+      { groups: [group('g1', { cwd: '/roots/b/x' }), group('g2')], displayOrder: [] },
+      ctx()
+    )
+    expect((out.get(B)!.groups[0] as { workspaceId: string }).workspaceId).toBe(B)
+    expect((out.get(A)!.groups[0] as { workspaceId: string }).workspaceId).toBe(A)
+  })
+
+  it('every group lands in exactly one partition — the sum equals the input', () => {
+    const groups = [
+      group('g1', { workspaceId: A }),
+      group('g2', { workspaceId: B }),
+      group('g3', { cwd: '/roots/b/y' }),
+      group('g4')
+    ]
+    const out = partitionLegacyLayout({ groups, displayOrder: [] }, ctx())
+    const landed = [...out.values()].flatMap((l) => l.groups.map((g) => (g as { id: string }).id))
+    expect(landed.sort()).toEqual(['g1', 'g2', 'g3', 'g4'])
+  })
+
+  it('a duplicated group id is kept once', () => {
+    const out = partitionLegacyLayout(
+      {
+        groups: [group('g1', { workspaceId: A }), group('g1', { workspaceId: B })],
+        displayOrder: []
+      },
+      ctx()
+    )
+    expect(out.get(A)!.groups).toHaveLength(1)
+    expect(out.has(B)).toBe(false)
+  })
+
+  it('malformed entries (no string id) are dropped, not crashed on', () => {
+    const out = partitionLegacyLayout(
+      { groups: [null, 42, { name: 'no id' }, group('ok', { workspaceId: B })], displayOrder: [] },
+      ctx()
+    )
+    expect(out.get(B)!.groups).toHaveLength(1)
+    expect(out.size).toBe(1)
+  })
+})
+
+describe('partitionLegacyLayout — displayOrder follows its items', () => {
+  it('a group id follows its group, a session id follows its record, order is preserved', () => {
+    const out = partitionLegacyLayout(
+      {
+        groups: [group('gA', { workspaceId: A }), group('gB', { workspaceId: B })],
+        displayOrder: ['sess-b', 'gA', 'sess-a', 'gB', 'sess-unknown']
+      },
+      ctx()
+    )
+    expect(out.get(A)!.displayOrder).toEqual(['gA', 'sess-a', 'sess-unknown'])
+    expect(out.get(B)!.displayOrder).toEqual(['sess-b', 'gB'])
+  })
+
+  it('a session id whose record names an unregistered workspace goes to the fallback', () => {
+    const out = partitionLegacyLayout(
+      { groups: [], displayOrder: ['s1'] },
+      ctx({ resolveWorkspaceForSession: () => 'gone', fallbackWorkspaceId: B })
+    )
+    expect(out.get(B)!.displayOrder).toEqual(['s1'])
+  })
+
+  it('duplicate and non-string order ids are dropped', () => {
+    const out = partitionLegacyLayout(
+      { groups: [], displayOrder: ['sess-a', 'sess-a', 7 as unknown as string] },
+      ctx()
+    )
+    expect(out.get(A)!.displayOrder).toEqual(['sess-a'])
+  })
+
+  it('tolerates a legacy file with missing arrays', () => {
+    const out = partitionLegacyLayout(
+      { groups: undefined as unknown as unknown[], displayOrder: undefined as unknown as string[] },
+      ctx()
+    )
+    expect(out.size).toBe(0)
+  })
+})
+
+describe('mergeLayouts — an existing per-workspace file wins', () => {
+  it('appends only unknown groups and order ids', () => {
+    const merged = mergeLayouts(
+      { groups: [group('g1', { name: 'kept' })], displayOrder: ['g1', 's1'] },
+      { groups: [group('g1', { name: 'legacy' }), group('g2')], displayOrder: ['g2', 's1', 's2'] }
+    )
+    expect(merged.groups.map((g) => (g as { id: string; name: string }).name)).toEqual([
+      'kept',
+      'g2'
+    ])
+    expect(merged.displayOrder).toEqual(['g1', 's1', 'g2', 's2'])
+  })
+
+  it('an empty existing file takes the incoming layout whole', () => {
+    const merged = mergeLayouts(
+      { groups: [], displayOrder: [] },
+      { groups: [group('g1')], displayOrder: ['g1', 's'] }
+    )
+    expect(merged.groups).toHaveLength(1)
+    expect(merged.displayOrder).toEqual(['g1', 's'])
+  })
+})
+
+describe('concatLayouts — the in-memory shape of several workspaces', () => {
+  it('concatenates in input order and deduplicates ids', () => {
+    const out = concatLayouts([
+      { groups: [group('gA')], displayOrder: ['gA', 'x'] },
+      { groups: [group('gB'), group('gA')], displayOrder: ['gB', 'x'] }
+    ])
+    expect(out.groups.map((g) => (g as { id: string }).id)).toEqual(['gA', 'gB'])
+    expect(out.displayOrder).toEqual(['gA', 'x', 'gB'])
+  })
+
+  it('is empty for no inputs', () => {
+    expect(concatLayouts([])).toEqual({ groups: [], displayOrder: [] })
+  })
+})

--- a/src/main/sidebar-layout-migration.ts
+++ b/src/main/sidebar-layout-migration.ts
@@ -1,0 +1,142 @@
+/**
+ * The one-time migration off the single `sidebar-layout.json` (PRDCT-1703).
+ *
+ * Pure: no filesystem, no Electron, so vitest pins every partition rule in
+ * node. The manager (sidebar-layout-manager.ts) reads the legacy file, calls
+ * `partitionLegacyLayout`, merges each partition into any per-workspace file
+ * that already exists (`mergeLayouts`), writes them, and RENAMES the legacy
+ * file to `sidebar-layout.json.migrated-backup` — never deletes it.
+ *
+ * A mis-partitioned layout is the classic silent defect: nothing errors, a
+ * group just shows up in the wrong workspace, or in none, days later. That
+ * is why the rules live here as testable sentences:
+ *
+ *   - a group carrying a REGISTERED workspaceId goes to that workspace;
+ *   - a group with none (or a stale id) goes to the workspace whose root
+ *     contains its cwd, else to the fallback (last-active, else the first
+ *     registered);
+ *   - every group is stamped with the workspace it landed in, so the
+ *     per-workspace file is self-describing;
+ *   - a displayOrder id that names a group follows that group;
+ *   - a displayOrder id that names a session follows the session's workspace
+ *     where the session records know it, else the fallback;
+ *   - order inside a partition is the legacy order; nothing is duplicated;
+ *   - every group lands in EXACTLY ONE partition.
+ */
+export interface SidebarLayoutData {
+  groups: unknown[]
+  displayOrder: string[]
+}
+
+export interface PartitionContext {
+  /** Registered workspace ids at migration time. */
+  workspaceIds: string[]
+  /** Where an unplaceable item goes: lastActiveWorkspaceId, else the first
+   *  registered workspace. The caller guarantees it is registered. */
+  fallbackWorkspaceId: string
+  /** `workspaceManager.resolveWorkspaceForCwd` — longest registered root
+   *  containing cwd, or null. */
+  resolveWorkspaceForCwd: (cwd: string) => string | null
+  /** Workspace of a session id from its record (stamped, else cwd-derived),
+   *  or null when no record knows it. */
+  resolveWorkspaceForSession: (sessionId: string) => string | null
+}
+
+interface GroupLike {
+  id?: unknown
+  workspaceId?: unknown
+  cwd?: unknown
+}
+
+function isRecord(x: unknown): x is Record<string, unknown> {
+  return typeof x === 'object' && x !== null && !Array.isArray(x)
+}
+
+/** Split a legacy `{groups, displayOrder}` into one layout per workspace. */
+export function partitionLegacyLayout(
+  legacy: SidebarLayoutData,
+  ctx: PartitionContext
+): Map<string, SidebarLayoutData> {
+  const registered = new Set(ctx.workspaceIds)
+  const place = (g: GroupLike): string => {
+    if (typeof g.workspaceId === 'string' && registered.has(g.workspaceId)) return g.workspaceId
+    const byCwd = typeof g.cwd === 'string' && g.cwd ? ctx.resolveWorkspaceForCwd(g.cwd) : null
+    return byCwd && registered.has(byCwd) ? byCwd : ctx.fallbackWorkspaceId
+  }
+
+  const out = new Map<string, SidebarLayoutData>()
+  const bucket = (ws: string): SidebarLayoutData => {
+    let b = out.get(ws)
+    if (!b) {
+      b = { groups: [], displayOrder: [] }
+      out.set(ws, b)
+    }
+    return b
+  }
+
+  const groupWorkspace = new Map<string, string>()
+  const seenGroupIds = new Set<string>()
+  for (const raw of Array.isArray(legacy.groups) ? legacy.groups : []) {
+    if (!isRecord(raw) || typeof raw.id !== 'string') continue
+    if (seenGroupIds.has(raw.id)) continue
+    seenGroupIds.add(raw.id)
+    const ws = place(raw)
+    groupWorkspace.set(raw.id, ws)
+    bucket(ws).groups.push({ ...raw, workspaceId: ws })
+  }
+
+  const seenOrderIds = new Set<string>()
+  for (const id of Array.isArray(legacy.displayOrder) ? legacy.displayOrder : []) {
+    if (typeof id !== 'string' || seenOrderIds.has(id)) continue
+    seenOrderIds.add(id)
+    const ws =
+      groupWorkspace.get(id) ??
+      (() => {
+        const bySession = ctx.resolveWorkspaceForSession(id)
+        return bySession && registered.has(bySession) ? bySession : ctx.fallbackWorkspaceId
+      })()
+    bucket(ws).displayOrder.push(id)
+  }
+
+  return out
+}
+
+/** Fold a migrated partition into a per-workspace file that already exists
+ *  (a workspace registered mid-run already wrote one): the existing file
+ *  wins on conflicts, incoming groups and order entries are appended only
+ *  when their id is absent. */
+export function mergeLayouts(
+  existing: SidebarLayoutData,
+  incoming: SidebarLayoutData
+): SidebarLayoutData {
+  const knownGroupIds = new Set(
+    existing.groups
+      .filter(isRecord)
+      .map((g) => g.id)
+      .filter((id): id is string => typeof id === 'string')
+  )
+  const groups = [...existing.groups]
+  for (const g of incoming.groups) {
+    if (isRecord(g) && typeof g.id === 'string' && knownGroupIds.has(g.id)) continue
+    groups.push(g)
+  }
+  const knownOrder = new Set(existing.displayOrder)
+  const displayOrder = [...existing.displayOrder]
+  for (const id of incoming.displayOrder) {
+    if (knownOrder.has(id)) continue
+    knownOrder.add(id)
+    displayOrder.push(id)
+  }
+  return { groups, displayOrder }
+}
+
+/** Concatenate several workspaces' layouts into the single in-memory shape
+ *  the renderer store holds (one flat groups array, one display order). Order
+ *  of the inputs is the order of the concatenation; ids are deduplicated the
+ *  same way `mergeLayouts` does. */
+export function concatLayouts(layouts: SidebarLayoutData[]): SidebarLayoutData {
+  return layouts.reduce<SidebarLayoutData>((acc, l) => mergeLayouts(acc, l), {
+    groups: [],
+    displayOrder: []
+  })
+}

--- a/src/main/window-registry.test.ts
+++ b/src/main/window-registry.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect } from 'vitest'
+import { WindowRegistry, type WindowLike } from './window-registry'
+
+/**
+ * The WindowRegistry's rules, without Electron. Every rule here is one the
+ * multi-window teardown, the spawn stamp, or the MCP routing leans on; a
+ * registry that gets one wrong fails SILENTLY — a spawn stamped with the wrong
+ * workspace or a tool call landing in the wrong window looks fine until
+ * someone opens a second window.
+ */
+class FakeWindow implements WindowLike {
+  private destroyed = false
+  constructor(readonly id: number) {}
+  isDestroyed(): boolean {
+    return this.destroyed
+  }
+  destroy(): void {
+    this.destroyed = true
+  }
+}
+
+function setup(focused: () => FakeWindow | null = () => null): {
+  reg: WindowRegistry<FakeWindow>
+  win: (id: number, ws: string | null) => FakeWindow
+} {
+  const reg = new WindowRegistry<FakeWindow>({ getFocusedWindow: focused })
+  return {
+    reg,
+    win: (id, ws) => {
+      const w = new FakeWindow(id)
+      reg.registerWindow(w, ws)
+      return w
+    }
+  }
+}
+
+describe('primary election', () => {
+  it('the first registered window is the primary', () => {
+    const { reg, win } = setup()
+    const a = win(1, 'A')
+    win(2, 'B')
+    expect(reg.getPrimaryWindow()).toBe(a)
+    expect(reg.isPrimary(1)).toBe(true)
+    expect(reg.isPrimary(2)).toBe(false)
+  })
+
+  it('re-elects the lowest surviving id when the primary closes', () => {
+    const { reg, win } = setup()
+    win(1, 'A')
+    const b = win(2, 'B')
+    win(3, 'C')
+    reg.unregisterWindow(1)
+    expect(reg.getPrimaryWindow()).toBe(b)
+    expect(reg.isPrimary(2)).toBe(true)
+  })
+
+  it('keeps the primary when a non-primary closes', () => {
+    const { reg, win } = setup()
+    const a = win(1, 'A')
+    win(2, 'B')
+    reg.unregisterWindow(2)
+    expect(reg.getPrimaryWindow()).toBe(a)
+  })
+
+  it('never returns a destroyed window as primary, even before unregister', () => {
+    const { reg, win } = setup()
+    const a = win(1, 'A')
+    const b = win(2, 'B')
+    a.destroy()
+    expect(reg.getPrimaryWindow()).toBe(b)
+  })
+
+  it('returns null with no windows', () => {
+    const { reg } = setup()
+    expect(reg.getPrimaryWindow()).toBeNull()
+  })
+})
+
+describe('window ↔ workspace', () => {
+  it('maps a workspace to the window showing it and back', () => {
+    const { reg, win } = setup()
+    const a = win(1, 'A')
+    expect(reg.getWindowForWorkspace('A')).toBe(a)
+    expect(reg.getWorkspaceForWindow(1)).toBe('A')
+    expect(reg.getWindowForWorkspace('nope')).toBeNull()
+    expect(reg.getWorkspaceForWindow(99)).toBeNull()
+  })
+
+  it('follows a switch', () => {
+    const { reg, win } = setup()
+    const a = win(1, 'A')
+    reg.setWindowWorkspace(1, 'B')
+    expect(reg.getWindowForWorkspace('B')).toBe(a)
+    expect(reg.getWindowForWorkspace('A')).toBeNull()
+  })
+
+  it('a workspace nobody shows is hosted by the primary', () => {
+    const { reg, win } = setup()
+    const a = win(1, 'A')
+    const b = win(2, 'B')
+    expect(reg.getHostWindowForWorkspace('C')).toBe(a)
+    expect(reg.getHostWindowForWorkspace('B')).toBe(b)
+  })
+
+  it('the hosted set: own workspace, plus the unshown ones for the primary only', () => {
+    const { reg, win } = setup()
+    win(1, 'A')
+    win(2, 'B')
+    const all = ['A', 'B', 'C', 'D']
+    expect(reg.getHostedWorkspaceIds(1, all)).toEqual(['A', 'C', 'D'])
+    expect(reg.getHostedWorkspaceIds(2, all)).toEqual(['B'])
+    expect(reg.getHostedWorkspaceIds(3, all)).toEqual([])
+  })
+
+  it('the hosted set moves when a window opens or closes', () => {
+    const { reg, win } = setup()
+    win(1, 'A')
+    const all = ['A', 'B']
+    expect(reg.getHostedWorkspaceIds(1, all)).toEqual(['A', 'B'])
+    win(2, 'B')
+    expect(reg.getHostedWorkspaceIds(1, all)).toEqual(['A'])
+    reg.unregisterWindow(2)
+    expect(reg.getHostedWorkspaceIds(1, all)).toEqual(['A', 'B'])
+  })
+})
+
+describe('write ownership (the hosting rule, enforced)', () => {
+  it('a window may write the workspace it shows', () => {
+    const { reg, win } = setup()
+    win(1, 'A')
+    win(2, 'B')
+    expect(reg.canWriteWorkspace(1, 'A')).toBe(true)
+    expect(reg.canWriteWorkspace(2, 'B')).toBe(true)
+  })
+
+  it('a window may never write a workspace another window shows', () => {
+    const { reg, win } = setup()
+    win(1, 'A')
+    win(2, 'B')
+    expect(reg.canWriteWorkspace(1, 'B')).toBe(false)
+    expect(reg.canWriteWorkspace(2, 'A')).toBe(false)
+  })
+
+  it('only the primary writes an unshown workspace', () => {
+    const { reg, win } = setup()
+    win(1, 'A')
+    win(2, 'B')
+    expect(reg.canWriteWorkspace(1, 'C')).toBe(true)
+    expect(reg.canWriteWorkspace(2, 'C')).toBe(false)
+  })
+
+  it('the null key (no-workspace mode) belongs to the primary alone', () => {
+    const { reg, win } = setup()
+    win(1, null)
+    win(2, null)
+    expect(reg.canWriteWorkspace(1, null)).toBe(true)
+    expect(reg.canWriteWorkspace(2, null)).toBe(false)
+  })
+
+  it('an unknown or destroyed window writes nothing', () => {
+    const { reg, win } = setup()
+    const a = win(1, 'A')
+    expect(reg.canWriteWorkspace(7, 'A')).toBe(false)
+    a.destroy()
+    expect(reg.canWriteWorkspace(1, 'A')).toBe(false)
+  })
+})
+
+describe('session hosting', () => {
+  it('binds a session to a window and lists it back', () => {
+    const { reg, win } = setup()
+    const a = win(1, 'A')
+    win(2, 'B')
+    reg.bindSession('s1', 1)
+    reg.bindSession('s2', 2)
+    reg.bindSession('s3', 1)
+    expect(reg.getWindowForSession('s1')).toBe(a)
+    expect(reg.getSessionsForWindow(1).sort()).toEqual(['s1', 's3'])
+    expect(reg.getSessionsForWindow(2)).toEqual(['s2'])
+  })
+
+  it('unbind forgets exactly that session', () => {
+    const { reg, win } = setup()
+    win(1, 'A')
+    reg.bindSession('s1', 1)
+    reg.bindSession('s2', 1)
+    reg.unbindSession('s1')
+    expect(reg.getWindowForSession('s1')).toBeNull()
+    expect(reg.getSessionsForWindow(1)).toEqual(['s2'])
+  })
+
+  it('a re-bind moves the session (the re-home case)', () => {
+    const { reg, win } = setup()
+    win(1, 'A')
+    const b = win(2, 'B')
+    reg.bindSession('s1', 1)
+    reg.bindSession('s1', 2)
+    expect(reg.getWindowForSession('s1')).toBe(b)
+    expect(reg.getSessionsForWindow(1)).toEqual([])
+  })
+
+  it("unregistering a window drops its bindings and no other window's", () => {
+    const { reg, win } = setup()
+    win(1, 'A')
+    const b = win(2, 'B')
+    reg.bindSession('s1', 1)
+    reg.bindSession('s2', 2)
+    reg.unregisterWindow(1)
+    expect(reg.getWindowForSession('s1')).toBeNull()
+    expect(reg.getWindowForSession('s2')).toBe(b)
+  })
+
+  it('a session bound to a destroyed window resolves to null', () => {
+    const { reg, win } = setup()
+    const a = win(1, 'A')
+    reg.bindSession('s1', 1)
+    a.destroy()
+    expect(reg.getWindowForSession('s1')).toBeNull()
+  })
+})
+
+describe('resolveTargetWindow ladder', () => {
+  it("rung 1: the subject session's hosting window wins over everything", () => {
+    const b = new FakeWindow(2)
+    const { reg, win } = setup(() => b)
+    const a = win(1, 'A')
+    reg.registerWindow(b, 'B')
+    reg.bindSession('s1', 1)
+    expect(reg.resolveTargetWindow({ sessionId: 's1', workspaceId: 'B' })).toBe(a)
+  })
+
+  it("rung 2: the workspace's host window (shown, else primary)", () => {
+    const { reg, win } = setup()
+    const a = win(1, 'A')
+    const b = win(2, 'B')
+    expect(reg.resolveTargetWindow({ workspaceId: 'B' })).toBe(b)
+    expect(reg.resolveTargetWindow({ workspaceId: 'unshown' })).toBe(a)
+  })
+
+  it('rung 3: the focused window when nothing more specific applies', () => {
+    const b = new FakeWindow(2)
+    const { reg, win } = setup(() => b)
+    win(1, 'A')
+    reg.registerWindow(b, 'B')
+    expect(reg.resolveTargetWindow({})).toBe(b)
+    expect(reg.resolveTargetWindow({ sessionId: 'unknown' })).toBe(b)
+  })
+
+  it('rung 4: the primary when nothing is focused', () => {
+    const { reg, win } = setup(() => null)
+    const a = win(1, 'A')
+    win(2, 'B')
+    expect(reg.resolveTargetWindow({})).toBe(a)
+  })
+
+  it('a focused window the registry never saw is ignored', () => {
+    const stranger = new FakeWindow(42)
+    const { reg, win } = setup(() => stranger)
+    const a = win(1, 'A')
+    expect(reg.resolveTargetWindow({})).toBe(a)
+  })
+
+  it('null when no window exists at all', () => {
+    const { reg } = setup()
+    expect(reg.resolveTargetWindow({ sessionId: 's', workspaceId: 'w' })).toBeNull()
+  })
+})
+
+describe('identity', () => {
+  it("reports the window's own identity and nothing about other windows", () => {
+    const { reg, win } = setup()
+    win(1, 'A')
+    win(2, 'B')
+    expect(reg.identityOf(2, ['A', 'B', 'C'])).toEqual({
+      windowId: 2,
+      workspaceId: 'B',
+      isPrimary: false,
+      hostedWorkspaceIds: ['B']
+    })
+    expect(reg.identityOf(1, ['A', 'B', 'C'])).toEqual({
+      windowId: 1,
+      workspaceId: 'A',
+      isPrimary: true,
+      hostedWorkspaceIds: ['A', 'C']
+    })
+    expect(reg.identityOf(9, [])).toBeNull()
+  })
+
+  it('lists live windows lowest id first', () => {
+    const { reg, win } = setup()
+    win(3, 'C')
+    const a = win(1, 'A')
+    const b = win(2, 'B')
+    reg.unregisterWindow(3)
+    expect(reg.listWindows()).toEqual([a, b])
+  })
+})

--- a/src/main/window-registry.ts
+++ b/src/main/window-registry.ts
@@ -1,0 +1,212 @@
+import { BrowserWindow } from 'electron'
+import type { WindowIdentity } from '../shared/workspace-types'
+
+export type { WindowIdentity }
+
+/**
+ * The WindowRegistry — the single in-main source of truth for multi-window
+ * Clave (PRDCT-1703). It answers three questions and nothing else:
+ *
+ *   1. which WORKSPACE does each window show (at most one window per
+ *      workspace — mirroring one workspace into two windows is out of scope),
+ *   2. which WINDOW hosts each live session (the renderer holding its xterm
+ *      and receiving its `pty:data`), bound at spawn / adoption / re-home,
+ *      unbound at exit,
+ *   3. which window is the PRIMARY — the first of the run, re-elected as the
+ *      lowest surviving id when it closes while others remain. The primary
+ *      hosts every workspace no window shows, and carries app-level
+ *      fallbacks.
+ *
+ * The registry emits nothing; callers route. It is deliberately generic over
+ * a minimal `WindowLike` so the class runs in plain node: the unit tests
+ * exercise every rule without Electron, and `BrowserWindow.getFocusedWindow`
+ * — the one Electron static the resolution ladder needs — is injected. The
+ * `windowRegistry` singleton below is the production instance.
+ *
+ * Nothing here is persisted: BrowserWindow ids restart at 1 on every launch.
+ */
+export interface WindowLike {
+  readonly id: number
+  isDestroyed(): boolean
+}
+
+export interface WindowRegistryDeps<W extends WindowLike> {
+  /** `BrowserWindow.getFocusedWindow`, injected so the registry is electron-free. */
+  getFocusedWindow: () => W | null
+}
+
+interface Entry<W extends WindowLike> {
+  win: W
+  workspaceId: string | null
+}
+
+export class WindowRegistry<W extends WindowLike = WindowLike> {
+  private readonly windows = new Map<number, Entry<W>>()
+  private readonly sessionHosts = new Map<string, number>()
+  private primaryId: number | null = null
+
+  constructor(private readonly deps: WindowRegistryDeps<W>) {}
+
+  // ── Windows ────────────────────────────────────────────────────────────────
+
+  registerWindow(win: W, workspaceId: string | null): void {
+    this.windows.set(win.id, { win, workspaceId })
+    if (this.primaryId === null || !this.isLive(this.primaryId)) this.primaryId = win.id
+  }
+
+  /** Forget a window (on 'closed'). Its session bindings are dropped — the
+   *  teardown ladder detaches those sessions BEFORE calling this, and a
+   *  re-home rebinds them through the spawn path — and the primary is
+   *  re-elected as the lowest surviving id when the primary itself left. */
+  unregisterWindow(windowId: number): void {
+    this.windows.delete(windowId)
+    for (const [sessionId, host] of this.sessionHosts) {
+      if (host === windowId) this.sessionHosts.delete(sessionId)
+    }
+    if (this.primaryId === windowId) this.primaryId = this.electPrimary()
+  }
+
+  setWindowWorkspace(windowId: number, workspaceId: string | null): void {
+    const entry = this.windows.get(windowId)
+    if (!entry) return
+    entry.workspaceId = workspaceId
+  }
+
+  getWindow(windowId: number): W | null {
+    return this.isLive(windowId) ? this.windows.get(windowId)!.win : null
+  }
+
+  /** The window SHOWING a workspace, if any (never the hidden host). */
+  getWindowForWorkspace(workspaceId: string): W | null {
+    for (const [id, entry] of this.windows) {
+      if (entry.workspaceId === workspaceId && this.isLive(id)) return entry.win
+    }
+    return null
+  }
+
+  getWorkspaceForWindow(windowId: number): string | null {
+    return this.isLive(windowId) ? this.windows.get(windowId)!.workspaceId : null
+  }
+
+  getPrimaryWindow(): W | null {
+    if (this.primaryId === null || !this.isLive(this.primaryId)) {
+      this.primaryId = this.electPrimary()
+    }
+    return this.primaryId === null ? null : this.getWindow(this.primaryId)
+  }
+
+  isPrimary(windowId: number): boolean {
+    return this.getPrimaryWindow()?.id === windowId
+  }
+
+  /** The hosting rule: a workspace's sessions are hosted by the window
+   *  showing it; a workspace no window shows is hosted by the primary. */
+  getHostWindowForWorkspace(workspaceId: string): W | null {
+    return this.getWindowForWorkspace(workspaceId) ?? this.getPrimaryWindow()
+  }
+
+  /** Every workspace a window may write for (layout file, pin refresh): the
+   *  one it shows, plus — for the primary — every registered workspace no
+   *  live window shows. `allWorkspaceIds` is the registry of the moment. */
+  getHostedWorkspaceIds(windowId: number, allWorkspaceIds: string[]): string[] {
+    if (!this.isLive(windowId)) return []
+    const own = this.windows.get(windowId)!.workspaceId
+    const hosted: string[] = own ? [own] : []
+    if (this.isPrimary(windowId)) {
+      for (const ws of allWorkspaceIds) {
+        if (ws !== own && this.getWindowForWorkspace(ws) === null) hosted.push(ws)
+      }
+    }
+    return hosted
+  }
+
+  /** May `windowId` write state scoped to `workspaceId`? True when it shows
+   *  that workspace, or when it is the primary and no window shows it. The
+   *  null key (no-workspace mode) belongs to the primary alone. */
+  canWriteWorkspace(windowId: number, workspaceId: string | null): boolean {
+    if (!this.isLive(windowId)) return false
+    if (workspaceId === null) return this.isPrimary(windowId)
+    const shown = this.getWindowForWorkspace(workspaceId)
+    if (shown) return shown.id === windowId
+    return this.isPrimary(windowId)
+  }
+
+  identityOf(windowId: number, allWorkspaceIds: string[]): WindowIdentity | null {
+    if (!this.isLive(windowId)) return null
+    return {
+      windowId,
+      workspaceId: this.windows.get(windowId)!.workspaceId,
+      isPrimary: this.isPrimary(windowId),
+      hostedWorkspaceIds: this.getHostedWorkspaceIds(windowId, allWorkspaceIds)
+    }
+  }
+
+  /** Live windows, lowest id first. */
+  listWindows(): W[] {
+    return [...this.windows.keys()]
+      .filter((id) => this.isLive(id))
+      .sort((a, b) => a - b)
+      .map((id) => this.windows.get(id)!.win)
+  }
+
+  // ── Sessions ───────────────────────────────────────────────────────────────
+
+  bindSession(sessionId: string, windowId: number): void {
+    this.sessionHosts.set(sessionId, windowId)
+  }
+
+  unbindSession(sessionId: string): void {
+    this.sessionHosts.delete(sessionId)
+  }
+
+  getWindowForSession(sessionId: string): W | null {
+    const host = this.sessionHosts.get(sessionId)
+    return host === undefined ? null : this.getWindow(host)
+  }
+
+  getSessionsForWindow(windowId: number): string[] {
+    const out: string[] = []
+    for (const [sessionId, host] of this.sessionHosts) if (host === windowId) out.push(sessionId)
+    return out
+  }
+
+  // ── Routing ────────────────────────────────────────────────────────────────
+
+  /** The ladder every UI-landing call resolves through: the subject session's
+   *  hosting window → the workspace's host window → the focused window → the
+   *  primary → null. Every rung is checked non-destroyed. */
+  resolveTargetWindow(opts: { sessionId?: string; workspaceId?: string }): W | null {
+    if (opts.sessionId) {
+      const bySession = this.getWindowForSession(opts.sessionId)
+      if (bySession) return bySession
+    }
+    if (opts.workspaceId) {
+      const byWorkspace = this.getHostWindowForWorkspace(opts.workspaceId)
+      if (byWorkspace) return byWorkspace
+    }
+    const focused = this.deps.getFocusedWindow()
+    if (focused && !focused.isDestroyed() && this.windows.has(focused.id)) return focused
+    return this.getPrimaryWindow()
+  }
+
+  // ── Internals ──────────────────────────────────────────────────────────────
+
+  private isLive(windowId: number): boolean {
+    const entry = this.windows.get(windowId)
+    return !!entry && !entry.win.isDestroyed()
+  }
+
+  private electPrimary(): number | null {
+    let lowest: number | null = null
+    for (const id of this.windows.keys()) {
+      if (this.isLive(id) && (lowest === null || id < lowest)) lowest = id
+    }
+    return lowest
+  }
+}
+
+/** The production registry. `BrowserWindow` is only touched inside the
+ *  injected lookup, never at import — this module stays loadable in node. */
+export const windowRegistry = new WindowRegistry<BrowserWindow>({
+  getFocusedWindow: () => BrowserWindow.getFocusedWindow()
+})

--- a/src/main/workspace-manager.ts
+++ b/src/main/workspace-manager.ts
@@ -39,8 +39,17 @@ interface LegacyWorkspaceEntry {
   rootDir?: string | null
 }
 
+function withLastActive(
+  base: Omit<WorkspaceStateFile, 'lastActiveWorkspaceId' | 'activeWorkspaceId'>,
+  lastActive: string | null
+): WorkspaceStateFile {
+  // Both keys carry the same value: the new one is what this build reads,
+  // the old one is what the previous release reads after a downgrade.
+  return { ...base, lastActiveWorkspaceId: lastActive, activeWorkspaceId: lastActive }
+}
+
 function emptyState(): WorkspaceStateFile {
-  return { version: 1, workspaces: [], activeWorkspaceId: null, pins: [], pinsMigrated: true }
+  return withLastActive({ version: 1, workspaces: [], pins: [], pinsMigrated: true }, null)
 }
 
 /** One-time Phase A migration: collapse the retired per-file registry into
@@ -95,13 +104,31 @@ function migrateLegacyRegistry(): WorkspaceStateFile {
   if (!activeWorkspaceId && workspaces.length > 0) activeWorkspaceId = workspaces[0].id
 
   // pinsMigrated: false → the renderer still has to import localStorage pins.
-  return { version: 1, workspaces, activeWorkspaceId, pins: [], pinsMigrated: false }
+  return withLastActive(
+    { version: 1, workspaces, pins: [], pinsMigrated: false },
+    activeWorkspaceId
+  )
 }
 
-/** Persisted workspace registry + pins. Same philosophy as sidebar-layout:
- *  synchronous write-then-rename on every change (survives a hard kill), the
- *  renderer as source of truth during a run, and an in-memory cache so the
- *  PTY layer can stamp spawns synchronously. */
+/** The pins partition a blueprint belongs to: its workspace, or the null
+ *  (unstamped) partition. The renderer's pinned-store owns the shape; main
+ *  only ever looks at this one key. */
+function pinPartition(pin: unknown): string | null {
+  const ws = (pin as { workspaceId?: unknown } | null)?.workspaceId
+  return typeof ws === 'string' ? ws : null
+}
+
+/** Persisted workspace registry + pins. Same philosophy as the sidebar
+ *  layouts: synchronous write-then-rename on every change (survives a hard
+ *  kill), the renderer as source of truth during a run, and an in-memory
+ *  cache so the PTY layer can stamp spawns synchronously.
+ *
+ *  Since multi-window (PRDCT-1703) the file is written FIELD BY FIELD from
+ *  main — `updateRegistry`, `updatePins`, `setLastActive` — instead of being
+ *  replaced whole by whichever window saved last: the registry and the pins
+ *  are global, each window only ever rewrites the pins of workspaces it
+ *  hosts, and the old global "active workspace" survives only as the
+ *  last-active default for the first window of the next run. */
 class WorkspaceManager {
   private filePath: string
   private cache: WorkspaceStateFile | null = null
@@ -113,33 +140,32 @@ class WorkspaceManager {
   load(): WorkspaceStateFile {
     if (this.cache) return this.cache
     try {
-      const data = JSON.parse(fs.readFileSync(this.filePath, 'utf-8')) as WorkspaceStateFile
-      this.cache = {
-        version: 1,
-        workspaces: Array.isArray(data.workspaces) ? data.workspaces : [],
-        activeWorkspaceId:
-          typeof data.activeWorkspaceId === 'string' ? data.activeWorkspaceId : null,
-        pins: Array.isArray(data.pins) ? data.pins : [],
-        pinsMigrated: data.pinsMigrated !== false
-      }
+      const data = JSON.parse(
+        fs.readFileSync(this.filePath, 'utf-8')
+      ) as Partial<WorkspaceStateFile>
+      // New key first, old key as the fallback for a file written by the
+      // previous release.
+      const lastActive =
+        typeof data.lastActiveWorkspaceId === 'string'
+          ? data.lastActiveWorkspaceId
+          : typeof data.activeWorkspaceId === 'string'
+            ? data.activeWorkspaceId
+            : null
+      this.cache = withLastActive(
+        {
+          version: 1,
+          workspaces: Array.isArray(data.workspaces) ? data.workspaces : [],
+          pins: Array.isArray(data.pins) ? data.pins : [],
+          pinsMigrated: data.pinsMigrated !== false
+        },
+        lastActive
+      )
     } catch {
       // First boot of the workspace model — migrate the retired registry.
       this.cache = migrateLegacyRegistry()
       this.persist()
     }
     return this.cache
-  }
-
-  save(data: WorkspaceStateFile): void {
-    this.cache = {
-      version: 1,
-      workspaces: Array.isArray(data?.workspaces) ? data.workspaces : [],
-      activeWorkspaceId:
-        typeof data?.activeWorkspaceId === 'string' ? data.activeWorkspaceId : null,
-      pins: Array.isArray(data?.pins) ? data.pins : [],
-      pinsMigrated: data?.pinsMigrated !== false
-    }
-    this.persist()
   }
 
   private persist(): void {
@@ -155,23 +181,69 @@ class WorkspaceManager {
     }
   }
 
-  getActiveWorkspaceId(): string | null {
-    return this.load().activeWorkspaceId
+  /** Replace the registry (the list of workspaces). Global: any window. */
+  updateRegistry(workspaces: Workspace[]): void {
+    const state = this.load()
+    this.cache = { ...state, workspaces: Array.isArray(workspaces) ? workspaces : [] }
+    this.persist()
+  }
+
+  /** Replace ONE partition of the pins — the blueprints stamped with
+   *  `workspaceId` (null = the unstamped ones) — leaving every other
+   *  workspace's pins untouched. `'all'` replaces the whole list: the one-time
+   *  localStorage import (Phase B) is its only caller. Either way the pins
+   *  are now migrated. */
+  updatePins(scope: string | null | 'all', pins: unknown[]): void {
+    const state = this.load()
+    const incoming = Array.isArray(pins) ? pins : []
+    const kept = scope === 'all' ? [] : state.pins.filter((p) => pinPartition(p) !== scope)
+    this.cache = { ...state, pins: [...kept, ...incoming], pinsMigrated: true }
+    this.persist()
+  }
+
+  setLastActive(workspaceId: string | null): void {
+    const state = this.load()
+    if (state.lastActiveWorkspaceId === workspaceId) return
+    this.cache = withLastActive(state, workspaceId)
+    this.persist()
+  }
+
+  getLastActiveWorkspaceId(): string | null {
+    return this.load().lastActiveWorkspaceId
+  }
+
+  /** What the first window of a run opens on: the last-active workspace when
+   *  it is still registered, else the first registered one, else null (the
+   *  no-workspace onboarding state). */
+  resolveInitialWorkspaceId(): string | null {
+    const { workspaces, lastActiveWorkspaceId } = this.load()
+    if (lastActiveWorkspaceId && workspaces.some((w) => w.id === lastActiveWorkspaceId)) {
+      return lastActiveWorkspaceId
+    }
+    return workspaces[0]?.id ?? null
   }
 
   getWorkspaces(): Workspace[] {
     return this.load().workspaces
   }
 
+  isRegistered(workspaceId: string): boolean {
+    return this.load().workspaces.some((w) => w.id === workspaceId)
+  }
+
   /** Workspace whose rootDir contains cwd (longest prefix wins — defense for
    *  nested roots even though registration rejects them). Null when outside
-   *  every registered root. Used to place legacy, unstamped session records. */
+   *  every registered root. Used to place legacy, unstamped session records
+   *  and, in the sidebar-layout migration, unstamped groups. Both sides are
+   *  realpath-normalized: a root registered through a symlink (`/tmp` is one
+   *  on macOS) must still contain the realpath'd cwd of its sessions. */
   resolveWorkspaceForCwd(cwd: string): string | null {
     const real = normalizeDir(cwd)
     let best: { id: string; len: number } | null = null
     for (const ws of this.load().workspaces) {
-      if (isInside(ws.rootDir, real) && (!best || ws.rootDir.length > best.len)) {
-        best = { id: ws.id, len: ws.rootDir.length }
+      const root = normalizeDir(ws.rootDir)
+      if (isInside(root, real) && (!best || root.length > best.len)) {
+        best = { id: ws.id, len: root.length }
       }
     }
     return best?.id ?? null

--- a/src/main/workspace-manager.ts
+++ b/src/main/workspace-manager.ts
@@ -132,6 +132,8 @@ function pinPartition(pin: unknown): string | null {
 class WorkspaceManager {
   private filePath: string
   private cache: WorkspaceStateFile | null = null
+  /** realpath is a syscall per call; roots barely change, so cache them. */
+  private normalizedRoots = new Map<string, string>()
 
   constructor() {
     this.filePath = path.join(app.getPath('userData'), 'workspace-state.json')
@@ -160,6 +162,9 @@ class WorkspaceManager {
         },
         lastActive
       )
+      // A file from the previous release carries only the old key: write it
+      // back once with both, so the new key exists from the first boot on.
+      if (typeof data.lastActiveWorkspaceId !== 'string' && lastActive !== null) this.persist()
     } catch {
       // First boot of the workspace model — migrate the retired registry.
       this.cache = migrateLegacyRegistry()
@@ -241,7 +246,11 @@ class WorkspaceManager {
     const real = normalizeDir(cwd)
     let best: { id: string; len: number } | null = null
     for (const ws of this.load().workspaces) {
-      const root = normalizeDir(ws.rootDir)
+      let root = this.normalizedRoots.get(ws.rootDir)
+      if (!root) {
+        root = normalizeDir(ws.rootDir)
+        this.normalizedRoots.set(ws.rootDir, root)
+      }
       if (isInside(root, real) && (!best || root.length > best.len)) {
         best = { id: ws.id, len: root.length }
       }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -476,7 +476,9 @@ export interface ElectronAPI {
     data: { groups: unknown[]; displayOrder: string[] }
   ) => Promise<ScopedWriteResult>
   workspaceLoad: () => Promise<WorkspaceStateFile>
-  workspaceUpdateRegistry: (workspaces: Workspace[]) => Promise<{ ok: true }>
+  workspaceUpdateRegistry: (
+    workspaces: Workspace[]
+  ) => Promise<{ ok: true } | { ok: false; reason: 'invalid' }>
   workspaceUpdatePins: (scope: string | null | 'all', pins: unknown[]) => Promise<ScopedWriteResult>
   workspaceSetLastActive: (workspaceId: string | null) => Promise<{ ok: true }>
   onWorkspaceStateChanged: (
@@ -484,7 +486,11 @@ export interface ElectronAPI {
   ) => () => void
   windowIdentity: () => Promise<WindowIdentity | null>
   onWindowWorkspaceChanged: (callback: (identity: WindowIdentity) => void) => () => void
-  windowSetWorkspace: (workspaceId: string | null) => Promise<SetWorkspaceResult>
+  windowSetWorkspace: (
+    workspaceId: string | null,
+    options?: { focus?: boolean }
+  ) => Promise<SetWorkspaceResult>
+  liveSessionsElsewhere: (workspaceIds: string[]) => Promise<string[]>
   windowOpen: (workspaceId: string) => Promise<{ windowId: number; focusedExisting: boolean }>
   getUsageLimits: () => Promise<UsageLimits | UsageError>
   gitCheckIgnored: (cwd: string, paths: string[]) => Promise<string[]>

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -3,10 +3,24 @@ import type {
   MutationResult,
   MutationScope
 } from '../shared/extensions-types'
-import type { WorkspaceStateFile } from '../shared/workspace-types'
+import type { WindowIdentity, Workspace, WorkspaceStateFile } from '../shared/workspace-types'
 import type { DownloadProgress, UpdaterState } from '../shared/updater-types'
 
-export type { DownloadProgress, UpdaterState }
+export type { DownloadProgress, UpdaterState, WindowIdentity }
+
+/** Main's answer to `windowSetWorkspace`: the guard that keeps one workspace
+ *  in one window lives in main, so a refusal names the window that shows it. */
+export type SetWorkspaceResult =
+  | { ok: true }
+  | { ok: false; reason: 'shown-elsewhere'; shownIn: number }
+  | { ok: false; reason: 'unknown-workspace' | 'no-window' }
+
+/** Main's answer to a workspace-scoped write (layout, pins): refused when the
+ *  sender does not host that workspace — loud in main's log, never silent. */
+export type ScopedWriteResult =
+  | { ok: true }
+  | { ok: false; reason: 'not-host'; hostWindowId: number | null }
+  | { ok: false; reason: 'invalid-key' }
 
 /** Endpoint identity stamped on exchange-capture events; mirrors the
  *  contract's EndpointIdentity (src/main/exchange-capture/contract). `model`
@@ -337,8 +351,9 @@ export interface ElectronAPI {
   ) => Promise<void>
   setSessionWorkspace: (id: string, workspaceId: string | null) => Promise<void>
   tmuxAvailable: () => Promise<boolean>
-  listSessionRecords: () => Promise<SessionRecord[]>
+  listSessionRecords: (workspaceId?: string) => Promise<SessionRecord[]>
   discardSessionRecord: (key: string) => Promise<void>
+  onSessionRehome: (callback: (sessionIds: string[]) => void) => () => void
   onSessionData: (id: string, callback: (data: string) => void) => () => void
   onSessionExit: (id: string, callback: (exitCode: number) => void) => () => void
   onSessionAutoTitle: (sessionId: string, callback: (title: string) => void) => () => void
@@ -453,10 +468,24 @@ export interface ElectronAPI {
   watchDir: (cwd: string, dirs?: string[]) => Promise<void>
   unwatchDir: () => Promise<void>
   onFsChanged: (callback: (cwd: string, changedDirs: string[]) => void) => () => void
-  sidebarLayoutLoad: () => Promise<{ groups: unknown[]; displayOrder: string[] }>
-  sidebarLayoutSave: (data: { groups: unknown[]; displayOrder: string[] }) => Promise<void>
+  sidebarLayoutLoad: (
+    workspaceIds: (string | null)[]
+  ) => Promise<{ groups: unknown[]; displayOrder: string[] }>
+  sidebarLayoutSave: (
+    workspaceId: string | null,
+    data: { groups: unknown[]; displayOrder: string[] }
+  ) => Promise<ScopedWriteResult>
   workspaceLoad: () => Promise<WorkspaceStateFile>
-  workspaceSave: (data: WorkspaceStateFile) => Promise<void>
+  workspaceUpdateRegistry: (workspaces: Workspace[]) => Promise<{ ok: true }>
+  workspaceUpdatePins: (scope: string | null | 'all', pins: unknown[]) => Promise<ScopedWriteResult>
+  workspaceSetLastActive: (workspaceId: string | null) => Promise<{ ok: true }>
+  onWorkspaceStateChanged: (
+    callback: (state: { workspaces: Workspace[]; pins: unknown[] }) => void
+  ) => () => void
+  windowIdentity: () => Promise<WindowIdentity | null>
+  onWindowWorkspaceChanged: (callback: (identity: WindowIdentity) => void) => () => void
+  windowSetWorkspace: (workspaceId: string | null) => Promise<SetWorkspaceResult>
+  windowOpen: (workspaceId: string) => Promise<{ windowId: number; focusedExisting: boolean }>
   getUsageLimits: () => Promise<UsageLimits | UsageError>
   gitCheckIgnored: (cwd: string, paths: string[]) => Promise<string[]>
   getGitStatus: (cwd: string) => Promise<GitStatusResult>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -289,8 +289,12 @@ const electronAPI = {
     createIpcListener<[unknown]>('window:workspace-changed', callback),
   // Ask main to show a workspace in THIS window; refused (and the other
   // window brought forward) when another window already shows it.
-  windowSetWorkspace: (workspaceId: string | null) =>
-    ipcRenderer.invoke('window:set-workspace', workspaceId),
+  windowSetWorkspace: (workspaceId: string | null, options?: { focus?: boolean }) =>
+    ipcRenderer.invoke('window:set-workspace', workspaceId, options),
+  // Live sessions of these workspaces hosted by OTHER windows — what a window
+  // taking over a workspace's layout must not prune.
+  liveSessionsElsewhere: (workspaceIds: string[]) =>
+    ipcRenderer.invoke('sessions:live-elsewhere', workspaceIds),
   // Show a workspace in a window of its own (focuses an existing one).
   windowOpen: (workspaceId: string) => ipcRenderer.invoke('window:open', workspaceId),
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -60,9 +60,15 @@ const electronAPI = {
 
   tmuxAvailable: () => ipcRenderer.invoke('tmux:available'),
 
-  listSessionRecords: () => ipcRenderer.invoke('records:list-adoptable'),
+  listSessionRecords: (workspaceId?: string) =>
+    ipcRenderer.invoke('records:list-adoptable', workspaceId),
 
   discardSessionRecord: (key: string) => ipcRenderer.invoke('records:discard', key),
+
+  // Sessions a closing window hosted, handed to this window to re-adopt
+  // (their ids; the records carry the rest).
+  onSessionRehome: (callback: (sessionIds: string[]) => void) =>
+    createIpcListener<[string[]]>('session:rehome', callback),
 
   onSessionData: (id: string, callback: (data: string) => void) =>
     createIpcListener<[string]>(`pty:data:${id}`, callback),
@@ -244,16 +250,49 @@ const electronAPI = {
   onFsChanged: (callback: (cwd: string, changedDirs: string[]) => void) =>
     createIpcListener<[string, string[]]>('fs:changed', callback),
 
-  // Sidebar layout (session groups + display order) — persisted from the main
-  // process so it survives a hard kill that drops lazily-flushed localStorage.
-  sidebarLayoutLoad: () => ipcRenderer.invoke('sidebar-layout:load'),
-  sidebarLayoutSave: (data: { groups: unknown[]; displayOrder: string[] }) =>
-    ipcRenderer.invoke('sidebar-layout:save', data),
+  // Sidebar layouts (session groups + display order), one file per workspace,
+  // persisted from the main process so they survive a hard kill that drops
+  // lazily-flushed localStorage. `load` takes the keys this window hosts
+  // (null = the unscoped, no-workspace layout) and returns them concatenated;
+  // `save` writes ONE workspace's partition and is refused by main when this
+  // window does not host that workspace.
+  sidebarLayoutLoad: (workspaceIds: (string | null)[]) =>
+    ipcRenderer.invoke('sidebar-layout:load', workspaceIds),
+  sidebarLayoutSave: (
+    workspaceId: string | null,
+    data: { groups: unknown[]; displayOrder: string[] }
+  ) => ipcRenderer.invoke('sidebar-layout:save', workspaceId, data),
 
   // Workspace registry + pins — main-process JSON storage, same crash-safety
-  // rationale as the sidebar layout.
+  // rationale as the sidebar layouts, written FIELD BY FIELD: several windows
+  // share the file, and a whole-file save was last-writer-wins.
   workspaceLoad: () => ipcRenderer.invoke('workspace:load'),
-  workspaceSave: (data: unknown) => ipcRenderer.invoke('workspace:save', data),
+  workspaceUpdateRegistry: (workspaces: unknown[]) =>
+    ipcRenderer.invoke('workspace:update-registry', workspaces),
+  workspaceUpdatePins: (scope: string | null | 'all', pins: unknown[]) =>
+    ipcRenderer.invoke('workspace:update-pins', scope, pins),
+  workspaceSetLastActive: (workspaceId: string | null) =>
+    ipcRenderer.invoke('workspace:set-last-active', workspaceId),
+  onWorkspaceStateChanged: (
+    callback: (state: { workspaces: unknown[]; pins: unknown[] }) => void
+  ) =>
+    createIpcListener<[{ workspaces: unknown[]; pins: unknown[] }]>(
+      'workspace:state-changed',
+      callback
+    ),
+
+  // This window's identity — which workspace it shows, whether it is the
+  // primary, which workspaces it hosts. A renderer only ever learns its own;
+  // main pushes it again whenever hosting moves.
+  windowIdentity: () => ipcRenderer.invoke('window:identity'),
+  onWindowWorkspaceChanged: (callback: (identity: unknown) => void) =>
+    createIpcListener<[unknown]>('window:workspace-changed', callback),
+  // Ask main to show a workspace in THIS window; refused (and the other
+  // window brought forward) when another window already shows it.
+  windowSetWorkspace: (workspaceId: string | null) =>
+    ipcRenderer.invoke('window:set-workspace', workspaceId),
+  // Show a workspace in a window of its own (focuses an existing one).
+  windowOpen: (workspaceId: string) => ipcRenderer.invoke('window:open', workspaceId),
 
   // Usage
   getUsageLimits: () => ipcRenderer.invoke('usage:get-limits'),

--- a/src/renderer/src/components/layout/AppShell.tsx
+++ b/src/renderer/src/components/layout/AppShell.tsx
@@ -112,19 +112,35 @@ export function AppShell() {
         // the active workspace. (This is the single sequential boot owner —
         // the old lazy loadWorkspaces() in Sidebar raced this effect.)
         await bootWorkspaces()
-        const activeWorkspaceId = useWorkspaceStore.getState().activeWorkspaceId
+        const wsState = useWorkspaceStore.getState()
+        const activeWorkspaceId = wsState.activeWorkspaceId
 
         // Read the previous run's saved groups BEFORE any session is adopted
         // (re-adoption mutates the layout). Then rebuild groups around the
-        // survivors and only then turn persistence on, so the saved file is
-        // never overwritten before we've loaded it.
-        const savedLayout = await window.electronAPI?.sidebarLayoutLoad?.().catch(() => null)
+        // survivors and only then turn persistence on, so the saved files are
+        // never overwritten before we've loaded them. Layouts are one file per
+        // workspace: this window loads the ones it HOSTS — the primary at boot
+        // hosts every workspace, a secondary window its own (null = the
+        // unscoped layout of no-workspace mode).
+        const layoutKeys: (string | null)[] =
+          activeWorkspaceId === null ? [null] : wsState.hostedWorkspaceIds
+        const savedLayout = await window.electronAPI
+          ?.sidebarLayoutLoad?.(layoutKeys)
+          .catch(() => null)
         const persisted = {
           groups: (savedLayout?.groups ?? []) as SessionGroup[],
           displayOrder: savedLayout?.displayOrder ?? []
         }
 
-        const survivors = (await window.electronAPI?.listSessionRecords?.()) ?? []
+        // The primary adopts every survivor (hidden where not its workspace),
+        // so cross-workspace messaging and clave_list never regress. A
+        // SECONDARY window only ever adopts — and prompts for — its own
+        // workspace's records; the live ones another window hosts are already
+        // filtered out by main (alreadyAdopted).
+        const survivors =
+          (await window.electronAPI?.listSessionRecords?.(
+            wsState.isPrimary ? undefined : (activeWorkspaceId ?? undefined)
+          )) ?? []
 
         /** Bring one record back as a tab. Live tmux survivors reattach; dead
          *  ones (plain, or tmux killed by a reboot) relaunch fresh in the same

--- a/src/renderer/src/components/layout/AppShell.tsx
+++ b/src/renderer/src/components/layout/AppShell.tsx
@@ -1,7 +1,14 @@
 import { emitTabClosed } from '../../lib/exchange-capture'
 import { useEffect, useCallback, useRef, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { useSessionStore, isFileTabId, getVisibleFlatOrder, inActiveWorkspace, enableSidebarPersistence } from '../../store/session-store'
+import {
+  useSessionStore,
+  isFileTabId,
+  getVisibleFlatOrder,
+  inActiveWorkspace,
+  enableSidebarPersistence,
+  markLayoutKeysTaken
+} from '../../store/session-store'
 import type { SessionGroup, SettingsSection } from '../../store/session-store'
 import { useAgentStore } from '../../store/agent-store'
 import { Sidebar } from './Sidebar'
@@ -26,7 +33,12 @@ import { Bars3BottomLeftIcon, MagnifyingGlassIcon } from '@heroicons/react/24/ou
 import { cn } from '../../lib/utils'
 import { usePinnedStore, initClaveFileWatchers } from '../../store/pinned-store'
 import { useWorkspaceStore } from '../../store/workspace-store'
-import { bootWorkspaces, refreshActiveWorkspacePins, cycleWorkspace } from '../../lib/workspace-actions'
+import {
+  bootWorkspaces,
+  refreshActiveWorkspacePins,
+  cycleWorkspace,
+  markBootLayoutsDone
+} from '../../lib/workspace-actions'
 import { promptRestore } from '../../store/restore-prompt-store'
 import { RestorePromptDialog } from '../ui/RestorePromptDialog'
 import { initMcpDispatcher } from '../../lib/mcp-dispatcher'
@@ -221,12 +233,18 @@ export function AppShell() {
           }
         }
 
-        // Reattach = silent, relaunch = ask. Live tmux survivors were never
-        // disrupted, so they come back unprompted (as always). Everything else
-        // needs actual process launches on the user's behalf — gate those
-        // behind the restore prompt, "Start fresh" discarding the records.
+        // Reattach = silent, relaunch = ask. Live tmux survivors of EVERY
+        // workspace this window hosts re-attach unprompted (the primary hosts
+        // all; a workspace hidden here is still hosted), so cross-workspace
+        // messaging and clave_list never regress. Dead records are OFFERED
+        // only for the workspace this window SHOWS; dead records of a
+        // hidden-hosted workspace wait until that workspace is opened, their
+        // groups kept as shells meanwhile (spec §3.6). null active
+        // (no-workspace mode) shows everything.
+        const showsWorkspace = (s: (typeof survivors)[number]): boolean =>
+          (s.workspaceId ?? activeWorkspaceId ?? null) === (activeWorkspaceId ?? null)
         const liveOnes = survivors.filter((s) => s.live)
-        const deadOnes = survivors.filter((s) => !s.live)
+        const deadOnes = survivors.filter((s) => !s.live && showsWorkspace(s))
 
         const adoptedIds: string[] = []
         for (const s of liveOnes) {
@@ -246,15 +264,28 @@ export function AppShell() {
           }
         }
 
-        // Rebuild the persisted groups around the sessions that came back.
-        if (adoptedIds.length && persisted.groups.length) {
-          useSessionStore.getState().restoreGroups(adoptedIds, persisted)
-        }
+        // Rebuild the per-workspace layouts around what survives. A group is
+        // kept if a member does: an adopted session (live, or a shown-
+        // workspace dead record the user chose to relaunch), a dead record of
+        // a HIDDEN-hosted workspace still on disk (a shell, offered when that
+        // workspace is opened), or a live session held by another window (the
+        // secondary case). Only a shown-workspace record the user discarded is
+        // gone for good — today's single-window "Start fresh".
+        const surviving = new Set(adoptedIds)
+        for (const s of survivors) if (!showsWorkspace(s)) surviving.add(s.id)
+        const hostedStringKeys = layoutKeys.filter((k): k is string => typeof k === 'string')
+        const elsewhere =
+          (await window.electronAPI?.liveSessionsElsewhere?.(hostedStringKeys).catch(() => [])) ?? []
+        for (const id of elsewhere) surviving.add(id)
+        useSessionStore.getState().mergeLayoutForKeys(layoutKeys, persisted, [...surviving])
+        markLayoutKeysTaken(layoutKeys)
       } catch (err) {
         console.error('Failed to restore sessions/groups on launch:', err)
       } finally {
-        // Turn persistence on only now — after the saved layout was loaded and
-        // groups restored — so adoption writes can't clobber the saved file.
+        // Turn persistence on only now — after the saved layouts were loaded
+        // and groups restored — so adoption writes can't clobber the files;
+        // and only now may a layout gained at runtime be merged in.
+        markBootLayoutsDone()
         enableSidebarPersistence()
       }
 
@@ -374,8 +405,12 @@ export function AppShell() {
       // Cmd+? (Cmd+Shift+/) — open help panel
       if (e.metaKey && e.shiftKey && e.key === '/') {
         e.preventDefault()
-        const { fileTreeOpen: helpFileTreeOpen, toggleFileTree: helpToggleFileTree, sidePanelTab, setSidePanelTab } =
-          useSessionStore.getState()
+        const {
+          fileTreeOpen: helpFileTreeOpen,
+          toggleFileTree: helpToggleFileTree,
+          sidePanelTab,
+          setSidePanelTab
+        } = useSessionStore.getState()
         if (helpFileTreeOpen && sidePanelTab === 'help') {
           helpToggleFileTree()
         } else {
@@ -476,7 +511,8 @@ export function AppShell() {
         if (e.key === ']') {
           nextIdx = currentIdx < 0 ? 0 : (currentIdx + 1) % flatIds.length
         } else {
-          nextIdx = currentIdx < 0 ? flatIds.length - 1 : (currentIdx - 1 + flatIds.length) % flatIds.length
+          nextIdx =
+            currentIdx < 0 ? flatIds.length - 1 : (currentIdx - 1 + flatIds.length) % flatIds.length
         }
         state.selectSession(flatIds[nextIdx], false)
       }
@@ -517,12 +553,15 @@ export function AppShell() {
     return window.electronAPI.onSshConnectionClosed((locationId) => {
       useSessionStore.setState((state) => {
         const remoteSessions = state.sessions.filter(
-          (s) => s.locationId === locationId && (s.sessionType === 'remote-terminal' || s.sessionType === 'remote-claude')
+          (s) =>
+            s.locationId === locationId &&
+            (s.sessionType === 'remote-terminal' || s.sessionType === 'remote-claude')
         )
         if (remoteSessions.length === 0) return {}
         return {
           sessions: state.sessions.map((s) =>
-            s.locationId === locationId && (s.sessionType === 'remote-terminal' || s.sessionType === 'remote-claude')
+            s.locationId === locationId &&
+            (s.sessionType === 'remote-terminal' || s.sessionType === 'remote-claude')
               ? { ...s, alive: false, activityStatus: 'ended' as const }
               : s
           )
@@ -534,46 +573,65 @@ export function AppShell() {
   // Sync agent STATUS updates to existing agent sessions in the sidebar.
   // Does NOT auto-add agents — only the picker adds agents to the sidebar.
   // Only updates sessions array when status actually changed to avoid unnecessary re-renders.
-  const syncAgentStatus = useCallback((locationId: string, typedAgents: import('../../../../shared/remote-types').Agent[]) => {
-    useSessionStore.setState((state) => {
-      const currentAgentSessions = state.sessions.filter(
-        (s) => s.sessionType === 'agent' && s.locationId === locationId
-      )
-      if (currentAgentSessions.length === 0) return {}
+  const syncAgentStatus = useCallback(
+    (locationId: string, typedAgents: import('../../../../shared/remote-types').Agent[]) => {
+      useSessionStore.setState((state) => {
+        const currentAgentSessions = state.sessions.filter(
+          (s) => s.sessionType === 'agent' && s.locationId === locationId
+        )
+        if (currentAgentSessions.length === 0) return {}
 
-      const incomingMap = new Map(typedAgents.map((a) => [a.id, a]))
-      const updates: Array<{ sessionId: string; alive: boolean; activityStatus: import('../../store/session-types').ActivityStatus; cwd?: string }> = []
+        const incomingMap = new Map(typedAgents.map((a) => [a.id, a]))
+        const updates: Array<{
+          sessionId: string
+          alive: boolean
+          activityStatus: import('../../store/session-types').ActivityStatus
+          cwd?: string
+        }> = []
 
-      for (const session of currentAgentSessions) {
-        if (!session.agentId) continue
-        const agent = incomingMap.get(session.agentId)
-        if (agent) {
-          const alive = agent.status !== 'offline'
-          const activityStatus: import('../../store/session-types').ActivityStatus =
-            agent.status === 'busy' ? 'active' : agent.status === 'offline' ? 'ended' : 'idle'
-          const cwd = agent.cwd
-          if (session.alive !== alive || session.activityStatus !== activityStatus || (cwd && session.cwd !== cwd)) {
-            updates.push({ sessionId: session.id, alive, activityStatus, cwd })
-          }
-        } else {
-          // Agent disappeared — mark offline if not already
-          if (session.alive || session.activityStatus !== 'ended') {
-            updates.push({ sessionId: session.id, alive: false, activityStatus: 'ended' })
+        for (const session of currentAgentSessions) {
+          if (!session.agentId) continue
+          const agent = incomingMap.get(session.agentId)
+          if (agent) {
+            const alive = agent.status !== 'offline'
+            const activityStatus: import('../../store/session-types').ActivityStatus =
+              agent.status === 'busy' ? 'active' : agent.status === 'offline' ? 'ended' : 'idle'
+            const cwd = agent.cwd
+            if (
+              session.alive !== alive ||
+              session.activityStatus !== activityStatus ||
+              (cwd && session.cwd !== cwd)
+            ) {
+              updates.push({ sessionId: session.id, alive, activityStatus, cwd })
+            }
+          } else {
+            // Agent disappeared — mark offline if not already
+            if (session.alive || session.activityStatus !== 'ended') {
+              updates.push({ sessionId: session.id, alive: false, activityStatus: 'ended' })
+            }
           }
         }
-      }
 
-      if (updates.length === 0) return {}
+        if (updates.length === 0) return {}
 
-      const updateMap = new Map(updates.map((u) => [u.sessionId, u]))
-      return {
-        sessions: state.sessions.map((s) => {
-          const update = updateMap.get(s.id)
-          return update ? { ...s, alive: update.alive, activityStatus: update.activityStatus, ...(update.cwd ? { cwd: update.cwd } : {}) } : s
-        })
-      }
-    })
-  }, [])
+        const updateMap = new Map(updates.map((u) => [u.sessionId, u]))
+        return {
+          sessions: state.sessions.map((s) => {
+            const update = updateMap.get(s.id)
+            return update
+              ? {
+                  ...s,
+                  alive: update.alive,
+                  activityStatus: update.activityStatus,
+                  ...(update.cwd ? { cwd: update.cwd } : {})
+                }
+              : s
+          })
+        }
+      })
+    },
+    []
+  )
 
   // Subscribe to agent updates from OpenClaw connections
   useEffect(() => {
@@ -641,21 +699,26 @@ export function AppShell() {
               onMouseDown={handleResizeStart}
               className="absolute top-0 right-0 w-2.5 h-full cursor-col-resize z-10 group/resize"
             >
-              <div className={cn(
-                'absolute top-0 right-0 h-full transition-colors border-r border-border/20',
-                draggingLeft ? 'bg-accent' : 'group-hover/resize:bg-accent/50'
-              )} style={{ width: '1.5px' }} />
+              <div
+                className={cn(
+                  'absolute top-0 right-0 h-full transition-colors border-r border-border/20',
+                  draggingLeft ? 'bg-accent' : 'group-hover/resize:bg-accent/50'
+                )}
+                style={{ width: '1.5px' }}
+              />
             </div>
           </motion.div>
         )}
       </AnimatePresence>
 
       {/* Inset main content — transparent flex container for floating boxes */}
-      <div className={cn(
-        'flex-1 flex flex-col min-w-0 my-2 gap-2 z-10 transition-[margin] duration-200',
-        sidebarOpen ? 'ml-1' : 'ml-2',
-        fileTreeOpen ? 'mr-1' : 'mr-2'
-      )}>
+      <div
+        className={cn(
+          'flex-1 flex flex-col min-w-0 my-2 gap-2 z-10 transition-[margin] duration-200',
+          sidebarOpen ? 'ml-1' : 'ml-2',
+          fileTreeOpen ? 'mr-1' : 'mr-2'
+        )}
+      >
         {/* Toolbar — its own floating card. Its row height is a token because
             the sidebar derives from it: --content-top-offset, and with it the
             launcher panel's top edge, is measured off this bar. */}
@@ -702,10 +765,7 @@ export function AppShell() {
               {/* File tree button */}
               <button
                 onClick={toggleFileTree}
-                className={cn(
-                  'btn-icon btn-icon-sm flex-shrink-0',
-                  fileTreeOpen && '!text-accent'
-                )}
+                className={cn('btn-icon btn-icon-sm flex-shrink-0', fileTreeOpen && '!text-accent')}
                 title="File tree (Cmd+E)"
               >
                 <Bars3BottomLeftIcon className="w-4 h-4 scale-x-[-1]" />
@@ -715,13 +775,17 @@ export function AppShell() {
         </div>
 
         {/* Non-terminal views — single floating card */}
-        <div className={cn(
-          'flex-1 min-h-0 floating-card',
-          activeView === 'terminals' ? 'hidden' : 'flex'
-        )}>
+        <div
+          className={cn(
+            'flex-1 min-h-0 floating-card',
+            activeView === 'terminals' ? 'hidden' : 'flex'
+          )}
+        >
           {/* view-fade-in re-fires each time a hidden panel is shown (display:none
               kills the animation, re-display restarts it). Terminals stay instant. */}
-          <div className={activeView === 'settings' ? 'flex-1 flex min-h-0 view-fade-in' : 'hidden'}>
+          <div
+            className={activeView === 'settings' ? 'flex-1 flex min-h-0 view-fade-in' : 'hidden'}
+          >
             <SettingsPanel />
           </div>
           <div className={activeView === 'agents' ? 'flex-1 flex min-h-0 view-fade-in' : 'hidden'}>
@@ -757,10 +821,13 @@ export function AppShell() {
               onMouseDown={handleTreeResizeStart}
               className="absolute top-0 left-0 w-2.5 h-full cursor-col-resize z-10 group/resize"
             >
-              <div className={cn(
-                'absolute top-0 left-0 h-full transition-colors border-l border-border/20',
-                draggingRight ? 'bg-accent' : 'group-hover/resize:bg-accent/50'
-              )} style={{ width: '1.5px' }} />
+              <div
+                className={cn(
+                  'absolute top-0 left-0 h-full transition-colors border-l border-border/20',
+                  draggingRight ? 'bg-accent' : 'group-hover/resize:bg-accent/50'
+                )}
+                style={{ width: '1.5px' }}
+              />
             </div>
             <SidePanel />
           </motion.div>
@@ -806,9 +873,7 @@ function ToolbarQuickActions() {
     <>
       {toolbarPins.map((pg, pgIdx) => (
         <div key={pg.id} className="flex items-center gap-0.5 flex-shrink-0">
-          {pgIdx > 0 && (
-            <div className="w-px h-3.5 bg-border-subtle mx-0.5" />
-          )}
+          {pgIdx > 0 && <div className="w-px h-3.5 bg-border-subtle mx-0.5" />}
           {pg.terminals.map((t, i) => {
             const key = `${pg.id}-${i}`
             const IconComp = getTerminalIconComponent(t.icon)
@@ -827,43 +892,43 @@ function ToolbarQuickActions() {
                 onOpenChange={(open) => setOpenId(open ? key : null)}
                 header={<IconComp className="w-3.5 h-3.5 shrink-0" style={{ color: colorHex }} />}
               >
-                {t.serverUrl
-                  ? (api) => (
-                      <button
-                        onClick={(e) => {
-                          if (e.altKey) api.openTerminalOnly()
-                          else api.handleClick()
-                        }}
-                        onContextMenu={(e) => {
-                          e.preventDefault()
-                          api.openTerminalOnly()
-                        }}
-                        className="relative p-1.5 rounded-lg hover:bg-surface-200 transition-colors"
-                        style={{ color: colorHex }}
-                        title={api.title}
-                      >
-                        <IconComp className="w-4 h-4" />
-                        {api.state !== 'unknown' && (
-                          <span
-                            className={cn(
-                              'absolute right-0.5 bottom-0.5 w-1.5 h-1.5 rounded-full',
-                              api.state === 'up' && 'bg-emerald-500',
-                              api.state === 'starting' && 'bg-amber-400 animate-pulse',
-                              api.state === 'down' && 'bg-text-tertiary'
-                            )}
-                          />
-                        )}
-                      </button>
-                    )
-                  : (
-                      <button
-                        className="p-1.5 rounded-lg hover:bg-surface-200 transition-colors"
-                        style={{ color: colorHex }}
-                        title={t.command || 'Shell'}
-                      >
-                        <IconComp className="w-4 h-4" />
-                      </button>
-                    )}
+                {t.serverUrl ? (
+                  (api) => (
+                    <button
+                      onClick={(e) => {
+                        if (e.altKey) api.openTerminalOnly()
+                        else api.handleClick()
+                      }}
+                      onContextMenu={(e) => {
+                        e.preventDefault()
+                        api.openTerminalOnly()
+                      }}
+                      className="relative p-1.5 rounded-lg hover:bg-surface-200 transition-colors"
+                      style={{ color: colorHex }}
+                      title={api.title}
+                    >
+                      <IconComp className="w-4 h-4" />
+                      {api.state !== 'unknown' && (
+                        <span
+                          className={cn(
+                            'absolute right-0.5 bottom-0.5 w-1.5 h-1.5 rounded-full',
+                            api.state === 'up' && 'bg-emerald-500',
+                            api.state === 'starting' && 'bg-amber-400 animate-pulse',
+                            api.state === 'down' && 'bg-text-tertiary'
+                          )}
+                        />
+                      )}
+                    </button>
+                  )
+                ) : (
+                  <button
+                    className="p-1.5 rounded-lg hover:bg-surface-200 transition-colors"
+                    style={{ color: colorHex }}
+                    title={t.command || 'Shell'}
+                  >
+                    <IconComp className="w-4 h-4" />
+                  </button>
+                )}
               </ToolbarTerminalPopover>
             )
           })}
@@ -873,4 +938,3 @@ function ToolbarQuickActions() {
     </>
   )
 }
-

--- a/src/renderer/src/lib/sidebar-layout-partition.test.ts
+++ b/src/renderer/src/lib/sidebar-layout-partition.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+import {
+  mergeLayoutForKeys,
+  partitionSidebarLayout,
+  type LayoutGroupLike,
+  type LayoutSessionLike
+} from './sidebar-layout-partition'
+
+const A = 'ws-a'
+const B = 'ws-b'
+const g = (
+  id: string,
+  sessionIds: string[],
+  workspaceId?: string,
+  terminals: { sessionId: string | null }[] = []
+): LayoutGroupLike => ({
+  id,
+  sessionIds,
+  terminals,
+  ...(workspaceId ? { workspaceId } : {})
+})
+const s = (id: string, workspaceId?: string): LayoutSessionLike => ({
+  id,
+  ...(workspaceId ? { workspaceId } : {})
+})
+
+describe('partitionSidebarLayout', () => {
+  it('splits groups by their stamp and order ids by what they name', () => {
+    const parts = partitionSidebarLayout(
+      [g('gA', ['sA'], A), g('gB', ['sB'], B)],
+      ['gA', 'sX', 'gB', 'sB2', 'tab-1'],
+      [s('sA', A), s('sB', B), s('sX', A), s('sB2', B)],
+      A
+    )
+    expect(parts.get(A)).toEqual({
+      groups: [g('gA', ['sA'], A)],
+      displayOrder: ['gA', 'sX', 'tab-1']
+    })
+    expect(parts.get(B)).toEqual({ groups: [g('gB', ['sB'], B)], displayOrder: ['gB', 'sB2'] })
+  })
+
+  it('sends unstamped items to the fallback, null included', () => {
+    const parts = partitionSidebarLayout([g('g1', ['s1'])], ['g1', 's2'], [s('s2')], null)
+    expect([...parts.keys()]).toEqual([null])
+    expect(parts.get(null)!.displayOrder).toEqual(['g1', 's2'])
+  })
+})
+
+describe('mergeLayoutForKeys', () => {
+  const store = {
+    groups: [g('gA', ['sA'], A), g('gB-old', ['sB-old'], B)],
+    displayOrder: ['gA', 'sA2', 'gB-old', 'sB-free'],
+    sessions: [s('sA', A), s('sA2', A), s('sB-free', B)]
+  }
+
+  it('replaces only the merged workspace and leaves the others untouched', () => {
+    const out = mergeLayoutForKeys(
+      store,
+      [B],
+      { groups: [g('gB-new', ['sB1', 'sB2'], B)], displayOrder: ['gB-new', 'sB-free'] },
+      ['sB1', 'sB-free'],
+      A
+    )
+    expect(out.groups.map((x) => x.id)).toEqual(['gA', 'gB-new'])
+    expect(out.groups[1].sessionIds).toEqual(['sB1'])
+    expect(out.displayOrder).toEqual(['gA', 'sA2', 'gB-new', 'sB-free'])
+  })
+
+  it('keeps a group whose members survive ELSEWHERE as a shell (no truncation)', () => {
+    const out = mergeLayoutForKeys(
+      { groups: [], displayOrder: [], sessions: [] },
+      [B],
+      { groups: [g('gB', ['hosted-elsewhere'], B)], displayOrder: ['gB'] },
+      ['hosted-elsewhere'],
+      B
+    )
+    expect(out.groups.map((x) => x.id)).toEqual(['gB'])
+    expect(out.displayOrder).toEqual(['gB'])
+  })
+
+  it('prunes a group whose members are gone everywhere, and detaches its dead terminal', () => {
+    const out = mergeLayoutForKeys(
+      { groups: [], displayOrder: [], sessions: [] },
+      [B],
+      {
+        groups: [g('dead', ['gone'], B), g('live', ['ok'], B, [{ sessionId: 'gone-term' }])],
+        displayOrder: ['dead', 'live']
+      },
+      ['ok'],
+      B
+    )
+    expect(out.groups.map((x) => x.id)).toEqual(['live'])
+    expect(out.groups[0].terminals).toEqual([{ sessionId: null }])
+    expect(out.displayOrder).toEqual(['live'])
+  })
+
+  it('never surfaces a nested session at the top level, appends missed standalone sessions', () => {
+    const out = mergeLayoutForKeys(
+      { groups: [], displayOrder: [], sessions: [s('in-group', B), s('standalone', B)] },
+      [B],
+      { groups: [g('gB', ['in-group'], B)], displayOrder: ['in-group', 'gB'] },
+      ['in-group', 'standalone'],
+      B
+    )
+    expect(out.displayOrder).toEqual(['gB', 'standalone'])
+  })
+
+  it('drops stale ids of the merged workspace from the old order', () => {
+    const out = mergeLayoutForKeys(
+      { groups: [], displayOrder: ['ghost'], sessions: [] },
+      [B],
+      { groups: [], displayOrder: [] },
+      [],
+      B
+    )
+    expect(out.displayOrder).toEqual([])
+  })
+})

--- a/src/renderer/src/lib/sidebar-layout-partition.test.ts
+++ b/src/renderer/src/lib/sidebar-layout-partition.test.ts
@@ -44,6 +44,13 @@ describe('partitionSidebarLayout', () => {
     expect([...parts.keys()]).toEqual([null])
     expect(parts.get(null)!.displayOrder).toEqual(['g1', 's2'])
   })
+
+  it('the WRITE path routes an unstamped group to the window workspace (fallback)', () => {
+    // Asymmetry with the TAKE path below: a persist in a workspace-bearing
+    // window writes an unstamped group to that workspace's file.
+    const parts = partitionSidebarLayout([g('g1', ['s1'])], ['g1'], [s('s1')], A)
+    expect(parts.get(A)!.groups.map((x) => x.id)).toEqual(['g1'])
+  })
 })
 
 describe('mergeLayoutForKeys', () => {
@@ -58,8 +65,7 @@ describe('mergeLayoutForKeys', () => {
       store,
       [B],
       { groups: [g('gB-new', ['sB1', 'sB2'], B)], displayOrder: ['gB-new', 'sB-free'] },
-      ['sB1', 'sB-free'],
-      A
+      ['sB1', 'sB-free']
     )
     expect(out.groups.map((x) => x.id)).toEqual(['gA', 'gB-new'])
     expect(out.groups[1].sessionIds).toEqual(['sB1'])
@@ -71,8 +77,7 @@ describe('mergeLayoutForKeys', () => {
       { groups: [], displayOrder: [], sessions: [] },
       [B],
       { groups: [g('gB', ['hosted-elsewhere'], B)], displayOrder: ['gB'] },
-      ['hosted-elsewhere'],
-      B
+      ['hosted-elsewhere']
     )
     expect(out.groups.map((x) => x.id)).toEqual(['gB'])
     expect(out.displayOrder).toEqual(['gB'])
@@ -86,8 +91,7 @@ describe('mergeLayoutForKeys', () => {
         groups: [g('dead', ['gone'], B), g('live', ['ok'], B, [{ sessionId: 'gone-term' }])],
         displayOrder: ['dead', 'live']
       },
-      ['ok'],
-      B
+      ['ok']
     )
     expect(out.groups.map((x) => x.id)).toEqual(['live'])
     expect(out.groups[0].terminals).toEqual([{ sessionId: null }])
@@ -99,8 +103,7 @@ describe('mergeLayoutForKeys', () => {
       { groups: [], displayOrder: [], sessions: [s('in-group', B), s('standalone', B)] },
       [B],
       { groups: [g('gB', ['in-group'], B)], displayOrder: ['in-group', 'gB'] },
-      ['in-group', 'standalone'],
-      B
+      ['in-group', 'standalone']
     )
     expect(out.displayOrder).toEqual(['gB', 'standalone'])
   })
@@ -110,9 +113,39 @@ describe('mergeLayoutForKeys', () => {
       { groups: [], displayOrder: ['ghost'], sessions: [] },
       [B],
       { groups: [], displayOrder: [] },
-      [],
-      B
+      []
     )
     expect(out.displayOrder).toEqual([])
+  })
+
+  // ── The F1 seam: taking a string workspace must NEVER claim, and then drop
+  //    from an empty file, an UNSTAMPED store group. Registering the first
+  //    workspace fired takeLayouts([W]) while the groups were still unstamped;
+  //    ownership by `?? fallback`(=W) then rebuilt W from its empty file and
+  //    dropped them. Ownership is by explicit stamp: an unstamped group is the
+  //    null partition's, never a string key's. ──
+  it('taking a string workspace keeps unstamped store groups untouched (F1)', () => {
+    const out = mergeLayoutForKeys(
+      {
+        groups: [g('orphan-one', ['o1']), g('orphan-two', ['o2'])], // UNSTAMPED
+        displayOrder: ['orphan-one', 'orphan-two'],
+        sessions: [s('o1'), s('o2')] // unstamped sessions
+      },
+      [A], // taking workspace A, whose file is empty
+      { groups: [], displayOrder: [] }, // empty file — the destructive input
+      [] // nothing "surviving" for A
+    )
+    expect(out.groups.map((x) => x.id)).toEqual(['orphan-one', 'orphan-two'])
+    expect(out.displayOrder).toEqual(['orphan-one', 'orphan-two'])
+  })
+
+  it('merging the NULL key does own unstamped groups (no-workspace boot)', () => {
+    const out = mergeLayoutForKeys(
+      { groups: [], displayOrder: [], sessions: [s('u1')] },
+      [null], // the unscoped partition
+      { groups: [g('gN', ['u1'])], displayOrder: ['gN'] }, // its file
+      ['u1']
+    )
+    expect(out.groups.map((x) => x.id)).toEqual(['gN'])
   })
 })

--- a/src/renderer/src/lib/sidebar-layout-partition.ts
+++ b/src/renderer/src/lib/sidebar-layout-partition.ts
@@ -1,0 +1,145 @@
+/**
+ * The renderer's half of per-workspace sidebar layouts (PRDCT-1703), kept
+ * pure so vitest pins it: how the one in-memory sidebar is split into one
+ * layout per workspace for writing, and how a workspace's layout read from
+ * its file is merged back into the store when a window starts hosting it.
+ *
+ * The rule both directions share: an item belongs to the workspace it is
+ * stamped with; unstamped items belong to `fallback` — this window's
+ * workspace, or null in no-workspace mode (the unscoped layout).
+ */
+export interface LayoutGroupLike {
+  id: string
+  sessionIds: string[]
+  terminals: { sessionId: string | null }[]
+  workspaceId?: string
+}
+
+export interface LayoutSessionLike {
+  id: string
+  workspaceId?: string
+  view?: { serverSessionId?: string | null } | null
+}
+
+export interface LayoutSlice<G extends LayoutGroupLike> {
+  groups: G[]
+  displayOrder: string[]
+}
+
+export type LayoutKey = string | null
+
+/** Split the sidebar into one layout per workspace. A group goes by its own
+ *  stamp; a display-order id goes by the group or session it names; anything
+ *  unstamped or unknown (file tabs, stale ids) goes to `fallback`. */
+export function partitionSidebarLayout<G extends LayoutGroupLike>(
+  groups: G[],
+  displayOrder: string[],
+  sessions: LayoutSessionLike[],
+  fallback: LayoutKey
+): Map<LayoutKey, LayoutSlice<G>> {
+  const out = new Map<LayoutKey, LayoutSlice<G>>()
+  const bucket = (key: LayoutKey): LayoutSlice<G> => {
+    let b = out.get(key)
+    if (!b) {
+      b = { groups: [], displayOrder: [] }
+      out.set(key, b)
+    }
+    return b
+  }
+  const groupKey = new Map<string, LayoutKey>()
+  for (const g of groups) {
+    const key = g.workspaceId ?? fallback
+    groupKey.set(g.id, key)
+    bucket(key).groups.push(g)
+  }
+  const sessionKey = new Map<string, LayoutKey>()
+  for (const s of sessions) sessionKey.set(s.id, s.workspaceId ?? fallback)
+  for (const id of displayOrder) {
+    const key = groupKey.has(id) ? groupKey.get(id)! : (sessionKey.get(id) ?? fallback)
+    bucket(key).displayOrder.push(id)
+  }
+  return out
+}
+
+/**
+ * Replace the partitions of `keys` in the store with `persisted` (those
+ * workspaces' layouts as read from their files), pruned to `surviving`
+ * sessions, and leave every other workspace's groups and order untouched.
+ *
+ * `surviving` is every session that still EXISTS for those workspaces — in
+ * this store, live in another window, or a record on disk — not merely the
+ * ones this window holds: a group whose members live elsewhere is kept as a
+ * shell (its rows render nothing here), because pruning it would rewrite the
+ * file without it the moment this window persists. Only a session that is
+ * gone everywhere prunes its group, exactly as boot restore does.
+ *
+ * The same shape as the boot-time restore (`restoreGroups`): a group with no
+ * surviving member is dropped, a terminal whose session is gone is detached,
+ * the persisted order is kept minus dead references, surviving standalone
+ * sessions of those workspaces the order missed are appended, then kept
+ * groups not yet placed. Ids nested inside a kept group (a member, a group
+ * terminal, a session view's hidden server) never surface at the top level.
+ */
+export function mergeLayoutForKeys<G extends LayoutGroupLike>(
+  state: { groups: G[]; displayOrder: string[]; sessions: LayoutSessionLike[] },
+  keys: LayoutKey[],
+  persisted: LayoutSlice<G>,
+  surviving: Iterable<string>,
+  fallback: LayoutKey
+): { groups: G[]; displayOrder: string[] } {
+  const keySet = new Set<LayoutKey>(keys)
+  const alive = new Set(surviving)
+  const ownsGroup = (g: G): boolean => keySet.has(g.workspaceId ?? fallback)
+  const sessionKey = new Map<string, LayoutKey>()
+  for (const s of state.sessions) sessionKey.set(s.id, s.workspaceId ?? fallback)
+
+  // Everything of OTHER workspaces stays exactly where it is.
+  const others = state.groups.filter((g) => !ownsGroup(g))
+  const otherGroupIds = new Set(others.map((g) => g.id))
+
+  const kept: G[] = []
+  for (const g of persisted.groups ?? []) {
+    const sessionIds = (g.sessionIds ?? []).filter((sid) => alive.has(sid))
+    if (sessionIds.length === 0) continue
+    const terminals = (g.terminals ?? []).map((t) =>
+      t.sessionId && !alive.has(t.sessionId) ? { ...t, sessionId: null } : t
+    )
+    kept.push({ ...g, sessionIds, terminals })
+  }
+  const keptIds = new Set(kept.map((g) => g.id))
+
+  const nested = new Set<string>()
+  for (const g of kept) {
+    for (const sid of g.sessionIds) nested.add(sid)
+    for (const t of g.terminals) if (t.sessionId) nested.add(t.sessionId)
+  }
+  for (const s of state.sessions) {
+    if (s.view?.serverSessionId) nested.add(s.view.serverSessionId)
+  }
+
+  const order: string[] = []
+  const seen = new Set<string>()
+  const push = (id: string): void => {
+    if (seen.has(id)) return
+    seen.add(id)
+    order.push(id)
+  }
+  // Other workspaces' entries keep their positions; this window's entries of
+  // the merged keys are rebuilt below. An id that names nothing known is
+  // stale and dropped.
+  for (const id of state.displayOrder) {
+    if (otherGroupIds.has(id)) push(id)
+    else if (sessionKey.has(id) && !keySet.has(sessionKey.get(id)!)) push(id)
+    else if (!sessionKey.has(id) && !keySet.size) push(id)
+  }
+  for (const id of persisted.displayOrder ?? []) {
+    if (keptIds.has(id)) push(id)
+    else if (alive.has(id) && !nested.has(id)) push(id)
+  }
+  for (const s of state.sessions) {
+    if (keySet.has(sessionKey.get(s.id)!) && !nested.has(s.id)) push(s.id)
+  }
+  for (const g of kept) push(g.id)
+
+  return { groups: [...others, ...kept], displayOrder: order }
+}

--- a/src/renderer/src/lib/sidebar-layout-partition.ts
+++ b/src/renderer/src/lib/sidebar-layout-partition.ts
@@ -73,7 +73,7 @@ export function partitionSidebarLayout<G extends LayoutGroupLike>(
  * file without it the moment this window persists. Only a session that is
  * gone everywhere prunes its group, exactly as boot restore does.
  *
- * The same shape as the boot-time restore (`restoreGroups`): a group with no
+ * The same shape the boot restore uses: a group with no
  * surviving member is dropped, a terminal whose session is gone is detached,
  * the persisted order is kept minus dead references, surviving standalone
  * sessions of those workspaces the order missed are appended, then kept
@@ -84,14 +84,24 @@ export function mergeLayoutForKeys<G extends LayoutGroupLike>(
   state: { groups: G[]; displayOrder: string[]; sessions: LayoutSessionLike[] },
   keys: LayoutKey[],
   persisted: LayoutSlice<G>,
-  surviving: Iterable<string>,
-  fallback: LayoutKey
+  surviving: Iterable<string>
 ): { groups: G[]; displayOrder: string[] } {
   const keySet = new Set<LayoutKey>(keys)
   const alive = new Set(surviving)
-  const ownsGroup = (g: G): boolean => keySet.has(g.workspaceId ?? fallback)
+  // Ownership is by EXPLICIT stamp; an unstamped item belongs to the unscoped
+  // (null) partition only, never to a string workspace being taken. This is
+  // the asymmetry with the WRITE path (partitionSidebarLayout routes an
+  // unstamped group to the window's workspace): a TAKE must never claim — and
+  // then drop from an empty file — an unstamped group that has not been
+  // stamped yet. Taking one workspace's layout leaves unstamped groups (and
+  // every other workspace's) exactly where they are; only when the NULL key
+  // itself is merged (no-workspace mode boot) does an unstamped group belong
+  // to it. (Regression guard for the first-workspace F1: registering the
+  // first workspace no longer routes the still-unstamped groups through the
+  // empty new file.)
+  const ownsGroup = (g: G): boolean => keySet.has(g.workspaceId ?? null)
   const sessionKey = new Map<string, LayoutKey>()
-  for (const s of state.sessions) sessionKey.set(s.id, s.workspaceId ?? fallback)
+  for (const s of state.sessions) sessionKey.set(s.id, s.workspaceId ?? null)
 
   // Everything of OTHER workspaces stays exactly where it is.
   const others = state.groups.filter((g) => !ownsGroup(g))

--- a/src/renderer/src/lib/workspace-actions.ts
+++ b/src/renderer/src/lib/workspace-actions.ts
@@ -8,7 +8,7 @@ import {
   type PinnedGroup,
   type PinnedGroupBlueprint
 } from '../store/pinned-store'
-import { useSessionStore } from '../store/session-store'
+import { useSessionStore, markLayoutKeysTaken, dropLayoutKeys } from '../store/session-store'
 
 /** Orchestration layer above the stores. The stores stay import-acyclic
  *  (session→workspace, pinned→workspace); everything that has to touch several
@@ -75,13 +75,84 @@ function enableWorkspacePersistence(): void {
 // ── Identity and the other windows ───────────────────────────────────────────
 
 let subscribed = false
+/** Claims in flight: a `window:workspace-changed` push that lands while this
+ *  window is itself switching must not run the view switch a second time. */
+let claimsInFlight = 0
+/** Resolved once the boot effect has restored its layouts — a key gained
+ *  before that must wait, or the boot restore would replace what it merged. */
+let bootLayoutsDone: () => void = () => {}
+const bootLayoutsReady = new Promise<void>((resolve) => {
+  bootLayoutsDone = resolve
+})
+/** Runtime layout takes, serialized: two identity pushes in a row (a window
+ *  closing, then another) must merge in order. */
+let layoutTakeQueue: Promise<void> = Promise.resolve()
+
+export function markBootLayoutsDone(): void {
+  bootLayoutsDone()
+}
+
+/**
+ * Take over the layouts of workspaces this window just started hosting: read
+ * their files and merge them into the store BEFORE anything could be written
+ * for them. Pruning uses every session that still exists for those
+ * workspaces — in this store, live in another window, or on disk as a record
+ * — so a group whose members live elsewhere (or wait for the next boot) is
+ * kept as a shell rather than dropped and written back as gone.
+ */
+export function takeLayouts(keys: (string | null)[]): Promise<void> {
+  layoutTakeQueue = layoutTakeQueue.then(async () => {
+    await bootLayoutsReady
+    if (keys.length === 0) return
+    const persisted = (await window.electronAPI?.sidebarLayoutLoad?.(keys).catch(() => null)) ?? {
+      groups: [],
+      displayOrder: []
+    }
+    const { activeWorkspaceId } = useWorkspaceStore.getState()
+    const surviving = new Set<string>()
+    for (const s of useSessionStore.getState().sessions) {
+      if (keys.includes(s.workspaceId ?? activeWorkspaceId)) surviving.add(s.id)
+    }
+    const ids = keys.filter((k): k is string => typeof k === 'string')
+    for (const id of ids) {
+      const records = (await window.electronAPI?.listSessionRecords?.(id).catch(() => [])) ?? []
+      for (const r of records) surviving.add(r.id)
+    }
+    const elsewhere = (await window.electronAPI?.liveSessionsElsewhere?.(ids).catch(() => [])) ?? []
+    for (const id of elsewhere) surviving.add(id)
+    useSessionStore
+      .getState()
+      .mergeLayoutForKeys(keys, persisted as { groups: never[]; displayOrder: string[] }, [
+        ...surviving
+      ])
+    markLayoutKeysTaken(keys)
+  })
+  return layoutTakeQueue
+}
 
 function applyIdentity(identity: WindowIdentity): void {
+  const prev = useWorkspaceStore.getState()
+  const before = new Set(prev.hostedWorkspaceIds)
+  const after = new Set(identity.hostedWorkspaceIds)
+  const gained = identity.hostedWorkspaceIds.filter((k) => !before.has(k))
+  const lost = prev.hostedWorkspaceIds.filter((k) => !after.has(k))
   useWorkspaceStore.setState({
     windowId: identity.windowId,
     isPrimary: identity.isPrimary,
     hostedWorkspaceIds: identity.hostedWorkspaceIds
   })
+  // The unscoped (null) partition follows the primary role.
+  if (identity.isPrimary && !prev.isPrimary) gained.push(null as unknown as string)
+  if (!identity.isPrimary && prev.isPrimary) lost.push(null as unknown as string)
+  if (lost.length) dropLayoutKeys(lost as (string | null)[])
+  if (gained.length) void takeLayouts(gained as (string | null)[])
+  // Main is the authority on which workspace this window shows. A change it
+  // made on its own (a later slice's picker or tool) is applied here; a
+  // change this window asked for is applied by the claim that asked.
+  if (claimsInFlight === 0 && identity.workspaceId !== prev.activeWorkspaceId && prev.loaded) {
+    useWorkspaceStore.setState({ activeWorkspaceId: identity.workspaceId })
+    useSessionStore.getState().applyWorkspaceSwitch(prev.activeWorkspaceId, identity.workspaceId)
+  }
 }
 
 /** Fold a change another window made. The registry is taken whole; of the
@@ -95,12 +166,13 @@ function foldExternalState(state: { workspaces: Workspace[]; pins: unknown[] }):
     const mine = s.pinnedGroups.filter((pg) => hostsWorkspace(pg.workspaceId))
     const known = new Map(s.pinnedGroups.map((pg) => [pg.id, pg]))
     const foreign: PinnedGroup[] = blueprints
+      .filter((bp) => typeof bp === 'object' && bp !== null && typeof bp.id === 'string')
       .filter((bp) => !hostsWorkspace(bp.workspaceId))
       .map((bp) => {
         const prev = known.get(bp.id)
         return {
           ...bp,
-          sessions: bp.sessions.map((sess) => ({
+          sessions: (Array.isArray(bp.sessions) ? bp.sessions : []).map((sess) => ({
             ...sess,
             antigravityMode:
               sess.antigravityMode ?? (sess as { geminiMode?: boolean }).geminiMode ?? false
@@ -135,18 +207,30 @@ function subscribeToMain(): void {
  *  store follows and the workspace becomes the last-active one (what the
  *  first window of the next run opens on). Does NOT run the view switch;
  *  callers that need it call applyWorkspaceSwitch themselves. */
-async function claimWorkspace(id: string | null): Promise<boolean> {
-  const res = (await window.electronAPI?.windowSetWorkspace?.(id)) ?? { ok: true as const }
-  if (!res.ok) return false
-  useWorkspaceStore.setState({ activeWorkspaceId: id })
-  void window.electronAPI?.workspaceSetLastActive?.(id)
-  return true
+async function claimWorkspace(
+  id: string | null,
+  options: { focus?: boolean } = {}
+): Promise<boolean> {
+  claimsInFlight++
+  try {
+    const res = (await window.electronAPI?.windowSetWorkspace?.(id, options)) ?? {
+      ok: true as const
+    }
+    if (!res.ok) return false
+    useWorkspaceStore.setState({ activeWorkspaceId: id })
+    void window.electronAPI?.workspaceSetLastActive?.(id)
+    return true
+  } finally {
+    claimsInFlight--
+  }
 }
 
-/** Claim the first candidate main accepts. `null` (unscoped) always succeeds. */
+/** Claim the first candidate main accepts, PROBING (no window is brought
+ *  forward on a refusal — this is a fallback landing, not a user's open).
+ *  `null` (unscoped) always succeeds. */
 async function claimFirstAvailable(candidates: (string | null)[]): Promise<string | null> {
   for (const id of candidates) {
-    if (await claimWorkspace(id)) return id
+    if (await claimWorkspace(id, { focus: false })) return id
   }
   return useWorkspaceStore.getState().activeWorkspaceId
 }

--- a/src/renderer/src/lib/workspace-actions.ts
+++ b/src/renderer/src/lib/workspace-actions.ts
@@ -8,7 +8,12 @@ import {
   type PinnedGroup,
   type PinnedGroupBlueprint
 } from '../store/pinned-store'
-import { useSessionStore, markLayoutKeysTaken, dropLayoutKeys } from '../store/session-store'
+import {
+  useSessionStore,
+  markLayoutKeysTaken,
+  dropLayoutKeys,
+  isLayoutKeyTaken
+} from '../store/session-store'
 
 /** Orchestration layer above the stores. The stores stay import-acyclic
  *  (session→workspace, pinned→workspace); everything that has to touch several
@@ -47,8 +52,9 @@ function persistPins(): void {
     const partition = serializePinnedGroups(groups.filter((pg) => pinPartition(pg) === key))
     const json = JSON.stringify(partition)
     if (lastPersistedPins.get(key) === json) continue
-    lastPersistedPins.set(key, json)
-    void window.electronAPI?.workspaceUpdatePins?.(key, partition)
+    void window.electronAPI?.workspaceUpdatePins?.(key, partition).then((res) => {
+      if (res?.ok) lastPersistedPins.set(key, json)
+    })
   }
 }
 
@@ -122,9 +128,7 @@ export function takeLayouts(keys: (string | null)[]): Promise<void> {
     for (const id of elsewhere) surviving.add(id)
     useSessionStore
       .getState()
-      .mergeLayoutForKeys(keys, persisted as { groups: never[]; displayOrder: string[] }, [
-        ...surviving
-      ])
+      .mergeLayoutForKeys(keys, persisted as { groups: never[]; displayOrder: string[] }, [...surviving])
     markLayoutKeysTaken(keys)
   })
   return layoutTakeQueue
@@ -144,8 +148,12 @@ function applyIdentity(identity: WindowIdentity): void {
   // The unscoped (null) partition follows the primary role.
   if (identity.isPrimary && !prev.isPrimary) gained.push(null as unknown as string)
   if (!identity.isPrimary && prev.isPrimary) lost.push(null as unknown as string)
-  if (lost.length) dropLayoutKeys(lost as (string | null)[])
-  if (gained.length) void takeLayouts(gained as (string | null)[])
+  if (lost.length) {
+    dropLayoutKeys(lost as (string | null)[])
+    for (const k of lost) lastPersistedPins.delete(k as string | null)
+  }
+  const toTake = (gained as (string | null)[]).filter((k) => !isLayoutKeyTaken(k))
+  if (toTake.length) void takeLayouts(toTake)
   // Main is the authority on which workspace this window shows. A change it
   // made on its own (a later slice's picker or tool) is applied here; a
   // change this window asked for is applied by the claim that asked.
@@ -412,18 +420,29 @@ export async function addWorkspace(
 
   const isFirst = workspaces.length === 0
   useWorkspaceStore.setState((s) => ({ workspaces: [...s.workspaces, ws] }))
-  // Main learns the workspace before this window claims it.
-  await persistWorkspaceRegistry()
 
   if (isFirst) {
-    // Invariant: active is null ⟺ zero workspaces. The first workspace
-    // becomes active immediately — this window claims it (no other window can
-    // be showing a workspace that did not exist a moment ago).
-    await claimWorkspace(ws.id)
-    // Leaving no-workspace mode: adopt everything that exists into the new
-    // workspace so nothing is stranded as "visible everywhere" noise.
+    // Leaving no-workspace mode. The current unscoped sidebar IS this
+    // workspace's content — there is nothing on disk to "take", so do the
+    // whole transition IN-STORE first, BEFORE main broadcasts the registry
+    // change: mark the workspace taken (so the gained-workspace identity push
+    // does not re-read its empty file and drop everything — the F1 race),
+    // make it active, and stamp every unscoped session/group/pin into it.
+    // Invariant: active is null ⟺ zero workspaces. No other window can be
+    // showing a workspace that did not exist a moment ago, so the optimistic
+    // active is safe and the claim below cannot be refused.
+    markLayoutKeysTaken([ws.id])
+    // The sole window now shows and hosts the new workspace; set both
+    // optimistically so the persist that stampUnowned triggers actually writes
+    // its file (the async identity push that would set hostedWorkspaceIds has
+    // not arrived yet). Main confirms hosting on the broadcast below.
+    useWorkspaceStore.setState({ activeWorkspaceId: ws.id, hostedWorkspaceIds: [ws.id] })
     stampUnowned(ws.id)
   }
+
+  // Main learns the workspace (and, on the first, that this window shows it).
+  await persistWorkspaceRegistry()
+  if (isFirst) await claimWorkspace(ws.id)
 
   await refreshWorkspacePins(ws)
   return ws

--- a/src/renderer/src/lib/workspace-actions.ts
+++ b/src/renderer/src/lib/workspace-actions.ts
@@ -128,7 +128,9 @@ export function takeLayouts(keys: (string | null)[]): Promise<void> {
     for (const id of elsewhere) surviving.add(id)
     useSessionStore
       .getState()
-      .mergeLayoutForKeys(keys, persisted as { groups: never[]; displayOrder: string[] }, [...surviving])
+      .mergeLayoutForKeys(keys, persisted as { groups: never[]; displayOrder: string[] }, [
+        ...surviving
+      ])
     markLayoutKeysTaken(keys)
   })
   return layoutTakeQueue

--- a/src/renderer/src/lib/workspace-actions.ts
+++ b/src/renderer/src/lib/workspace-actions.ts
@@ -1,10 +1,11 @@
-import type { Workspace, WorkspaceStateFile } from '../../../shared/workspace-types'
-import { useWorkspaceStore } from '../store/workspace-store'
+import type { WindowIdentity, Workspace } from '../../../shared/workspace-types'
+import { useWorkspaceStore, hostsWorkspace } from '../store/workspace-store'
 import {
   usePinnedStore,
   hydratePinnedGroups,
   serializePinnedGroups,
   refreshWorkspacePins,
+  type PinnedGroup,
   type PinnedGroupBlueprint
 } from '../store/pinned-store'
 import { useSessionStore } from '../store/session-store'
@@ -12,24 +13,49 @@ import { useSessionStore } from '../store/session-store'
 /** Orchestration layer above the stores. The stores stay import-acyclic
  *  (session→workspace, pinned→workspace); everything that has to touch several
  *  of them — activation side effects, add/remove cascades, persistence — lives
- *  here. UI and MCP call these, never store internals. */
+ *  here. UI and MCP call these, never store internals.
+ *
+ *  Multi-window (PRDCT-1703): this window's workspace is a per-window value
+ *  main hands over at boot (`window:identity`), and every switch ASKS MAIN
+ *  FIRST — the guard that keeps one workspace in one window lives there. The
+ *  state file is written field by field (registry, pins, last-active), and
+ *  only for the workspaces this window hosts; what other windows change
+ *  arrives as `workspace:state-changed` and is folded in below. */
 
 // ── Persistence ──────────────────────────────────────────────────────────────
 // Same latch pattern as enableSidebarPersistence: hydration must never be able
 // to clobber the state file before it has been read.
 
 let persistEnabled = false
+/** Per pins partition, the JSON last handed to main — re-sent only on change. */
+const lastPersistedPins = new Map<string | null, string>()
 
-export function persistWorkspaceState(): Promise<void> {
-  const ws = useWorkspaceStore.getState()
-  const data: WorkspaceStateFile = {
-    version: 1,
-    workspaces: ws.workspaces,
-    activeWorkspaceId: ws.activeWorkspaceId,
-    pins: serializePinnedGroups(usePinnedStore.getState().pinnedGroups),
-    pinsMigrated: true
+function pinPartition(pin: { workspaceId?: string | null }): string | null {
+  return pin.workspaceId ?? null
+}
+
+/** Write the pins of every workspace this window HOSTS whose partition
+ *  changed (the hosting rule; main refuses the rest loudly). */
+function persistPins(): void {
+  const groups = usePinnedStore.getState().pinnedGroups
+  const { hostedWorkspaceIds, isPrimary } = useWorkspaceStore.getState()
+  const keys = new Set<string | null>(hostedWorkspaceIds)
+  if (isPrimary) keys.add(null)
+  for (const pg of groups) keys.add(pinPartition(pg))
+  for (const key of keys) {
+    if (!hostsWorkspace(key)) continue
+    const partition = serializePinnedGroups(groups.filter((pg) => pinPartition(pg) === key))
+    const json = JSON.stringify(partition)
+    if (lastPersistedPins.get(key) === json) continue
+    lastPersistedPins.set(key, json)
+    void window.electronAPI?.workspaceUpdatePins?.(key, partition)
   }
-  return window.electronAPI?.workspaceSave(data) ?? Promise.resolve()
+}
+
+/** The registry is global: any window may rewrite the list of workspaces. */
+export function persistWorkspaceRegistry(): Promise<unknown> {
+  const { workspaces } = useWorkspaceStore.getState()
+  return window.electronAPI?.workspaceUpdateRegistry?.(workspaces) ?? Promise.resolve()
 }
 
 function enableWorkspacePersistence(): void {
@@ -42,8 +68,87 @@ function enableWorkspacePersistence(): void {
   usePinnedStore.subscribe((state) => {
     if (state.pinnedGroups === prevPins) return
     prevPins = state.pinnedGroups
-    void persistWorkspaceState()
+    persistPins()
   })
+}
+
+// ── Identity and the other windows ───────────────────────────────────────────
+
+let subscribed = false
+
+function applyIdentity(identity: WindowIdentity): void {
+  useWorkspaceStore.setState({
+    windowId: identity.windowId,
+    isPrimary: identity.isPrimary,
+    hostedWorkspaceIds: identity.hostedWorkspaceIds
+  })
+}
+
+/** Fold a change another window made. The registry is taken whole; of the
+ *  pins only the partitions this window does NOT host are replaced (the
+ *  hosted ones are this window's own truth), keeping the runtime state of a
+ *  pin already known here. Groups and sessions are never touched. */
+function foldExternalState(state: { workspaces: Workspace[]; pins: unknown[] }): void {
+  useWorkspaceStore.setState({ workspaces: state.workspaces })
+  const blueprints = state.pins as PinnedGroupBlueprint[]
+  usePinnedStore.setState((s) => {
+    const mine = s.pinnedGroups.filter((pg) => hostsWorkspace(pg.workspaceId))
+    const known = new Map(s.pinnedGroups.map((pg) => [pg.id, pg]))
+    const foreign: PinnedGroup[] = blueprints
+      .filter((bp) => !hostsWorkspace(bp.workspaceId))
+      .map((bp) => {
+        const prev = known.get(bp.id)
+        return {
+          ...bp,
+          sessions: bp.sessions.map((sess) => ({
+            ...sess,
+            antigravityMode:
+              sess.antigravityMode ?? (sess as { geminiMode?: boolean }).geminiMode ?? false
+          })),
+          activeGroupId: prev?.activeGroupId ?? null,
+          visible: prev?.visible ?? false
+        }
+      })
+    return { pinnedGroups: [...mine, ...foreign] }
+  })
+  // The workspace this window shows was removed from another window: land on
+  // the first remaining one this window may show, else the unscoped state.
+  const { activeWorkspaceId, workspaces } = useWorkspaceStore.getState()
+  if (activeWorkspaceId && !workspaces.some((w) => w.id === activeWorkspaceId)) {
+    void (async () => {
+      const landed = await claimFirstAvailable([...workspaces.map((w) => w.id), null])
+      useSessionStore.getState().applyWorkspaceSwitch(activeWorkspaceId, landed)
+    })()
+  }
+}
+
+function subscribeToMain(): void {
+  if (subscribed) return
+  subscribed = true
+  window.electronAPI?.onWindowWorkspaceChanged?.((identity) => applyIdentity(identity))
+  window.electronAPI?.onWorkspaceStateChanged?.((state) => foldExternalState(state))
+}
+
+/** Make this window SHOW `id` (null = unscoped): main is asked first and may
+ *  refuse — the workspace is already shown in another window, which main
+ *  then brings forward — in which case nothing changes here. On success the
+ *  store follows and the workspace becomes the last-active one (what the
+ *  first window of the next run opens on). Does NOT run the view switch;
+ *  callers that need it call applyWorkspaceSwitch themselves. */
+async function claimWorkspace(id: string | null): Promise<boolean> {
+  const res = (await window.electronAPI?.windowSetWorkspace?.(id)) ?? { ok: true as const }
+  if (!res.ok) return false
+  useWorkspaceStore.setState({ activeWorkspaceId: id })
+  void window.electronAPI?.workspaceSetLastActive?.(id)
+  return true
+}
+
+/** Claim the first candidate main accepts. `null` (unscoped) always succeeds. */
+async function claimFirstAvailable(candidates: (string | null)[]): Promise<string | null> {
+  for (const id of candidates) {
+    if (await claimWorkspace(id)) return id
+  }
+  return useWorkspaceStore.getState().activeWorkspaceId
 }
 
 // ── Boot ─────────────────────────────────────────────────────────────────────
@@ -110,13 +215,27 @@ function migrateLocalStoragePins(
 }
 
 /** Boot hydration — the single owner (called from AppShell's boot effect,
- *  before session adoption so adoption can stamp against the registry). */
+ *  before session adoption so adoption can stamp against the registry).
+ *  This window's workspace comes from main's registry (`window:identity`),
+ *  never from the state file; outside Electron there is no identity and the
+ *  renderer behaves as the sole, primary window on the last-active one. */
 export async function bootWorkspaces(): Promise<void> {
+  const identity = (await window.electronAPI?.windowIdentity?.().catch(() => null)) ?? null
   const state = await window.electronAPI?.workspaceLoad?.().catch(() => null)
   const workspaces = state?.workspaces ?? []
-  const activeWorkspaceId = state?.activeWorkspaceId ?? null
+  const activeWorkspaceId = identity
+    ? identity.workspaceId
+    : (state?.lastActiveWorkspaceId ?? state?.activeWorkspaceId ?? null)
 
-  useWorkspaceStore.setState({ workspaces, activeWorkspaceId, loaded: true })
+  useWorkspaceStore.setState({
+    workspaces,
+    activeWorkspaceId,
+    loaded: true,
+    windowId: identity?.windowId ?? null,
+    isPrimary: identity?.isPrimary ?? true,
+    hostedWorkspaceIds: identity?.hostedWorkspaceIds ?? workspaces.map((w) => w.id)
+  })
+  subscribeToMain()
 
   let pins: PinnedGroupBlueprint[]
   if (state && !state.pinsMigrated) {
@@ -135,9 +254,13 @@ export async function bootWorkspaces(): Promise<void> {
   enableWorkspacePersistence()
 
   if (state && !state.pinsMigrated) {
-    // Persist the migrated pins (flips pinsMigrated true), then retire the
-    // localStorage key for good.
-    await persistWorkspaceState()
+    // Persist the migrated pins — the whole list at once, this being the sole
+    // window of the very first boot of the workspace model (flips
+    // pinsMigrated true) — then retire the localStorage key for good.
+    await window.electronAPI?.workspaceUpdatePins?.(
+      'all',
+      serializePinnedGroups(usePinnedStore.getState().pinnedGroups)
+    )
     localStorage.removeItem('clave-pinned-groups')
   }
 }
@@ -152,16 +275,17 @@ export async function refreshActiveWorkspacePins(): Promise<void> {
 
 // ── Workspace mutations ──────────────────────────────────────────────────────
 
-/** Pure view switch. Persists BEFORE returning so the main-process cache is
- *  current when the next pty:spawn stamps its record (IPC is FIFO). */
+/** Pure view switch. Main is asked BEFORE anything changes here, so its
+ *  registry is current when the next pty:spawn stamps its record (IPC is
+ *  FIFO) — and so a workspace another window shows is never switched to:
+ *  that window comes forward and this one keeps its view. */
 export async function setActiveWorkspace(id: string): Promise<void> {
   const { workspaces, activeWorkspaceId } = useWorkspaceStore.getState()
   if (id === activeWorkspaceId) return
   const target = workspaces.find((w) => w.id === id)
   if (!target) return
 
-  useWorkspaceStore.setState({ activeWorkspaceId: id })
-  await persistWorkspaceState()
+  if (!(await claimWorkspace(id))) return
   useSessionStore.getState().applyWorkspaceSwitch(activeWorkspaceId, id)
   // Refresh from files in the background — the switch itself must be instant.
   void refreshWorkspacePins(target)
@@ -203,20 +327,20 @@ export async function addWorkspace(
   }
 
   const isFirst = workspaces.length === 0
-  useWorkspaceStore.setState((s) => ({
-    workspaces: [...s.workspaces, ws],
-    // Invariant: active is null ⟺ zero workspaces. The first workspace
-    // becomes active immediately.
-    activeWorkspaceId: isFirst ? ws.id : s.activeWorkspaceId
-  }))
+  useWorkspaceStore.setState((s) => ({ workspaces: [...s.workspaces, ws] }))
+  // Main learns the workspace before this window claims it.
+  await persistWorkspaceRegistry()
 
   if (isFirst) {
+    // Invariant: active is null ⟺ zero workspaces. The first workspace
+    // becomes active immediately — this window claims it (no other window can
+    // be showing a workspace that did not exist a moment ago).
+    await claimWorkspace(ws.id)
     // Leaving no-workspace mode: adopt everything that exists into the new
     // workspace so nothing is stranded as "visible everywhere" noise.
     stampUnowned(ws.id)
   }
 
-  await persistWorkspaceState()
   await refreshWorkspacePins(ws)
   return ws
 }
@@ -245,14 +369,14 @@ export async function renameWorkspace(id: string, name: string): Promise<void> {
   useWorkspaceStore.setState((s) => ({
     workspaces: s.workspaces.map((w) => (w.id === id ? { ...w, name: trimmed } : w))
   }))
-  await persistWorkspaceState()
+  await persistWorkspaceRegistry()
 }
 
 export async function setWorkspaceProfile(id: string, profileFile: string | null): Promise<void> {
   useWorkspaceStore.setState((s) => ({
     workspaces: s.workspaces.map((w) => (w.id === id ? { ...w, profileFile } : w))
   }))
-  await persistWorkspaceState()
+  await persistWorkspaceRegistry()
   const ws = useWorkspaceStore.getState().workspaces.find((w) => w.id === id)
   if (ws) await refreshWorkspacePins(ws)
 }
@@ -309,12 +433,18 @@ export async function removeWorkspace(id: string): Promise<void> {
   }
 
   const wasActive = id === activeWorkspaceId
-  useWorkspaceStore.setState((s) => ({
-    workspaces: s.workspaces.filter((w) => w.id !== id),
-    activeWorkspaceId: wasActive ? targetId : s.activeWorkspaceId
-  }))
-  await persistWorkspaceState()
+  useWorkspaceStore.setState((s) => ({ workspaces: s.workspaces.filter((w) => w.id !== id) }))
+  await persistWorkspaceRegistry()
   if (wasActive) {
-    useSessionStore.getState().applyWorkspaceSwitch(id, targetId)
+    // The preferred target may be shown in another window (main refuses it);
+    // land on the first remaining workspace this window may show, else the
+    // unscoped state.
+    const remaining = useWorkspaceStore.getState().workspaces.map((w) => w.id)
+    const landed = await claimFirstAvailable([
+      ...(targetId ? [targetId] : []),
+      ...remaining.filter((w) => w !== targetId),
+      null
+    ])
+    useSessionStore.getState().applyWorkspaceSwitch(id, landed)
   }
 }

--- a/src/renderer/src/store/session-store.ts
+++ b/src/renderer/src/store/session-store.ts
@@ -273,8 +273,7 @@ function persistSidebarLayout(state: {
   // hosting rule; main refuses the rest loudly). Hosted keys with no items
   // still get written, so deleting the last group of a workspace reaches its
   // file.
-  const hosted: (string | null)[] =
-    ws.activeWorkspaceId === null ? [null] : ws.hostedWorkspaceIds
+  const hosted: (string | null)[] = ws.activeWorkspaceId === null ? [null] : ws.hostedWorkspaceIds
   for (const key of new Set<string | null>([...hosted, ...parts.keys()])) {
     if (!hosted.includes(key) || !layoutKeysTaken.has(key)) continue
     const part = parts.get(key) ?? { groups: [], displayOrder: [] }

--- a/src/renderer/src/store/session-store.ts
+++ b/src/renderer/src/store/session-store.ts
@@ -19,6 +19,7 @@ import type {
 } from './session-types'
 import type { Agent, AgentStatus } from '../../../shared/remote-types'
 import { useWorkspaceStore } from './workspace-store'
+import { partitionSidebarLayout, mergeLayoutForKeys } from '../lib/sidebar-layout-partition'
 
 // Re-export types and constants so existing imports continue to work
 export type { Theme, AppIcon, ActivityStatus, GroupTerminalConfig, GroupTerminalColor, GroupTerminalIcon, GroupViewConfig, SessionViewConfig, Session, SessionGroup, FileTab, ActiveView, SettingsSection, ExtensionsSection, SessionType }
@@ -107,6 +108,16 @@ interface SessionState {
   restoreGroups: (
     survivingSessionIds: string[],
     persisted: { groups: SessionGroup[]; displayOrder: string[] }
+  ) => void
+  /** Replace the layout of the given workspaces (null = unscoped) with the
+   *  one read from their files, pruned to `survivingSessionIds` (sessions
+   *  that still exist anywhere — here, in another window, or on disk), and
+   *  leave every other workspace's groups untouched. The runtime counterpart
+   *  of restoreGroups, for a window that starts hosting a workspace. */
+  mergeLayoutForKeys: (
+    keys: (string | null)[],
+    persisted: { groups: SessionGroup[]; displayOrder: string[] },
+    survivingSessionIds: string[]
   ) => void
   selectSession: (id: string, addToSelection: boolean) => void
   selectSessions: (ids: string[]) => void
@@ -219,44 +230,32 @@ let groupCounter = 0
 let sidebarPersistEnabled = false
 let lastPersistedGroups: SessionGroup[] | null = null
 let lastPersistedOrder: string[] | null = null
-/** Per layout key, the JSON last handed to main: a partition is re-sent only
- *  when IT changed, so a group edit in one workspace never rewrites the
- *  others' files. */
+/** Per layout key, the JSON last handed to main — a partition is re-sent
+ *  only when IT changed, so a group edit in one workspace never rewrites the
+ *  others' files. Set only once main accepted the write (a refused write must
+ *  be retried, not remembered as done). */
 const lastPersistedPartitions = new Map<string | null, string>()
+/** Layout keys this window has TAKEN: loaded from their files and merged into
+ *  the store. Only a taken key is ever written — a window that merely hosts a
+ *  workspace, before it has read that workspace's layout, must not overwrite
+ *  the file with an empty partition. Boot marks its keys taken after the
+ *  restore; a key gained at runtime is taken by `takeLayouts` (workspace-
+ *  actions); a key lost is dropped so regaining it reloads the file. */
+const layoutKeysTaken = new Set<string | null>()
 
-/** Split the in-memory sidebar into one layout per workspace (multi-window:
- *  a window shows one workspace, and each workspace's layout is its own file).
- *  A group goes by its own stamp; a display-order id goes by the group or
- *  session it names; anything unstamped or unknown goes to `fallback` — this
- *  window's workspace (null in no-workspace mode, the unscoped layout). */
-export function partitionSidebarLayout(
-  groups: SessionGroup[],
-  displayOrder: string[],
-  sessions: Session[],
-  fallback: string | null
-): Map<string | null, { groups: SessionGroup[]; displayOrder: string[] }> {
-  const out = new Map<string | null, { groups: SessionGroup[]; displayOrder: string[] }>()
-  const bucket = (key: string | null): { groups: SessionGroup[]; displayOrder: string[] } => {
-    let b = out.get(key)
-    if (!b) {
-      b = { groups: [], displayOrder: [] }
-      out.set(key, b)
-    }
-    return b
+export function markLayoutKeysTaken(keys: (string | null)[]): void {
+  for (const k of keys) layoutKeysTaken.add(k)
+}
+
+export function dropLayoutKeys(keys: (string | null)[]): void {
+  for (const k of keys) {
+    layoutKeysTaken.delete(k)
+    lastPersistedPartitions.delete(k)
   }
-  const groupKey = new Map<string, string | null>()
-  for (const g of groups) {
-    const key = g.workspaceId ?? fallback
-    groupKey.set(g.id, key)
-    bucket(key).groups.push(g)
-  }
-  const sessionKey = new Map<string, string | null>()
-  for (const s of sessions) sessionKey.set(s.id, s.workspaceId ?? fallback)
-  for (const id of displayOrder) {
-    const key = groupKey.has(id) ? groupKey.get(id)! : (sessionKey.get(id) ?? fallback)
-    bucket(key).displayOrder.push(id)
-  }
-  return out
+}
+
+export function isLayoutKeyTaken(key: string | null): boolean {
+  return layoutKeysTaken.has(key)
 }
 
 function persistSidebarLayout(state: {
@@ -270,19 +269,25 @@ function persistSidebarLayout(state: {
   lastPersistedOrder = displayOrder
   const ws = useWorkspaceStore.getState()
   const parts = partitionSidebarLayout(groups, displayOrder, sessions, ws.activeWorkspaceId)
-  // Only the workspaces THIS window hosts are written (the hosting rule; main
-  // refuses the rest loudly). Hosted keys with no items still get written, so
-  // deleting the last group of a workspace reaches its file.
-  const hosted: (string | null)[] = ws.activeWorkspaceId === null ? [null] : ws.hostedWorkspaceIds
+  // Only the workspaces THIS window hosts AND has taken are written (the
+  // hosting rule; main refuses the rest loudly). Hosted keys with no items
+  // still get written, so deleting the last group of a workspace reaches its
+  // file.
+  const hosted: (string | null)[] =
+    ws.activeWorkspaceId === null ? [null] : ws.hostedWorkspaceIds
   for (const key of new Set<string | null>([...hosted, ...parts.keys()])) {
-    if (!hosted.includes(key)) continue
+    if (!hosted.includes(key) || !layoutKeysTaken.has(key)) continue
     const part = parts.get(key) ?? { groups: [], displayOrder: [] }
     const json = JSON.stringify(part)
     if (lastPersistedPartitions.get(key) === json) continue
-    lastPersistedPartitions.set(key, json)
-    window.electronAPI?.sidebarLayoutSave?.(key, part).catch(() => {
-      // Persistence failures are non-fatal — groups stay in memory for this run.
-    })
+    window.electronAPI
+      ?.sidebarLayoutSave?.(key, part)
+      .then((res) => {
+        if (res?.ok) lastPersistedPartitions.set(key, json)
+      })
+      .catch(() => {
+        // Persistence failures are non-fatal — groups stay in memory for this run.
+      })
   }
 }
 
@@ -637,6 +642,19 @@ export const useSessionStore = create<SessionState>((set) => ({
       groupCounter = Math.max(groupCounter, groups.length)
 
       return { ...state, groups, displayOrder: order }
+    }),
+
+  mergeLayoutForKeys: (keys, persisted, survivingSessionIds) =>
+    set((state) => {
+      const merged = mergeLayoutForKeys(
+        state,
+        keys,
+        persisted,
+        survivingSessionIds,
+        useWorkspaceStore.getState().activeWorkspaceId
+      )
+      groupCounter = Math.max(groupCounter, merged.groups.length)
+      return { ...state, groups: merged.groups, displayOrder: merged.displayOrder }
     }),
 
   removeSession: (id) =>

--- a/src/renderer/src/store/session-store.ts
+++ b/src/renderer/src/store/session-store.ts
@@ -219,14 +219,71 @@ let groupCounter = 0
 let sidebarPersistEnabled = false
 let lastPersistedGroups: SessionGroup[] | null = null
 let lastPersistedOrder: string[] | null = null
+/** Per layout key, the JSON last handed to main: a partition is re-sent only
+ *  when IT changed, so a group edit in one workspace never rewrites the
+ *  others' files. */
+const lastPersistedPartitions = new Map<string | null, string>()
 
-function persistSidebarLayout(groups: SessionGroup[], displayOrder: string[]): void {
+/** Split the in-memory sidebar into one layout per workspace (multi-window:
+ *  a window shows one workspace, and each workspace's layout is its own file).
+ *  A group goes by its own stamp; a display-order id goes by the group or
+ *  session it names; anything unstamped or unknown goes to `fallback` — this
+ *  window's workspace (null in no-workspace mode, the unscoped layout). */
+export function partitionSidebarLayout(
+  groups: SessionGroup[],
+  displayOrder: string[],
+  sessions: Session[],
+  fallback: string | null
+): Map<string | null, { groups: SessionGroup[]; displayOrder: string[] }> {
+  const out = new Map<string | null, { groups: SessionGroup[]; displayOrder: string[] }>()
+  const bucket = (key: string | null): { groups: SessionGroup[]; displayOrder: string[] } => {
+    let b = out.get(key)
+    if (!b) {
+      b = { groups: [], displayOrder: [] }
+      out.set(key, b)
+    }
+    return b
+  }
+  const groupKey = new Map<string, string | null>()
+  for (const g of groups) {
+    const key = g.workspaceId ?? fallback
+    groupKey.set(g.id, key)
+    bucket(key).groups.push(g)
+  }
+  const sessionKey = new Map<string, string | null>()
+  for (const s of sessions) sessionKey.set(s.id, s.workspaceId ?? fallback)
+  for (const id of displayOrder) {
+    const key = groupKey.has(id) ? groupKey.get(id)! : (sessionKey.get(id) ?? fallback)
+    bucket(key).displayOrder.push(id)
+  }
+  return out
+}
+
+function persistSidebarLayout(state: {
+  groups: SessionGroup[]
+  displayOrder: string[]
+  sessions: Session[]
+}): void {
+  const { groups, displayOrder, sessions } = state
   if (groups === lastPersistedGroups && displayOrder === lastPersistedOrder) return
   lastPersistedGroups = groups
   lastPersistedOrder = displayOrder
-  window.electronAPI?.sidebarLayoutSave?.({ groups, displayOrder }).catch(() => {
-    // Persistence failures are non-fatal — groups stay in memory for this run.
-  })
+  const ws = useWorkspaceStore.getState()
+  const parts = partitionSidebarLayout(groups, displayOrder, sessions, ws.activeWorkspaceId)
+  // Only the workspaces THIS window hosts are written (the hosting rule; main
+  // refuses the rest loudly). Hosted keys with no items still get written, so
+  // deleting the last group of a workspace reaches its file.
+  const hosted: (string | null)[] = ws.activeWorkspaceId === null ? [null] : ws.hostedWorkspaceIds
+  for (const key of new Set<string | null>([...hosted, ...parts.keys()])) {
+    if (!hosted.includes(key)) continue
+    const part = parts.get(key) ?? { groups: [], displayOrder: [] }
+    const json = JSON.stringify(part)
+    if (lastPersistedPartitions.get(key) === json) continue
+    lastPersistedPartitions.set(key, json)
+    window.electronAPI?.sidebarLayoutSave?.(key, part).catch(() => {
+      // Persistence failures are non-fatal — groups stay in memory for this run.
+    })
+  }
 }
 
 /** Mirror a session's tab name into its tmux sidecar (main process), so the
@@ -254,8 +311,7 @@ function persistSessionName(
  *  overwrite the saved file before we read it. */
 export function enableSidebarPersistence(): void {
   sidebarPersistEnabled = true
-  const { groups, displayOrder } = useSessionStore.getState()
-  persistSidebarLayout(groups, displayOrder)
+  persistSidebarLayout(useSessionStore.getState())
 }
 
 type SidebarSnapshot = {
@@ -1414,6 +1470,6 @@ export const useSessionStore = create<SessionState>((set) => ({
 useSessionStore.subscribe((state) => {
   if (!sidebarPersistEnabled) return
   if (state.groups !== lastPersistedGroups || state.displayOrder !== lastPersistedOrder) {
-    persistSidebarLayout(state.groups, state.displayOrder)
+    persistSidebarLayout(state)
   }
 })

--- a/src/renderer/src/store/session-store.ts
+++ b/src/renderer/src/store/session-store.ts
@@ -102,18 +102,11 @@ interface SessionState {
   addSession: (session: Session) => void
   removeSession: (id: string) => void
   resetSessions: () => Promise<void>
-  /** Rebuild groups + display order from a persisted layout after tmux-backed
-   *  sessions have been re-adopted on launch. Dangling references (sessions
-   *  whose tmux session did not survive) are pruned. */
-  restoreGroups: (
-    survivingSessionIds: string[],
-    persisted: { groups: SessionGroup[]; displayOrder: string[] }
-  ) => void
   /** Replace the layout of the given workspaces (null = unscoped) with the
    *  one read from their files, pruned to `survivingSessionIds` (sessions
    *  that still exist anywhere — here, in another window, or on disk), and
    *  leave every other workspace's groups untouched. The runtime counterpart
-   *  of restoreGroups, for a window that starts hosting a workspace. */
+   *  the boot restore, for a window that starts hosting a workspace. */
   mergeLayoutForKeys: (
     keys: (string | null)[],
     persisted: { groups: SessionGroup[]; displayOrder: string[] },
@@ -571,87 +564,9 @@ export const useSessionStore = create<SessionState>((set) => ({
     })
   },
 
-  restoreGroups: (survivingSessionIds, persisted) =>
-    set((state) => {
-      const persistedGroups = persisted?.groups ?? []
-      if (persistedGroups.length === 0) return state
-
-      const surviving = new Set(survivingSessionIds)
-
-      // Prune each group to the sessions/terminals that actually came back.
-      // A group whose members all vanished is dropped (it would render empty).
-      const groups: SessionGroup[] = []
-      for (const g of persistedGroups) {
-        const sessionIds = (g.sessionIds ?? []).filter((sid) => surviving.has(sid))
-        if (sessionIds.length === 0) continue
-        const terminals = (g.terminals ?? []).map((t) =>
-          t.sessionId && !surviving.has(t.sessionId) ? { ...t, sessionId: null } : t
-        )
-        // Legacy stamp: groups persisted before the workspace model inherit
-        // their first surviving member's workspace (adoption stamped it).
-        const memberWorkspaceId = state.sessions.find((s) => s.id === sessionIds[0])?.workspaceId
-        groups.push({ ...g, sessionIds, terminals, workspaceId: g.workspaceId ?? memberWorkspaceId })
-      }
-      if (groups.length === 0) return state
-
-      const keptGroupIds = new Set(groups.map((g) => g.id))
-      // Sessions nested inside a kept group (as a member or a group terminal)
-      // must not also appear at the top level of the display order.
-      const nested = new Set<string>()
-      for (const g of groups) {
-        for (const sid of g.sessionIds) nested.add(sid)
-        for (const t of g.terminals) if (t.sessionId) nested.add(t.sessionId)
-      }
-      // A session view's hidden serving session is nested the same way a group
-      // terminal's is — it must never surface as a top-level row.
-      for (const sess of state.sessions) {
-        if (sess.view?.serverSessionId) nested.add(sess.view.serverSessionId)
-      }
-
-      // Rebuild displayOrder from the persisted order, dropping dead references.
-      const order: string[] = []
-      const seen = new Set<string>()
-      for (const id of persisted?.displayOrder ?? []) {
-        if (seen.has(id)) continue
-        if (keptGroupIds.has(id)) {
-          order.push(id)
-          seen.add(id)
-        } else if (surviving.has(id) && !nested.has(id)) {
-          order.push(id)
-          seen.add(id)
-        }
-      }
-      // Append any surviving standalone session the persisted order missed,
-      // then any kept group not yet placed (belt-and-suspenders).
-      for (const s of state.sessions) {
-        if (!seen.has(s.id) && !nested.has(s.id)) {
-          order.push(s.id)
-          seen.add(s.id)
-        }
-      }
-      for (const g of groups) {
-        if (!seen.has(g.id)) {
-          order.push(g.id)
-          seen.add(g.id)
-        }
-      }
-
-      // Keep auto-generated group names ("Group N") from colliding with the
-      // restored ones on the next createGroup.
-      groupCounter = Math.max(groupCounter, groups.length)
-
-      return { ...state, groups, displayOrder: order }
-    }),
-
   mergeLayoutForKeys: (keys, persisted, survivingSessionIds) =>
     set((state) => {
-      const merged = mergeLayoutForKeys(
-        state,
-        keys,
-        persisted,
-        survivingSessionIds,
-        useWorkspaceStore.getState().activeWorkspaceId
-      )
+      const merged = mergeLayoutForKeys(state, keys, persisted, survivingSessionIds)
       groupCounter = Math.max(groupCounter, merged.groups.length)
       return { ...state, groups: merged.groups, displayOrder: merged.displayOrder }
     }),

--- a/src/renderer/src/store/workspace-store.ts
+++ b/src/renderer/src/store/workspace-store.ts
@@ -8,9 +8,16 @@ export type { Workspace }
  *  (activation side effects, add/remove cascades, persistence) lives in
  *  lib/workspace-actions.ts, which sits above every store.
  *
+ *  Multi-window (PRDCT-1703): `activeWorkspaceId` is the workspace THIS
+ *  WINDOW shows — a per-window value handed to the renderer by main at boot,
+ *  never read from the state file. The identity fields beside it say which
+ *  window this is, whether it is the primary, and which workspaces it hosts
+ *  (may write layout and pins for): its own, plus — for the primary — every
+ *  registered workspace no window shows.
+ *
  *  Invariant: `activeWorkspaceId === null` ⟺ `workspaces.length === 0`.
- *  While workspaces exist, exactly one is always active — there is no
- *  "deactivated" state. With zero workspaces the app runs unscoped and
+ *  While workspaces exist, exactly one is always active in a window — there
+ *  is no "deactivated" state. With zero workspaces the app runs unscoped and
  *  behaves as if the workspace feature didn't exist.
  */
 interface WorkspaceState {
@@ -18,12 +25,20 @@ interface WorkspaceState {
   activeWorkspaceId: string | null
   /** True once boot hydration (workspace:load + pin import) has run. */
   loaded: boolean
+  /** This window's BrowserWindow id; null until identity arrives (or outside
+   *  Electron, where the renderer behaves as the sole, primary window). */
+  windowId: number | null
+  isPrimary: boolean
+  hostedWorkspaceIds: string[]
 }
 
 export const useWorkspaceStore = create<WorkspaceState>(() => ({
   workspaces: [],
   activeWorkspaceId: null,
-  loaded: false
+  loaded: false,
+  windowId: null,
+  isPrimary: true,
+  hostedWorkspaceIds: []
 }))
 
 /** The active workspace's id, for stamping newly created sessions/groups/pins.
@@ -35,4 +50,12 @@ export function getActiveWorkspaceId(): string | null {
 export function getWorkspaceById(id: string | null | undefined): Workspace | undefined {
   if (!id) return undefined
   return useWorkspaceStore.getState().workspaces.find((w) => w.id === id)
+}
+
+/** Does this window host `workspaceId` — may it write that workspace's
+ *  layout and pins? The null (unscoped) partition belongs to the primary. */
+export function hostsWorkspace(workspaceId: string | null | undefined): boolean {
+  const s = useWorkspaceStore.getState()
+  if (workspaceId == null) return s.isPrimary
+  return s.hostedWorkspaceIds.includes(workspaceId)
 }

--- a/src/shared/workspace-types.ts
+++ b/src/shared/workspace-types.ts
@@ -2,10 +2,11 @@
  *
  * A workspace is a ROOT FOLDER (e.g. ~/.antasphere), not a .clave file: each
  * workspace carries one chosen profile file (.clave/workspaces/<name>.clave)
- * that defines its pinned groups and toolbar. Exactly one workspace is active
- * at a time and scopes everything visible (sessions, groups, pins, toolbar);
- * `activeWorkspaceId === null` if and only if no workspaces are registered
- * (the app then behaves as if the feature didn't exist).
+ * that defines its pinned groups and toolbar. Each WINDOW shows exactly one
+ * workspace and scopes everything visible in it (sessions, groups, pins,
+ * toolbar); a window's `activeWorkspaceId === null` if and only if no
+ * workspaces are registered (the app then behaves as if the feature didn't
+ * exist). At most one window shows a given workspace at a time.
  */
 export interface Workspace {
   /** Stable uuid — sessions, groups, and pins are stamped with it. */
@@ -23,11 +24,34 @@ export interface Workspace {
 
 /** Everything persisted in <userData>/workspace-state.json. The main process
  *  stores `pins` opaquely (the renderer's pinned-store owns their shape), the
- *  same way sidebar-layout.json stores groups — main is dumb, crash-safe
+ *  same way the sidebar layouts store groups — main is dumb, crash-safe
  *  storage; the renderer is the source of truth during a run. */
+/** What a renderer learns about the window it runs in — and only that
+ *  window. Runtime truth from the main-process WindowRegistry, never
+ *  persisted (BrowserWindow ids restart at 1 on every launch). */
+export interface WindowIdentity {
+  windowId: number
+  /** The workspace this window SHOWS; null only in no-workspace mode. */
+  workspaceId: string | null
+  /** The first window of the run, re-elected as the lowest surviving id when
+   *  it closes: hosts every workspace no window shows, carries app-level
+   *  fallbacks, and alone writes the unscoped (no-workspace) state. */
+  isPrimary: boolean
+  /** Workspaces whose sessions and state writes this window owns: its own,
+   *  plus — for the primary — every registered workspace no window shows. */
+  hostedWorkspaceIds: string[]
+}
+
 export interface WorkspaceStateFile {
   version: 1
   workspaces: Workspace[]
+  /** What the FIRST window of a run opens on; updated whenever any window
+   *  switches to or opens a workspace. Informational only while running — a
+   *  window's own workspace lives in the WindowRegistry, never here. */
+  lastActiveWorkspaceId: string | null
+  /** Legacy mirror of `lastActiveWorkspaceId`, read by releases before the
+   *  multi-window build. Written for one release so a downgrade keeps its
+   *  active workspace; read only when the new key is absent. */
   activeWorkspaceId: string | null
   pins: unknown[]
   /** False right after the main-side registry migration (Phase A); the

--- a/tests/e2e/harness.mjs
+++ b/tests/e2e/harness.mjs
@@ -6,6 +6,7 @@
 // where `window.electronAPI` is undefined and none of this works.
 import { _electron as electron } from 'playwright-core'
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -100,11 +101,17 @@ export async function stubReviewDialog(app, { response, checkboxChecked = false 
  *  server and its per-session bearer token, which belong to specs about the
  *  transport itself (see self-checkpoint.spec.mjs). Rejects on the handler's
  *  own error so a spec fails on a bad call instead of asserting on undefined. */
-export async function callMcp(app, command, payload, timeoutMs = 10_000) {
+export async function callMcp(app, command, payload, timeoutMs = 10_000, windowId = null) {
   const res = await app.evaluate(
-    async ({ BrowserWindow, ipcMain }, { command, payload, timeoutMs }) => {
-      const win = BrowserWindow.getAllWindows()[0]
-      if (!win) return { ok: false, error: 'no window' }
+    async ({ BrowserWindow, ipcMain }, { command, payload, timeoutMs, windowId }) => {
+      // Multi-window: the command runs in the renderer of the window named,
+      // else the lowest-id (primary) one — the dispatcher and the store it
+      // mutates are per window.
+      const win =
+        windowId != null
+          ? BrowserWindow.fromId(windowId)
+          : [...BrowserWindow.getAllWindows()].sort((a, b) => a.id - b.id)[0]
+      if (!win || win.isDestroyed()) return { ok: false, error: `no window ${windowId ?? ''}` }
       const requestId = `e2e-${Date.now()}-${Math.random().toString(36).slice(2)}`
       return await new Promise((resolve) => {
         const onResponse = (_e, res) => {
@@ -120,10 +127,97 @@ export async function callMcp(app, command, payload, timeoutMs = 10_000) {
         }, timeoutMs)
       })
     },
-    { command, payload, timeoutMs }
+    { command, payload, timeoutMs, windowId }
   )
   if (!res?.ok) throw new Error(`MCP "${command}" failed: ${res?.error ?? 'unknown'}`)
   return res.result
+}
+
+/** `callMcp` addressed to one window's renderer (multi-window specs). */
+export function callMcpIn(app, windowId, command, payload, timeoutMs = 10_000) {
+  return callMcp(app, command, payload, timeoutMs, windowId)
+}
+
+// ── Multi-window (PRDCT-1703) ────────────────────────────────────────────────
+
+/** Every open window as `{ id, page }`, lowest BrowserWindow id first. */
+export async function windows(app) {
+  const out = []
+  for (const page of app.windows()) {
+    if (page.isClosed()) continue
+    const bw = await app.browserWindow(page)
+    const id = await bw.evaluate((w) => w.id)
+    out.push({ id, page })
+  }
+  return out.sort((a, b) => a.id - b.id)
+}
+
+/** The page of the window with this BrowserWindow id, or null. */
+export async function windowFor(app, windowId) {
+  return (await windows(app)).find((w) => w.id === windowId)?.page ?? null
+}
+
+/** This renderer's identity as main reports it (`window:identity`). */
+export function identityOf(page) {
+  return page.evaluate(() => window.electronAPI.windowIdentity())
+}
+
+/** Show a workspace in a window of its own, driving the REAL path: the
+ *  renderer of `fromPage` calls `window.electronAPI.windowOpen`, exactly what
+ *  the File menu, the picker and clave_open_window do. Resolves once the new
+ *  window's renderer has loaded and settled; when the workspace was already
+ *  shown somewhere, `focusedExisting` is true and `page` is that window's. */
+export async function openWindow(app, fromPage, workspaceId, { settleMs = 4000 } = {}) {
+  const before = new Set(app.windows())
+  const result = await fromPage.evaluate((ws) => window.electronAPI.windowOpen(ws), workspaceId)
+  if (result.focusedExisting) {
+    return { ...result, page: await windowFor(app, result.windowId) }
+  }
+  let page = app.windows().find((p) => !before.has(p))
+  if (!page) page = await app.waitForEvent('window')
+  await page.waitForLoadState('domcontentloaded')
+  await page.waitForTimeout(settleMs)
+  return { ...result, page }
+}
+
+/** Close a window the way the user does (the BrowserWindow's own close, so
+ *  main's 'closed' handler — the teardown ladder — runs). */
+export async function closeWindow(app, page) {
+  const bw = await app.browserWindow(page)
+  await bw.evaluate((w) => w.close())
+  await new Promise((r) => setTimeout(r, 1000))
+}
+
+/**
+ * The PTYs live on the SHARED tmux socket ('clave', a fixed constant), so
+ * `--user-data-dir` isolation stops at userData: a spawned tab's tmux session
+ * and its live process survive `app.close()`. Kill ONLY sessions named for
+ * e2e fixture roots ('clave-e2e' is the harness's own prefix) — never
+ * anything of the user's, and never with pkill.
+ */
+export function killLeakedE2eTmux() {
+  try {
+    const names = execFileSync('tmux', ['-L', 'clave', 'list-sessions', '-F', '#{session_name}'], {
+      encoding: 'utf-8'
+    })
+      .split('\n')
+      .filter(Boolean)
+    for (const n of names) {
+      if (n.includes('clave-e2e')) execFileSync('tmux', ['-L', 'clave', 'kill-session', '-t', n])
+    }
+  } catch {
+    // No tmux server = nothing leaked.
+  }
+}
+
+/** Is a tmux session of that name alive on the app's socket? */
+export function tmuxSessionAlive(name) {
+  try {
+    execFileSync('tmux', ['-L', 'clave', 'has-session', '-t', `=${name}`], { stdio: 'ignore' })
+    return true
+  } catch {
+    return false
+  }
 }
 
 /** The labels of the sidebar's session rows. */

--- a/tests/e2e/harness.mjs
+++ b/tests/e2e/harness.mjs
@@ -58,7 +58,6 @@ export async function launchApp(dir, { settleMs = 4000 } = {}) {
   return { app, win }
 }
 
-
 /** Replace the native folder picker in the MAIN process so a spec can tell
  *  "opened the picker" from "went straight to the workspace root" — a native
  *  modal would otherwise block the run forever. Returns a reader for the count. */

--- a/tests/e2e/harness.mjs
+++ b/tests/e2e/harness.mjs
@@ -58,6 +58,7 @@ export async function launchApp(dir, { settleMs = 4000 } = {}) {
   return { app, win }
 }
 
+
 /** Replace the native folder picker in the MAIN process so a spec can tell
  *  "opened the picker" from "went straight to the workspace root" — a native
  *  modal would otherwise block the run forever. Returns a reader for the count. */
@@ -169,15 +170,29 @@ export function identityOf(page) {
  *  shown somewhere, `focusedExisting` is true and `page` is that window's. */
 export async function openWindow(app, fromPage, workspaceId, { settleMs = 4000 } = {}) {
   const before = new Set(app.windows())
+  // Subscribe BEFORE asking, so a window that appears between the answer and
+  // the wait cannot slip past unobserved.
+  const nextWindow = app.waitForEvent('window', { timeout: 15_000 }).catch(() => null)
   const result = await fromPage.evaluate((ws) => window.electronAPI.windowOpen(ws), workspaceId)
   if (result.focusedExisting) {
     return { ...result, page: await windowFor(app, result.windowId) }
   }
-  let page = app.windows().find((p) => !before.has(p))
-  if (!page) page = await app.waitForEvent('window')
+  const page = app.windows().find((p) => !before.has(p)) ?? (await nextWindow)
+  if (!page)
+    throw new Error(`window:open answered ${JSON.stringify(result)} but no window appeared`)
   await page.waitForLoadState('domcontentloaded')
   await page.waitForTimeout(settleMs)
   return { ...result, page }
+}
+
+/** Poll until `fn` returns a truthy value or the budget runs out. */
+export async function until(fn, { tries = 40, gapMs = 250 } = {}) {
+  for (let i = 0; i < tries; i++) {
+    const v = await fn()
+    if (v) return v
+    await new Promise((r) => setTimeout(r, gapMs))
+  }
+  return null
 }
 
 /** Close a window the way the user does (the BrowserWindow's own close, so
@@ -203,7 +218,9 @@ export function killLeakedE2eTmux() {
       .split('\n')
       .filter(Boolean)
     for (const n of names) {
-      if (n.includes('clave-e2e')) execFileSync('tmux', ['-L', 'clave', 'kill-session', '-t', n])
+      // `=name` is an EXACT target: never a prefix or a glob match.
+      if (n.includes('clave-e2e'))
+        execFileSync('tmux', ['-L', 'clave', 'kill-session', '-t', `=${n}`])
     }
   } catch {
     // No tmux server = nothing leaked.

--- a/tests/e2e/multi-window-core.spec.mjs
+++ b/tests/e2e/multi-window-core.spec.mjs
@@ -1,0 +1,347 @@
+/**
+ * Multi-window core (PRDCT-1703, slice 1): one workspace per window, each
+ * window hosting its own sessions and writing its own layout file.
+ *
+ * What this pins, on the REAL app with real PTYs:
+ *   - a second window opens on another workspace with its own identity, and
+ *     opening a workspace already shown somewhere focuses that window instead
+ *     of duplicating it (invariant 12);
+ *   - a spawn from a window is stamped with THAT window's workspace even when
+ *     the state file's last-active workspace says otherwise (invariant 4);
+ *   - the two windows write two separate layout files, neither losing the
+ *     other's groups (invariant 5), and the legacy single file never appears;
+ *   - closing window B leaves window A's session ALIVE AND STREAMING — the
+ *     observation is the terminal buffer still advancing after the close,
+ *     not process liveness (invariant 1); B's tmux-backed session is
+ *     detached, not killed (its process and record survive);
+ *   - after a restart the first window comes back on the last-active
+ *     workspace, and BOTH workspaces' groups come back from their own files
+ *     around the re-adopted sessions (invariant 15's single-window floor plus
+ *     the per-workspace half of the restart assertion; the two-window half
+ *     needs re-homing, slice 2).
+ *
+ * Failure modes this must catch: the old whole-app teardown on any close
+ * (the streaming assertion goes red), a whole-file layout write (one
+ * workspace's file carries the other's group), a spawn stamped from the state
+ * file (the stamp assertion goes red), a guard that opens a second window.
+ */
+import {
+  launchApp,
+  seedWorkspaces,
+  seedTrustedRoots,
+  userDataDir,
+  callMcp,
+  callMcpIn,
+  windows,
+  identityOf,
+  openWindow,
+  closeWindow,
+  killLeakedE2eTmux,
+  tmuxSessionAlive
+} from './harness.mjs'
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+const DIR = userDataDir('multi-window-core')
+const ROOT_A = '/tmp/clave-e2e-mw-core-a'
+const ROOT_B = '/tmp/clave-e2e-mw-core-b'
+const WS_A = {
+  id: 'aaaaaaaa-0000-4000-8000-0000000000a1',
+  name: 'CoreA',
+  rootDir: ROOT_A,
+  profileFile: null,
+  createdAt: 1
+}
+const WS_B = {
+  id: 'bbbbbbbb-0000-4000-8000-0000000000b1',
+  name: 'CoreB',
+  rootDir: ROOT_B,
+  profileFile: null,
+  createdAt: 1
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+function layoutFile(wsId) {
+  return path.join(DIR, 'sidebar-layouts', `${wsId}.json`)
+}
+function readLayout(wsId) {
+  return existsSync(layoutFile(wsId)) ? JSON.parse(readFileSync(layoutFile(wsId), 'utf-8')) : null
+}
+function groupNames(layout) {
+  return (layout?.groups ?? []).map((g) => g.name)
+}
+function sessionRecords() {
+  const dir = path.join(DIR, 'session-records')
+  if (!existsSync(dir)) return []
+  return readdirSync(dir)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => JSON.parse(readFileSync(path.join(dir, f), 'utf-8')))
+}
+/** The highest tick number visible in a session's terminal buffer. */
+async function lastTick(app, sessionId, windowId) {
+  // A read needs a caller identity; a tab may always read itself.
+  const read = await callMcpIn(app, windowId, 'readSession', {
+    sessionId,
+    lines: 40,
+    callerSessionId: sessionId
+  })
+  const text = typeof read === 'string' ? read : JSON.stringify(read)
+  const ticks = [...text.matchAll(/tick-(\d+)/g)].map((m) => Number(m[1]))
+  return ticks.length ? Math.max(...ticks) : -1
+}
+
+export async function run(t) {
+  killLeakedE2eTmux()
+  mkdirSync(ROOT_A, { recursive: true })
+  mkdirSync(ROOT_B, { recursive: true })
+  // The OLD key only: the new build reads it as the last-active workspace
+  // (the downgrade-compatibility read half of invariant 7).
+  seedWorkspaces(DIR, { workspaces: [WS_A, WS_B], activeWorkspaceId: WS_A.id, fresh: true })
+  seedTrustedRoots(DIR, [ROOT_A, ROOT_B])
+
+  let app = null
+  let sessionA = null
+  let sessionB = null
+  let sessionA2 = null
+  try {
+    // ── window A: the primary, on the last-active workspace ──
+    const launched = await launchApp(DIR)
+    app = launched.app
+    const winA = launched.win
+    const idA = await identityOf(winA)
+    t.equal('the first window shows the last-active workspace', idA?.workspaceId, WS_A.id)
+    t.equal('the first window is the primary', idA?.isPrimary, true)
+    t.check(
+      'alone, the primary hosts every workspace',
+      idA?.hostedWorkspaceIds?.includes(WS_A.id) && idA?.hostedWorkspaceIds?.includes(WS_B.id),
+      idA?.hostedWorkspaceIds
+    )
+
+    // A group with a ticking terminal in A. The loop is the streaming probe.
+    const groupA = await callMcp(app, 'createGroup', { name: 'A lane' })
+    const opened = await callMcp(app, 'openSession', {
+      cwd: ROOT_A,
+      mode: 'terminal',
+      groupId: groupA.groupId,
+      command: 'i=0; while true; do i=$((i+1)); echo tick-$i; sleep 0.2; done',
+      autoRun: true
+    })
+    sessionA = opened.sessionId
+    await sleep(3000)
+    const t0 = await lastTick(app, sessionA, idA.windowId)
+    t.check('the terminal in A is streaming (positive control)', t0 > 0, t0)
+
+    // A DEAD record of workspace A, written after A booted: window B's boot
+    // must neither adopt nor prompt for it (the restore prompt is scoped to
+    // the window's own workspace; the primary alone sees everyone's).
+    const deadId = 'dddddddd-0000-4000-8000-00000000dead'
+    mkdirSync(path.join(DIR, 'session-records'), { recursive: true })
+    writeFileSync(
+      path.join(DIR, 'session-records', `${deadId}.json`),
+      JSON.stringify({
+        id: deadId,
+        cwd: ROOT_A,
+        folderName: path.basename(ROOT_A),
+        claudeMode: false,
+        antigravityMode: false,
+        codexMode: false,
+        claudeAgentsMode: false,
+        dangerousMode: false,
+        workspaceId: WS_A.id
+      })
+    )
+
+    // ── window B on workspace B ──
+    const b = await openWindow(app, winA, WS_B.id)
+    t.equal('opening workspace B made a NEW window', b.focusedExisting, false)
+    const promptInB = await b.page.evaluate(() =>
+      (document.body.textContent || '').includes('Restore previous session?')
+    )
+    t.check("window B did not prompt for workspace A's dead record", !promptInB)
+    t.check(
+      'the dead record of A is still there for A (B discarded nothing)',
+      existsSync(path.join(DIR, 'session-records', `${deadId}.json`))
+    )
+    rmSync(path.join(DIR, 'session-records', `${deadId}.json`), { force: true })
+    const idB = await identityOf(b.page)
+    t.equal('window B shows workspace B', idB?.workspaceId, WS_B.id)
+    t.equal('window B is not the primary', idB?.isPrimary, false)
+    t.check(
+      'window B hosts only workspace B',
+      JSON.stringify(idB?.hostedWorkspaceIds) === JSON.stringify([WS_B.id]),
+      idB?.hostedWorkspaceIds
+    )
+    const idA2 = await identityOf(winA)
+    t.check(
+      'the primary no longer hosts workspace B once B shows it',
+      idA2?.hostedWorkspaceIds?.includes(WS_A.id) && !idA2?.hostedWorkspaceIds?.includes(WS_B.id),
+      idA2?.hostedWorkspaceIds
+    )
+    t.equal('two windows are open', (await windows(app)).length, 2)
+
+    // The guard: workspace B is shown — asking again focuses, never duplicates.
+    const again = await openWindow(app, winA, WS_B.id)
+    t.equal('opening a shown workspace reports focusedExisting', again.focusedExisting, true)
+    t.equal('and names the window that shows it', again.windowId, idB.windowId)
+    t.equal('and opened no window', (await windows(app)).length, 2)
+
+    // The state file's last-active is now B (B was opened last)...
+    const stateAfterOpen = JSON.parse(readFileSync(path.join(DIR, 'workspace-state.json'), 'utf-8'))
+    t.equal(
+      'opening B made it the last-active workspace',
+      stateAfterOpen.lastActiveWorkspaceId,
+      WS_B.id
+    )
+    t.equal(
+      'the old key mirrors the new one (downgrade safety)',
+      stateAfterOpen.activeWorkspaceId,
+      WS_B.id
+    )
+
+    // ...yet a spawn from A, with no workspace named, is stamped A (invariant 4).
+    const openedA2 = await callMcpIn(app, idA.windowId, 'openSession', {
+      cwd: ROOT_A,
+      mode: 'terminal',
+      groupId: groupA.groupId
+    })
+    sessionA2 = openedA2.sessionId
+    await sleep(1500)
+    const recA2 = sessionRecords().find((r) => r.id === sessionA2)
+    t.equal(
+      'a spawn from window A is stamped with A, not the last-active B',
+      recA2?.workspaceId,
+      WS_A.id
+    )
+
+    // A group with a session in B, from B's own renderer.
+    const groupB = await callMcpIn(app, idB.windowId, 'createGroup', { name: 'B lane' })
+    const openedB = await callMcpIn(app, idB.windowId, 'openSession', {
+      cwd: ROOT_B,
+      mode: 'terminal',
+      groupId: groupB.groupId
+    })
+    sessionB = openedB.sessionId
+    await sleep(2500)
+    const recB = sessionRecords().find((r) => r.id === sessionB)
+    t.equal('a spawn from window B is stamped with B', recB?.workspaceId, WS_B.id)
+
+    // ── two layout files, one per workspace, neither carrying the other's groups ──
+    const layoutA = readLayout(WS_A.id)
+    const layoutB = readLayout(WS_B.id)
+    t.check('workspace A has its own layout file', layoutA !== null, layoutFile(WS_A.id))
+    t.check('workspace B has its own layout file', layoutB !== null, layoutFile(WS_B.id))
+    t.check(
+      "A's file carries A's group and not B's",
+      groupNames(layoutA).includes('A lane') && !groupNames(layoutA).includes('B lane'),
+      groupNames(layoutA)
+    )
+    t.check(
+      "B's file carries B's group and not A's",
+      groupNames(layoutB).includes('B lane') && !groupNames(layoutB).includes('A lane'),
+      groupNames(layoutB)
+    )
+    t.check(
+      'the legacy single layout file never appears',
+      !existsSync(path.join(DIR, 'sidebar-layout.json'))
+    )
+
+    // ── close B: A keeps streaming, B's session is detached not killed ──
+    const tmuxB = recB?.tmuxName ?? null
+    t.check(
+      "B's session is tmux-backed (the detach case)",
+      !!tmuxB && tmuxSessionAlive(tmuxB),
+      tmuxB
+    )
+    const before = await lastTick(app, sessionA, idA.windowId)
+    await closeWindow(app, b.page)
+    t.equal('window B is gone', (await windows(app)).length, 1)
+    await sleep(1500)
+    const after = await lastTick(app, sessionA, idA.windowId)
+    t.check("A's terminal kept streaming across B's close", after > before, { before, after })
+    const listAfter = await callMcp(app, 'list', {})
+    const aAfter = listAfter.sessions.find((s) => s.id === sessionA)
+    t.equal("A's session never received pty:exit", aAfter?.alive, true)
+    t.check(
+      "B's tmux session survived the close (detached, not killed)",
+      tmuxSessionAlive(tmuxB),
+      tmuxB
+    )
+    t.check(
+      "B's session record survived the close",
+      sessionRecords().some((r) => r.id === sessionB)
+    )
+    const idA3 = await identityOf(winA)
+    t.check(
+      'the primary hosts workspace B again after B closed',
+      idA3?.hostedWorkspaceIds?.includes(WS_B.id),
+      idA3?.hostedWorkspaceIds
+    )
+
+    // ── restart: the last-active workspace, and both layouts, come back ──
+    await app.close()
+    app = null
+    await sleep(1500)
+    const relaunched = await launchApp(DIR, { settleMs: 6000 })
+    app = relaunched.app
+    const win1 = relaunched.win
+    const id1 = await identityOf(win1)
+    t.equal(
+      'after a restart the first window opens on the last-active workspace',
+      id1?.workspaceId,
+      WS_B.id
+    )
+    const listed = await callMcp(app, 'list', {})
+    const names = listed.groups.map((g) => g.name)
+    t.check("workspace A's group came back from its own file", names.includes('A lane'), names)
+    t.check("workspace B's group came back from its own file", names.includes('B lane'), names)
+    const gA = listed.groups.find((g) => g.name === 'A lane')
+    const gB = listed.groups.find((g) => g.name === 'B lane')
+    t.equal("A's group is scoped to A", gA?.workspaceId, WS_A.id)
+    t.equal("B's group is scoped to B", gB?.workspaceId, WS_B.id)
+    t.check(
+      "A's ticking session came back inside its group",
+      gA?.sessionIds?.includes(sessionA),
+      gA?.sessionIds
+    )
+    t.check(
+      "B's session came back inside its group",
+      gB?.sessionIds?.includes(sessionB),
+      gB?.sessionIds
+    )
+    // The primary now holds BOTH workspaces' groups in one store, and still
+    // writes each workspace's file with that workspace's groups only.
+    await sleep(1500)
+    const layoutA2 = readLayout(WS_A.id)
+    const layoutB2 = readLayout(WS_B.id)
+    t.check(
+      "after the restart A's file still carries only A's group",
+      groupNames(layoutA2).includes('A lane') && !groupNames(layoutA2).includes('B lane'),
+      groupNames(layoutA2)
+    )
+    t.check(
+      "after the restart B's file still carries only B's group",
+      groupNames(layoutB2).includes('B lane') && !groupNames(layoutB2).includes('A lane'),
+      groupNames(layoutB2)
+    )
+    const state2 = JSON.parse(readFileSync(path.join(DIR, 'workspace-state.json'), 'utf-8'))
+    t.check(
+      'the new build writes both keys (one-release downgrade safety)',
+      state2.lastActiveWorkspaceId === WS_B.id && state2.activeWorkspaceId === WS_B.id,
+      state2
+    )
+
+    // Single window: the in-window switch works as it always did.
+    await callMcp(app, 'switchWorkspace', { workspace: WS_A.id })
+    await sleep(800)
+    t.equal('the single window switched to A', (await identityOf(win1))?.workspaceId, WS_A.id)
+
+    // Cleanup: close every session this spec opened (kills their tmux sessions).
+    for (const sid of [sessionA, sessionA2, sessionB]) {
+      if (sid) await callMcp(app, 'closeSession', { sessionId: sid }).catch(() => {})
+    }
+  } finally {
+    if (app) await app.close()
+    killLeakedE2eTmux()
+  }
+}

--- a/tests/e2e/multi-window-core.spec.mjs
+++ b/tests/e2e/multi-window-core.spec.mjs
@@ -8,22 +8,30 @@
  *     of duplicating it (invariant 12);
  *   - a spawn from a window is stamped with THAT window's workspace even when
  *     the state file's last-active workspace says otherwise (invariant 4);
- *   - the two windows write two separate layout files, neither losing the
- *     other's groups (invariant 5), and the legacy single file never appears;
+ *   - the windows write separate layout files, none losing another's groups
+ *     (invariant 5): a window that starts hosting a workspace — at its own
+ *     boot, after an in-window switch, or when another window closes —
+ *     reads that workspace's file before it may write it, and a group whose
+ *     sessions merely live elsewhere is kept, never written back as gone;
+ *   - a cross-workspace write is refused by main, loudly;
+ *   - a secondary window's restore prompt lists only ITS workspace's dead
+ *     records (invariant 13) — with the positive control that it does prompt
+ *     for its own;
  *   - closing window B leaves window A's session ALIVE AND STREAMING — the
  *     observation is the terminal buffer still advancing after the close,
  *     not process liveness (invariant 1); B's tmux-backed session is
  *     detached, not killed (its process and record survive);
  *   - after a restart the first window comes back on the last-active
- *     workspace, and BOTH workspaces' groups come back from their own files
+ *     workspace, and every workspace's groups come back from their own files
  *     around the re-adopted sessions (invariant 15's single-window floor plus
  *     the per-workspace half of the restart assertion; the two-window half
  *     needs re-homing, slice 2).
  *
  * Failure modes this must catch: the old whole-app teardown on any close
- * (the streaming assertion goes red), a whole-file layout write (one
- * workspace's file carries the other's group), a spawn stamped from the state
- * file (the stamp assertion goes red), a guard that opens a second window.
+ * (the streaming assertion goes red), a whole-file layout write, a window
+ * writing a workspace it never read (the seed groups vanish from disk), a
+ * spawn stamped from the state file, a guard that opens a second window, an
+ * unfiltered restore prompt.
  */
 import {
   launchApp,
@@ -37,7 +45,8 @@ import {
   openWindow,
   closeWindow,
   killLeakedE2eTmux,
-  tmuxSessionAlive
+  tmuxSessionAlive,
+  until
 } from './harness.mjs'
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
@@ -45,20 +54,17 @@ import path from 'node:path'
 const DIR = userDataDir('multi-window-core')
 const ROOT_A = '/tmp/clave-e2e-mw-core-a'
 const ROOT_B = '/tmp/clave-e2e-mw-core-b'
-const WS_A = {
-  id: 'aaaaaaaa-0000-4000-8000-0000000000a1',
-  name: 'CoreA',
-  rootDir: ROOT_A,
+const ROOT_C = '/tmp/clave-e2e-mw-core-c'
+const ws = (letter, root) => ({
+  id: `${letter}${letter}${letter}${letter}${letter}${letter}${letter}${letter}-0000-4000-8000-0000000000${letter}1`,
+  name: `Core${letter.toUpperCase()}`,
+  rootDir: root,
   profileFile: null,
   createdAt: 1
-}
-const WS_B = {
-  id: 'bbbbbbbb-0000-4000-8000-0000000000b1',
-  name: 'CoreB',
-  rootDir: ROOT_B,
-  profileFile: null,
-  createdAt: 1
-}
+})
+const WS_A = ws('a', ROOT_A)
+const WS_B = ws('b', ROOT_B)
+const WS_C = ws('c', ROOT_C)
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
 
@@ -78,6 +84,23 @@ function sessionRecords() {
     .filter((f) => f.endsWith('.json'))
     .map((f) => JSON.parse(readFileSync(path.join(dir, f), 'utf-8')))
 }
+function writeDeadRecord(id, root, workspaceId) {
+  mkdirSync(path.join(DIR, 'session-records'), { recursive: true })
+  writeFileSync(
+    path.join(DIR, 'session-records', `${id}.json`),
+    JSON.stringify({
+      id,
+      cwd: root,
+      folderName: path.basename(root),
+      claudeMode: false,
+      antigravityMode: false,
+      codexMode: false,
+      claudeAgentsMode: false,
+      dangerousMode: false,
+      workspaceId
+    })
+  )
+}
 /** The highest tick number visible in a session's terminal buffer. */
 async function lastTick(app, sessionId, windowId) {
   // A read needs a caller identity; a tab may always read itself.
@@ -90,20 +113,24 @@ async function lastTick(app, sessionId, windowId) {
   const ticks = [...text.matchAll(/tick-(\d+)/g)].map((m) => Number(m[1]))
   return ticks.length ? Math.max(...ticks) : -1
 }
+/** Wait until a layout file lists exactly these group names (order-free). */
+async function untilGroups(wsId, names) {
+  return until(() => {
+    const got = groupNames(readLayout(wsId)).sort()
+    return JSON.stringify(got) === JSON.stringify([...names].sort()) ? got : null
+  })
+}
 
 export async function run(t) {
   killLeakedE2eTmux()
-  mkdirSync(ROOT_A, { recursive: true })
-  mkdirSync(ROOT_B, { recursive: true })
+  for (const r of [ROOT_A, ROOT_B, ROOT_C]) mkdirSync(r, { recursive: true })
   // The OLD key only: the new build reads it as the last-active workspace
   // (the downgrade-compatibility read half of invariant 7).
-  seedWorkspaces(DIR, { workspaces: [WS_A, WS_B], activeWorkspaceId: WS_A.id, fresh: true })
-  seedTrustedRoots(DIR, [ROOT_A, ROOT_B])
+  seedWorkspaces(DIR, { workspaces: [WS_A, WS_B, WS_C], activeWorkspaceId: WS_A.id, fresh: true })
+  seedTrustedRoots(DIR, [ROOT_A, ROOT_B, ROOT_C])
 
   let app = null
-  let sessionA = null
-  let sessionB = null
-  let sessionA2 = null
+  const opened = []
   try {
     // ── window A: the primary, on the last-active workspace ──
     const launched = await launchApp(DIR)
@@ -114,56 +141,87 @@ export async function run(t) {
     t.equal('the first window is the primary', idA?.isPrimary, true)
     t.check(
       'alone, the primary hosts every workspace',
-      idA?.hostedWorkspaceIds?.includes(WS_A.id) && idA?.hostedWorkspaceIds?.includes(WS_B.id),
+      [WS_A.id, WS_B.id, WS_C.id].every((w) => idA?.hostedWorkspaceIds?.includes(w)),
       idA?.hostedWorkspaceIds
     )
 
     // A group with a ticking terminal in A. The loop is the streaming probe.
     const groupA = await callMcp(app, 'createGroup', { name: 'A lane' })
-    const opened = await callMcp(app, 'openSession', {
+    const tick = await callMcp(app, 'openSession', {
       cwd: ROOT_A,
       mode: 'terminal',
       groupId: groupA.groupId,
       command: 'i=0; while true; do i=$((i+1)); echo tick-$i; sleep 0.2; done',
       autoRun: true
     })
-    sessionA = opened.sessionId
-    await sleep(3000)
-    const t0 = await lastTick(app, sessionA, idA.windowId)
-    t.check('the terminal in A is streaming (positive control)', t0 > 0, t0)
-
-    // A DEAD record of workspace A, written after A booted: window B's boot
-    // must neither adopt nor prompt for it (the restore prompt is scoped to
-    // the window's own workspace; the primary alone sees everyone's).
-    const deadId = 'dddddddd-0000-4000-8000-00000000dead'
-    mkdirSync(path.join(DIR, 'session-records'), { recursive: true })
-    writeFileSync(
-      path.join(DIR, 'session-records', `${deadId}.json`),
-      JSON.stringify({
-        id: deadId,
-        cwd: ROOT_A,
-        folderName: path.basename(ROOT_A),
-        claudeMode: false,
-        antigravityMode: false,
-        codexMode: false,
-        claudeAgentsMode: false,
-        dangerousMode: false,
-        workspaceId: WS_A.id
+    opened.push(tick.sessionId)
+    // Seed groups in B and C from the primary, which hosts them hidden: their
+    // files must survive every hosting hand-over below.
+    for (const [name, root, wsx] of [
+      ['B seed', ROOT_B, WS_B],
+      ['C seed', ROOT_C, WS_C]
+    ]) {
+      const g = await callMcp(app, 'createGroup', { name, workspace: wsx.id })
+      const s = await callMcp(app, 'openSession', {
+        cwd: root,
+        mode: 'terminal',
+        groupId: g.groupId,
+        workspace: wsx.id
       })
+      opened.push(s.sessionId)
+    }
+    await sleep(3000)
+    const t0 = await lastTick(app, tick.sessionId, idA.windowId)
+    t.check('the terminal in A is streaming (positive control)', t0 > 0, t0)
+    t.check(
+      "the primary wrote B's seed group to B's file",
+      !!(await untilGroups(WS_B.id, ['B seed'])),
+      groupNames(readLayout(WS_B.id))
     )
+    t.check(
+      "the primary wrote C's seed group to C's file",
+      !!(await untilGroups(WS_C.id, ['C seed'])),
+      groupNames(readLayout(WS_C.id))
+    )
+
+    // DEAD records for A and B, written after A booted: window B's boot must
+    // prompt for B's and neither adopt nor prompt for A's.
+    // Plain records are keyed by a UUID — a malformed id is pruned as junk.
+    const deadA = 'dddddddd-0000-4000-8000-00000000dea0'
+    const deadB = 'dddddddd-0000-4000-8000-00000000deb0'
+    writeDeadRecord(deadA, ROOT_A, WS_A.id)
+    writeDeadRecord(deadB, ROOT_B, WS_B.id)
 
     // ── window B on workspace B ──
-    const b = await openWindow(app, winA, WS_B.id)
+    const b = await openWindow(app, winA, WS_B.id, { settleMs: 1000 })
     t.equal('opening workspace B made a NEW window', b.focusedExisting, false)
-    const promptInB = await b.page.evaluate(() =>
-      (document.body.textContent || '').includes('Restore previous session?')
+    const prompt = await until(() =>
+      b.page.evaluate(() => {
+        const text = document.body.textContent || ''
+        return text.includes('Restore previous session?') ? text : null
+      })
     )
-    t.check("window B did not prompt for workspace A's dead record", !promptInB)
+    t.check('window B prompted for its own dead record (positive control)', prompt !== null)
     t.check(
-      'the dead record of A is still there for A (B discarded nothing)',
-      existsSync(path.join(DIR, 'session-records', `${deadId}.json`))
+      "and the prompt lists ONE terminal — B's, not A's",
+      !!prompt && prompt.includes('1 terminal') && !prompt.includes('2 terminals'),
+      prompt?.slice(
+        prompt.indexOf('Restore previous session?'),
+        prompt.indexOf('Restore previous session?') + 120
+      )
     )
-    rmSync(path.join(DIR, 'session-records', `${deadId}.json`), { force: true })
+    await b.page.click('button:has-text("Start fresh")')
+    await sleep(2500)
+    t.check(
+      'B discarded its own dead record',
+      !existsSync(path.join(DIR, 'session-records', `${deadB}.json`))
+    )
+    t.check(
+      "and left A's dead record alone",
+      existsSync(path.join(DIR, 'session-records', `${deadA}.json`))
+    )
+    rmSync(path.join(DIR, 'session-records', `${deadA}.json`), { force: true })
+
     const idB = await identityOf(b.page)
     t.equal('window B shows workspace B', idB?.workspaceId, WS_B.id)
     t.equal('window B is not the primary', idB?.isPrimary, false)
@@ -179,6 +237,20 @@ export async function run(t) {
       idA2?.hostedWorkspaceIds
     )
     t.equal('two windows are open', (await windows(app)).length, 2)
+
+    // B took over workspace B WITHOUT truncating its file: the seed group,
+    // whose session lives in the primary, is still there.
+    t.check(
+      "B's file still carries the seed group after B's boot",
+      groupNames(readLayout(WS_B.id)).includes('B seed'),
+      groupNames(readLayout(WS_B.id))
+    )
+    const listB = await callMcpIn(app, idB.windowId, 'list', { workspace: WS_B.id })
+    t.check(
+      'and B shows it as a group (its session lives elsewhere for now)',
+      listB.groups.some((g) => g.name === 'B seed'),
+      listB.groups.map((g) => g.name)
+    )
 
     // The guard: workspace B is shown — asking again focuses, never duplicates.
     const again = await openWindow(app, winA, WS_B.id)
@@ -225,9 +297,9 @@ export async function run(t) {
       mode: 'terminal',
       groupId: groupA.groupId
     })
-    sessionA2 = openedA2.sessionId
+    opened.push(openedA2.sessionId)
     await sleep(1500)
-    const recA2 = sessionRecords().find((r) => r.id === sessionA2)
+    const recA2 = sessionRecords().find((r) => r.id === openedA2.sessionId)
     t.equal(
       'a spawn from window A is stamped with A, not the last-active B',
       recA2?.workspaceId,
@@ -241,25 +313,21 @@ export async function run(t) {
       mode: 'terminal',
       groupId: groupB.groupId
     })
-    sessionB = openedB.sessionId
+    opened.push(openedB.sessionId)
     await sleep(2500)
-    const recB = sessionRecords().find((r) => r.id === sessionB)
+    const recB = sessionRecords().find((r) => r.id === openedB.sessionId)
     t.equal('a spawn from window B is stamped with B', recB?.workspaceId, WS_B.id)
 
-    // ── two layout files, one per workspace, neither carrying the other's groups ──
-    const layoutA = readLayout(WS_A.id)
-    const layoutB = readLayout(WS_B.id)
-    t.check('workspace A has its own layout file', layoutA !== null, layoutFile(WS_A.id))
-    t.check('workspace B has its own layout file', layoutB !== null, layoutFile(WS_B.id))
+    // ── one layout file per workspace, none carrying another's groups ──
     t.check(
       "A's file carries A's group and not B's",
-      groupNames(layoutA).includes('A lane') && !groupNames(layoutA).includes('B lane'),
-      groupNames(layoutA)
+      !!(await untilGroups(WS_A.id, ['A lane'])),
+      groupNames(readLayout(WS_A.id))
     )
     t.check(
-      "B's file carries B's group and not A's",
-      groupNames(layoutB).includes('B lane') && !groupNames(layoutB).includes('A lane'),
-      groupNames(layoutB)
+      "B's file carries the seed AND B's own group, nothing of A",
+      !!(await untilGroups(WS_B.id, ['B seed', 'B lane'])),
+      groupNames(readLayout(WS_B.id))
     )
     t.check(
       'the legacy single layout file never appears',
@@ -269,8 +337,8 @@ export async function run(t) {
     // A cross-workspace write is refused by main, loudly, and writes nothing:
     // B's renderer tries to overwrite A's layout file.
     const rogue = await b.page.evaluate(
-      (ws) =>
-        window.electronAPI.sidebarLayoutSave(ws, {
+      (wsId) =>
+        window.electronAPI.sidebarLayoutSave(wsId, {
           groups: [
             {
               id: 'rogue',
@@ -293,39 +361,93 @@ export async function run(t) {
       groupNames(readLayout(WS_A.id))
     )
 
-    // ── close B: A keeps streaming, B's session is detached not killed ──
-    const tmuxB = recB?.tmuxName ?? null
+    // ── B switches to C (unshown): it must READ C's file before writing it ──
+    await callMcpIn(app, idB.windowId, 'switchWorkspace', { workspace: WS_C.id })
+    await until(() => identityOf(b.page).then((id) => (id?.workspaceId === WS_C.id ? id : null)))
+    t.equal('window B now shows workspace C', (await identityOf(b.page))?.workspaceId, WS_C.id)
+    await sleep(1000)
+    const groupCfromB = await callMcpIn(app, idB.windowId, 'createGroup', { name: 'C from B' })
+    const openedC = await callMcpIn(app, idB.windowId, 'openSession', {
+      cwd: ROOT_C,
+      mode: 'terminal',
+      groupId: groupCfromB.groupId
+    })
+    opened.push(openedC.sessionId)
     t.check(
-      "B's session is tmux-backed (the detach case)",
-      !!tmuxB && tmuxSessionAlive(tmuxB),
-      tmuxB
+      "C's file keeps the seed group next to the one B added",
+      !!(await untilGroups(WS_C.id, ['C seed', 'C from B'])),
+      groupNames(readLayout(WS_C.id))
     )
-    const before = await lastTick(app, sessionA, idA.windowId)
+    t.check(
+      "B's file kept both of B's groups after B left it",
+      JSON.stringify(groupNames(readLayout(WS_B.id)).sort()) ===
+        JSON.stringify(['B lane', 'B seed']),
+      groupNames(readLayout(WS_B.id))
+    )
+
+    // ── close B: A keeps streaming, B's sessions are detached not killed,
+    //    and A regains C without clobbering what B wrote ──
+    // Its tmux session is created when the tab mounts; focus it, then poll.
+    await callMcpIn(app, idB.windowId, 'focus', { sessionId: openedC.sessionId })
+    const tmuxC = await until(() => {
+      const name = sessionRecords().find((r) => r.id === openedC.sessionId)?.tmuxName
+      return name && tmuxSessionAlive(name) ? name : null
+    })
+    t.check("B's session is tmux-backed and running (the detach case)", tmuxC !== null, tmuxC)
+    const before = await lastTick(app, tick.sessionId, idA.windowId)
     await closeWindow(app, b.page)
     t.equal('window B is gone', (await windows(app)).length, 1)
     await sleep(1500)
-    const after = await lastTick(app, sessionA, idA.windowId)
+    const after = await lastTick(app, tick.sessionId, idA.windowId)
     t.check("A's terminal kept streaming across B's close", after > before, { before, after })
     const listAfter = await callMcp(app, 'list', {})
-    const aAfter = listAfter.sessions.find((s) => s.id === sessionA)
+    const aAfter = listAfter.sessions.find((s) => s.id === tick.sessionId)
     t.equal("A's session never received pty:exit", aAfter?.alive, true)
     t.check(
       "B's tmux session survived the close (detached, not killed)",
-      tmuxSessionAlive(tmuxB),
-      tmuxB
+      tmuxSessionAlive(tmuxC),
+      tmuxC
     )
     t.check(
       "B's session record survived the close",
-      sessionRecords().some((r) => r.id === sessionB)
+      sessionRecords().some((r) => r.id === openedC.sessionId)
     )
     const idA3 = await identityOf(winA)
     t.check(
-      'the primary hosts workspace B again after B closed',
-      idA3?.hostedWorkspaceIds?.includes(WS_B.id),
+      'the primary hosts B and C again after B closed',
+      idA3?.hostedWorkspaceIds?.includes(WS_B.id) && idA3?.hostedWorkspaceIds?.includes(WS_C.id),
       idA3?.hostedWorkspaceIds
     )
+    // A change in A now: C's file must still hold what B wrote there. The
+    // group carries a session so it survives the restart below (an empty
+    // group has nothing to restore around).
+    const groupA2 = await callMcp(app, 'createGroup', { name: 'A second' })
+    const openedA3 = await callMcp(app, 'openSession', {
+      cwd: ROOT_A,
+      mode: 'terminal',
+      groupId: groupA2.groupId
+    })
+    opened.push(openedA3.sessionId)
+    await sleep(2000)
+    t.check(
+      "A's file gained the new group next to the first",
+      !!(await untilGroups(WS_A.id, ['A lane', 'A second'])),
+      groupNames(readLayout(WS_A.id))
+    )
+    t.check(
+      "C's file still carries what B wrote (A re-read it before writing)",
+      JSON.stringify(groupNames(readLayout(WS_C.id)).sort()) ===
+        JSON.stringify(['C from B', 'C seed']),
+      groupNames(readLayout(WS_C.id))
+    )
+    t.check(
+      "B's file is intact too",
+      JSON.stringify(groupNames(readLayout(WS_B.id)).sort()) ===
+        JSON.stringify(['B lane', 'B seed']),
+      groupNames(readLayout(WS_B.id))
+    )
 
-    // ── restart: the last-active workspace, and both layouts, come back ──
+    // ── restart: the last-active workspace, and every layout, come back ──
     await app.close()
     app = null
     await sleep(1500)
@@ -336,45 +458,83 @@ export async function run(t) {
     t.equal(
       'after a restart the first window opens on the last-active workspace',
       id1?.workspaceId,
-      WS_B.id
+      WS_C.id
     )
-    const listed = await callMcp(app, 'list', {})
+    // The first window shows C. Its restore prompt is scoped to C (§3.6): the
+    // C-seed session was spawned into a hidden workspace and never mounted, so
+    // it comes back as a dead record and is offered here — and ONLY it, not
+    // B's dead seed, which waits for B to be opened (its group stays a shell).
+    // Answer Restore so C seed relaunches; boot then finishes restoring.
+    const restartPrompt = await until(() =>
+      win1.evaluate(() => {
+        const text = document.body.textContent || ''
+        return text.includes('Restore previous session?') ? text : null
+      })
+    )
+    t.check('the restart prompt is scoped to the shown workspace (C)', restartPrompt !== null)
+    t.check(
+      'and offers ONE terminal — C-seed, not B-seed',
+      !!restartPrompt &&
+        restartPrompt.includes('1 terminal') &&
+        !restartPrompt.includes('2 terminals'),
+      restartPrompt?.slice(
+        restartPrompt.indexOf('Restore previous session?'),
+        restartPrompt.indexOf('Restore previous session?') + 120
+      )
+    )
+    await win1.click('button:has-text("Restore")')
+    await sleep(2500)
+    const expected = [
+      ['A lane', WS_A, tick.sessionId],
+      ['A second', WS_A, openedA3.sessionId],
+      ['B seed', WS_B, opened[1]], // hidden-hosted shell: group kept, dead record awaits B opening
+      ['B lane', WS_B, openedB.sessionId], // live, adopted hidden
+      ['C seed', WS_C, null], // relaunched fresh, new id
+      ['C from B', WS_C, openedC.sessionId]
+    ]
+    // Adoption of every survivor races the machine load; poll until the store
+    // holds every group rather than sampling once.
+    const listed =
+      (await until(async () => {
+        const l = await callMcp(app, 'list', {})
+        return expected.every(([name]) => l.groups.some((g) => g.name === name)) ? l : null
+      })) ?? (await callMcp(app, 'list', {}))
     const names = listed.groups.map((g) => g.name)
-    t.check("workspace A's group came back from its own file", names.includes('A lane'), names)
-    t.check("workspace B's group came back from its own file", names.includes('B lane'), names)
-    const gA = listed.groups.find((g) => g.name === 'A lane')
-    const gB = listed.groups.find((g) => g.name === 'B lane')
-    t.equal("A's group is scoped to A", gA?.workspaceId, WS_A.id)
-    t.equal("B's group is scoped to B", gB?.workspaceId, WS_B.id)
-    t.check(
-      "A's ticking session came back inside its group",
-      gA?.sessionIds?.includes(sessionA),
-      gA?.sessionIds
-    )
-    t.check(
-      "B's session came back inside its group",
-      gB?.sessionIds?.includes(sessionB),
-      gB?.sessionIds
-    )
-    // The primary now holds BOTH workspaces' groups in one store, and still
+    for (const [name, wsx, sid] of expected) {
+      const g = listed.groups.find((x) => x.name === name)
+      t.check(
+        `"${name}" came back from its own file, scoped to its workspace`,
+        g?.workspaceId === wsx.id,
+        { names, g }
+      )
+      if (sid)
+        t.check(`and its session is in "${name}"`, !!g?.sessionIds?.includes(sid), g?.sessionIds)
+    }
+    // The primary now holds every workspace's groups in one store, and still
     // writes each workspace's file with that workspace's groups only.
     await sleep(1500)
-    const layoutA2 = readLayout(WS_A.id)
-    const layoutB2 = readLayout(WS_B.id)
     t.check(
-      "after the restart A's file still carries only A's group",
-      groupNames(layoutA2).includes('A lane') && !groupNames(layoutA2).includes('B lane'),
-      groupNames(layoutA2)
+      "after the restart A's file carries only A's groups",
+      JSON.stringify(groupNames(readLayout(WS_A.id)).sort()) ===
+        JSON.stringify(['A lane', 'A second']),
+      groupNames(readLayout(WS_A.id))
     )
     t.check(
-      "after the restart B's file still carries only B's group",
-      groupNames(layoutB2).includes('B lane') && !groupNames(layoutB2).includes('A lane'),
-      groupNames(layoutB2)
+      "after the restart B's file carries only B's groups",
+      JSON.stringify(groupNames(readLayout(WS_B.id)).sort()) ===
+        JSON.stringify(['B lane', 'B seed']),
+      groupNames(readLayout(WS_B.id))
+    )
+    t.check(
+      "after the restart C's file carries only C's groups",
+      JSON.stringify(groupNames(readLayout(WS_C.id)).sort()) ===
+        JSON.stringify(['C from B', 'C seed']),
+      groupNames(readLayout(WS_C.id))
     )
     const state2 = JSON.parse(readFileSync(path.join(DIR, 'workspace-state.json'), 'utf-8'))
     t.check(
       'the new build writes both keys (one-release downgrade safety)',
-      state2.lastActiveWorkspaceId === WS_B.id && state2.activeWorkspaceId === WS_B.id,
+      state2.lastActiveWorkspaceId === WS_C.id && state2.activeWorkspaceId === WS_C.id,
       state2
     )
 
@@ -384,8 +544,8 @@ export async function run(t) {
     t.equal('the single window switched to A', (await identityOf(win1))?.workspaceId, WS_A.id)
 
     // Cleanup: close every session this spec opened (kills their tmux sessions).
-    for (const sid of [sessionA, sessionA2, sessionB]) {
-      if (sid) await callMcp(app, 'closeSession', { sessionId: sid }).catch(() => {})
+    for (const sid of opened) {
+      await callMcp(app, 'closeSession', { sessionId: sid }).catch(() => {})
     }
   } finally {
     if (app) await app.close()

--- a/tests/e2e/multi-window-core.spec.mjs
+++ b/tests/e2e/multi-window-core.spec.mjs
@@ -199,7 +199,27 @@ export async function run(t) {
       WS_B.id
     )
 
-    // ...yet a spawn from A, with no workspace named, is stamped A (invariant 4).
+    // ...yet a RAW pty:spawn from A's renderer with no workspace at all is
+    // stamped by main from A's window, not from the file (invariant 4 at
+    // main's own layer; every renderer path stamps explicitly, this is the
+    // fallback a windowed caller gets).
+    const rawId = await winA.evaluate(
+      (cwd) =>
+        window.electronAPI
+          .spawnSession(cwd, { claudeMode: false, tmuxMode: false })
+          .then((info) => info.id),
+      ROOT_A
+    )
+    await sleep(800)
+    const rawRec = sessionRecords().find((r) => r.id === rawId)
+    t.equal(
+      'a raw spawn from window A is stamped by main with A, not the last-active B',
+      rawRec?.workspaceId,
+      WS_A.id
+    )
+    await winA.evaluate((id) => window.electronAPI.killSession(id), rawId)
+
+    // ...and a spawn from A through the dispatcher, with no workspace named, is stamped A too.
     const openedA2 = await callMcpIn(app, idA.windowId, 'openSession', {
       cwd: ROOT_A,
       mode: 'terminal',
@@ -244,6 +264,33 @@ export async function run(t) {
     t.check(
       'the legacy single layout file never appears',
       !existsSync(path.join(DIR, 'sidebar-layout.json'))
+    )
+
+    // A cross-workspace write is refused by main, loudly, and writes nothing:
+    // B's renderer tries to overwrite A's layout file.
+    const rogue = await b.page.evaluate(
+      (ws) =>
+        window.electronAPI.sidebarLayoutSave(ws, {
+          groups: [
+            {
+              id: 'rogue',
+              name: 'Rogue',
+              sessionIds: [],
+              collapsed: false,
+              cwd: null,
+              terminals: []
+            }
+          ],
+          displayOrder: ['rogue']
+        }),
+      WS_A.id
+    )
+    t.equal("a write to another window's workspace is refused", rogue?.ok, false)
+    t.equal('the refusal names the reason', rogue?.reason, 'not-host')
+    t.check(
+      "and A's file is untouched",
+      !groupNames(readLayout(WS_A.id)).includes('Rogue'),
+      groupNames(readLayout(WS_A.id))
     )
 
     // ── close B: A keeps streaming, B's session is detached not killed ──

--- a/tests/e2e/multi-window-first-workspace.spec.mjs
+++ b/tests/e2e/multi-window-first-workspace.spec.mjs
@@ -1,0 +1,157 @@
+/**
+ * Registering the FIRST workspace must not destroy existing groups
+ * (PRDCT-1703, invariant 15 — the single-window regression floor). This is
+ * the F1 regression: groups created in no-workspace mode are UNSTAMPED, and
+ * when the first workspace is registered the primary "takes" that workspace's
+ * (empty) layout and used to prune every unstamped group as member-less,
+ * silently emptying the sidebar.
+ *
+ * Entirely production paths: MCP createGroup + openSession in no-workspace
+ * mode, then the real Settings → "Add Workspace" button with only the native
+ * folder dialog stubbed. The session cwd is OUTSIDE the workspace root, so
+ * nothing places the groups by cwd — the only signal is the workspace stamp.
+ *
+ * Fails (before the fix) with the groups gone from both the running app and
+ * the workspace's layout file; the legacy file is renamed to .migrated-backup
+ * where the groups survive but the app never reads it.
+ */
+import {
+  launchApp,
+  seedWorkspaces,
+  seedTrustedRoots,
+  userDataDir,
+  stubFolderDialog,
+  callMcp,
+  until,
+  killLeakedE2eTmux
+} from './harness.mjs'
+import { existsSync, mkdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+
+const DIR = userDataDir('multi-window-first-workspace')
+// The workspace root, and a session cwd OUTSIDE it (so no cwd placement).
+const ROOT_W = '/tmp/clave-e2e-firstws-w'
+const ROOT_S = '/tmp/clave-e2e-firstws-s'
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+const readJson = (p) => (existsSync(p) ? JSON.parse(readFileSync(p, 'utf-8')) : null)
+const groupNames = (l) => (l?.groups ?? []).map((g) => g.name).sort()
+
+export async function run(t) {
+  killLeakedE2eTmux()
+  mkdirSync(ROOT_W, { recursive: true })
+  mkdirSync(ROOT_S, { recursive: true })
+  // Zero workspaces: the app runs unscoped, exactly as before the workspace
+  // model — createGroup then stamps activeWorkspaceId, which is null here.
+  seedWorkspaces(DIR, { workspaces: [], activeWorkspaceId: null, fresh: true })
+  seedTrustedRoots(DIR, [ROOT_W, ROOT_S])
+
+  let app = null
+  const opened = []
+  try {
+    const launched = await launchApp(DIR, { settleMs: 5000 })
+    app = launched.app
+    const win = launched.win
+    const idBefore = await win.evaluate(() => window.electronAPI.windowIdentity())
+    t.equal('the app starts in no-workspace mode', idBefore?.workspaceId, null)
+
+    // Two groups, each with a real session (a member-less group is dropped by
+    // a pre-existing rule, so both must be filled before the next is made).
+    const g1 = await callMcp(app, 'createGroup', { name: 'ORPHAN ONE' })
+    const s1 = await callMcp(
+      app,
+      'openSession',
+      { cwd: ROOT_S, mode: 'terminal', groupId: g1.groupId },
+      20000
+    )
+    opened.push(s1.sessionId)
+    const g2 = await callMcp(app, 'createGroup', { name: 'ORPHAN TWO' })
+    const s2 = await callMcp(
+      app,
+      'openSession',
+      { cwd: ROOT_S, mode: 'terminal', groupId: g2.groupId },
+      20000
+    )
+    opened.push(s2.sessionId)
+    await sleep(3000)
+
+    const before = await callMcp(app, 'list', {})
+    t.check(
+      'both groups exist before registering a workspace',
+      JSON.stringify(before.groups.map((g) => g.name).sort()) ===
+        JSON.stringify(['ORPHAN ONE', 'ORPHAN TWO']),
+      before.groups.map((g) => g.name)
+    )
+    // In no-workspace mode both groups are unstamped.
+    t.check(
+      'the groups are unstamped in no-workspace mode',
+      before.groups.every((g) => g.workspaceId === null),
+      before.groups.map((g) => ({ n: g.name, ws: g.workspaceId }))
+    )
+
+    // ── Register the FIRST workspace through the real Settings button ──
+    await stubFolderDialog(app, { returns: ROOT_W })
+    await app.evaluate(({ BrowserWindow }) => {
+      BrowserWindow.getAllWindows()[0].webContents.send('menu:open-settings-section', 'general')
+    })
+    await win.waitForTimeout(1200)
+    await win.click('.settings-row-action:has-text("Add Workspace")')
+    const state = await until(async () => {
+      const s = await win.evaluate(() => window.electronAPI.workspaceLoad())
+      return s?.workspaces?.length === 1 ? s : null
+    })
+    t.check('the first workspace was registered', state !== null)
+    const wsId = state.workspaces[0].id
+    await sleep(4000)
+
+    // ── The groups must survive, in the running app AND on disk ──
+    const after = await callMcp(app, 'list', {})
+    t.check(
+      'both groups still exist in the app after registering the first workspace',
+      JSON.stringify(after.groups.map((g) => g.name).sort()) ===
+        JSON.stringify(['ORPHAN ONE', 'ORPHAN TWO']),
+      after.groups.map((g) => g.name)
+    )
+    t.check(
+      'and they are now stamped with the new workspace',
+      after.groups.length > 0 && after.groups.every((g) => g.workspaceId === wsId),
+      after.groups.map((g) => ({ n: g.name, ws: g.workspaceId }))
+    )
+    const idAfter = await win.evaluate(() => window.electronAPI.windowIdentity())
+    t.equal('the window now shows the new workspace', idAfter?.workspaceId, wsId)
+
+    // The workspace's layout file carries both groups; the legacy file was
+    // migrated to a backup (kept, never deleted).
+    const wFile = readJson(path.join(DIR, 'sidebar-layouts', `${wsId}.json`))
+    t.check(
+      "the workspace's layout file carries both groups",
+      JSON.stringify(groupNames(wFile)) === JSON.stringify(['ORPHAN ONE', 'ORPHAN TWO']),
+      groupNames(wFile)
+    )
+
+    // Restart: the groups come back from the workspace file around the
+    // re-adopted sessions (the single-window restore floor).
+    await app.close()
+    app = null
+    await sleep(1500)
+    const relaunched = await launchApp(DIR, { settleMs: 6000 })
+    app = relaunched.app
+    const listed =
+      (await until(async () => {
+        const l = await callMcp(app, 'list', {})
+        return l.groups.length >= 2 ? l : null
+      })) ?? (await callMcp(app, 'list', {}))
+    t.check(
+      'both groups come back after a restart, scoped to the workspace',
+      JSON.stringify(listed.groups.map((g) => g.name).sort()) ===
+        JSON.stringify(['ORPHAN ONE', 'ORPHAN TWO']) &&
+        listed.groups.every((g) => g.workspaceId === wsId),
+      listed.groups.map((g) => ({ n: g.name, ws: g.workspaceId }))
+    )
+
+    for (const sid of opened) await callMcp(app, 'closeSession', { sessionId: sid }).catch(() => {})
+  } finally {
+    if (app) await app.close()
+    killLeakedE2eTmux()
+  }
+}

--- a/tests/e2e/multi-window-migration.spec.mjs
+++ b/tests/e2e/multi-window-migration.spec.mjs
@@ -1,0 +1,227 @@
+/**
+ * The one-time sidebar-layout migration (PRDCT-1703, invariant 6): the legacy
+ * single `sidebar-layout.json` is partitioned into one file per workspace on
+ * the first load after the update, every legacy group landing in EXACTLY ONE
+ * per-workspace file, and the legacy file is kept as `.migrated-backup`.
+ *
+ * Seeded like a real pre-update profile: live tmux sessions with their
+ * records (so the groups survive the renderer's restore, which drops a group
+ * whose sessions are gone), and a legacy layout mixing a stamped group, an
+ * unstamped group placed by its cwd, an unstamped group with no usable cwd
+ * (fallback: the last-active workspace), and a bare session id in the display
+ * order placed by its record. The assertions read the FILES the migration
+ * wrote and then the app's own scoped listing.
+ *
+ * Failure modes this must catch: everything dumped into one workspace, a
+ * group dropped or duplicated, the legacy file deleted instead of kept, the
+ * display order not following its items.
+ */
+import {
+  launchApp,
+  seedWorkspaces,
+  seedTrustedRoots,
+  userDataDir,
+  callMcp,
+  killLeakedE2eTmux
+} from './harness.mjs'
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+const DIR = userDataDir('multi-window-migration')
+const ROOT_A = '/tmp/clave-e2e-mw-mig-a'
+const ROOT_B = '/tmp/clave-e2e-mw-mig-b'
+const WS_A = {
+  id: 'aaaaaaaa-0000-4000-8000-0000000000a2',
+  name: 'MigA',
+  rootDir: ROOT_A,
+  profileFile: null,
+  createdAt: 1
+}
+const WS_B = {
+  id: 'bbbbbbbb-0000-4000-8000-0000000000b2',
+  name: 'MigB',
+  rootDir: ROOT_B,
+  profileFile: null,
+  createdAt: 1
+}
+
+const SESS = {
+  a: {
+    id: '11111111-0000-4000-8000-000000000001',
+    tmux: 'clave-e2e-mig-a',
+    cwd: ROOT_A,
+    workspaceId: WS_A.id
+  },
+  b: {
+    id: '22222222-0000-4000-8000-000000000002',
+    tmux: 'clave-e2e-mig-b',
+    cwd: ROOT_B,
+    workspaceId: WS_B.id
+  },
+  c: {
+    id: '33333333-0000-4000-8000-000000000003',
+    tmux: 'clave-e2e-mig-c',
+    cwd: ROOT_A,
+    workspaceId: undefined
+  },
+  x: {
+    id: '44444444-0000-4000-8000-000000000004',
+    tmux: 'clave-e2e-mig-x',
+    cwd: ROOT_B,
+    workspaceId: WS_B.id
+  }
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+function seedLiveSession(s) {
+  execFileSync('tmux', ['-L', 'clave', 'new-session', '-d', '-s', s.tmux, '-c', s.cwd])
+  const dir = path.join(DIR, 'session-records')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(
+    path.join(dir, `${s.tmux}.json`),
+    JSON.stringify({
+      tmuxName: s.tmux,
+      id: s.id,
+      cwd: s.cwd,
+      folderName: path.basename(s.cwd),
+      claudeMode: false,
+      antigravityMode: false,
+      codexMode: false,
+      claudeAgentsMode: false,
+      dangerousMode: false,
+      ...(s.workspaceId ? { workspaceId: s.workspaceId } : {})
+    })
+  )
+}
+
+const group = (id, name, sessionIds, extra = {}) => ({
+  id,
+  name,
+  sessionIds,
+  collapsed: false,
+  cwd: null,
+  terminals: [],
+  ...extra
+})
+
+function readLayout(wsId) {
+  const f = path.join(DIR, 'sidebar-layouts', `${wsId}.json`)
+  return existsSync(f) ? JSON.parse(readFileSync(f, 'utf-8')) : null
+}
+
+export async function run(t) {
+  killLeakedE2eTmux()
+  mkdirSync(ROOT_A, { recursive: true })
+  mkdirSync(ROOT_B, { recursive: true })
+  seedWorkspaces(DIR, { workspaces: [WS_A, WS_B], activeWorkspaceId: WS_A.id, fresh: true })
+  seedTrustedRoots(DIR, [ROOT_A, ROOT_B])
+  for (const s of Object.values(SESS)) seedLiveSession(s)
+
+  const legacy = {
+    groups: [
+      group('g-stamped', 'Stamped A', [SESS.a.id], { workspaceId: WS_A.id }),
+      group('g-bycwd', 'By cwd B', [SESS.b.id], { cwd: ROOT_B }),
+      group('g-orphan', 'Orphan', [SESS.c.id], { cwd: '/nowhere/at/all' })
+    ],
+    displayOrder: [SESS.x.id, 'g-stamped', 'g-bycwd', 'g-orphan']
+  }
+  const legacyPath = path.join(DIR, 'sidebar-layout.json')
+  const legacyText = JSON.stringify(legacy, null, 2)
+  writeFileSync(legacyPath, legacyText)
+
+  let app = null
+  try {
+    const launched = await launchApp(DIR, { settleMs: 7000 })
+    app = launched.app
+
+    // ── the files ──
+    t.check('the legacy file is gone from its old path', !existsSync(legacyPath))
+    const backup = `${legacyPath}.migrated-backup`
+    t.check('the legacy file is kept as .migrated-backup', existsSync(backup), backup)
+    t.check(
+      'the backup is the legacy file byte for byte',
+      existsSync(backup) && readFileSync(backup, 'utf-8') === legacyText
+    )
+
+    const fileA = readLayout(WS_A.id)
+    const fileB = readLayout(WS_B.id)
+    t.check('workspace A got a layout file', fileA !== null)
+    t.check('workspace B got a layout file', fileB !== null)
+    const idsA = (fileA?.groups ?? []).map((g) => g.id).sort()
+    const idsB = (fileB?.groups ?? []).map((g) => g.id).sort()
+    t.check(
+      'the stamped group and the orphan (fallback = last-active A) landed in A',
+      JSON.stringify(idsA) === JSON.stringify(['g-orphan', 'g-stamped']),
+      idsA
+    )
+    t.check(
+      'the cwd-placed group landed in B',
+      JSON.stringify(idsB) === JSON.stringify(['g-bycwd']),
+      idsB
+    )
+    t.check(
+      'every group is stamped with the workspace it landed in',
+      (fileA?.groups ?? []).every((g) => g.workspaceId === WS_A.id) &&
+        (fileB?.groups ?? []).every((g) => g.workspaceId === WS_B.id)
+    )
+    t.check(
+      'the bare session id in the order followed its record to B',
+      (fileB?.displayOrder ?? []).includes(SESS.x.id) &&
+        !(fileA?.displayOrder ?? []).includes(SESS.x.id),
+      { a: fileA?.displayOrder, b: fileB?.displayOrder }
+    )
+    t.check(
+      'the order follows the groups, in the legacy order',
+      JSON.stringify(fileA?.displayOrder?.filter((id) => id.startsWith('g-'))) ===
+        JSON.stringify(['g-stamped', 'g-orphan']) &&
+        JSON.stringify(fileB?.displayOrder?.filter((id) => id.startsWith('g-'))) ===
+          JSON.stringify(['g-bycwd']),
+      { a: fileA?.displayOrder, b: fileB?.displayOrder }
+    )
+
+    // ── the app: each workspace lists exactly its own migrated groups ──
+    const inA = await callMcp(app, 'list', { workspace: WS_A.id })
+    const inB = await callMcp(app, 'list', { workspace: WS_B.id })
+    const namesA = inA.groups.map((g) => g.name).sort()
+    const namesB = inB.groups.map((g) => g.name).sort()
+    t.check(
+      'workspace A shows the stamped group and the orphan',
+      JSON.stringify(namesA) === JSON.stringify(['Orphan', 'Stamped A']),
+      namesA
+    )
+    t.check(
+      'workspace B shows the cwd-placed group',
+      JSON.stringify(namesB) === JSON.stringify(['By cwd B']),
+      namesB
+    )
+    const all = await callMcp(app, 'list', {})
+    t.equal('no group was duplicated across workspaces', all.groups.length, 3)
+    t.check(
+      'every seeded session came back alive',
+      Object.values(SESS).every((s) => all.sessions.some((l) => l.id === s.id && l.alive)),
+      all.sessions.map((s) => s.id)
+    )
+
+    // A second boot must not re-run anything: the backup stays, nothing changes.
+    await app.close()
+    app = null
+    await sleep(1000)
+    const again = await launchApp(DIR, { settleMs: 5000 })
+    app = again.app
+    t.check(
+      'a second boot leaves the backup in place (idempotent)',
+      existsSync(backup) && !existsSync(legacyPath)
+    )
+    const listed = await callMcp(app, 'list', {})
+    t.equal('and the groups are still three', listed.groups.length, 3)
+
+    for (const s of Object.values(SESS)) {
+      await callMcp(app, 'closeSession', { sessionId: s.id }).catch(() => {})
+    }
+  } finally {
+    if (app) await app.close()
+    killLeakedE2eTmux()
+  }
+}


### PR DESCRIPTION
## Multi-window core: WindowRegistry, per-window teardown, per-workspace sidebar layout

Slice 1 of 4 for PRDCT-1703 (lane `2026-08-23-multi-window`, spec §3.1–3.5, approved). Target `dev`; base `f53b6b8a30ad3d68c15c2018228c51e9867c9370` (origin/dev at spawn, unchanged since the lane opened). Slice 2 (`feat/multi-window-routing`) will stack on this branch's head.

### Fix round (verifier slot-1 FAIL — F1, plus J1/J3)

The independent verifier proved a single-window **F1**: registering the FIRST workspace destroyed every existing group (invariant 15 breach, silent data loss on the upgrade path). Mechanism: in no-workspace mode groups are unstamped; `addWorkspace` persisted the registry, main broadcast identities, the primary gained the new workspace and ran `takeLayouts([W])` while `activeWorkspaceId` was still null — `surviving` (matched on the stamp) came back empty while `mergeLayoutForKeys` re-read `activeWorkspaceId = W` after its awaits and treated the unstamped groups as owned by W, rebuilding W from its empty file and pruning every group member-less. Fixed:
- `addWorkspace` does the whole no-workspace→first-workspace transition IN-STORE before main broadcasts (mark the workspace taken, make it active, set `hostedWorkspaceIds`, `stampUnowned`), so the gained-workspace identity push finds it already taken and skips the take, and the `stampUnowned` change persists W's file immediately.
- `applyIdentity` never re-takes a key already taken (a key legitimately re-taken on regain was dropped from taken on loss, so regain is unaffected).
- `mergeLayoutForKeys` ownership is now by EXPLICIT stamp: an unstamped item belongs to the null (unscoped) partition only, never to a string workspace being taken. This is the deliberate asymmetry with the write path (`partitionSidebarLayout` still routes an unstamped group to the window's workspace) — the untested M7 seam, now covered by a pure-function test that goes red under its reintroduction.
- **J1**: removed `restoreGroups` (dead since `mergeLayoutForKeys` replaced it — verifier positive-control-proven uncalled).
- **J3**: the pins-persist memo is now set only on an accepted write and cleared on hosting loss, matching the layout memo (a latent version of the review's finding 9).
- New E2E `multi-window-first-workspace.spec.mjs` reproduces the verifier's exact scenario end to end.

The verifier confirmed F2 (ssh/openclaw teardown coverage gap) is a probe-proven-CORRECT behaviour; per the ruling its assertion is Romain's scope call and is NOT added here.

### What changes

**A window shows one workspace; main knows which.** `src/main/window-registry.ts` (new) is the single in-main truth for window → workspace, session → hosting window, and the primary window (first of the run, re-elected as the lowest surviving id). It is generic over `{id, isDestroyed()}` with the focused-window lookup injected, so its 28 vitest cases run in plain node; `windowRegistry` is the production instance. `createWindow(workspaceId)` registers the window before load; the first window opens on `lastActiveWorkspaceId` → first registered → null (no-workspace onboarding, as today). `openWorkspaceWindow(workspaceId)` is the one reach for "show W in its own window" (the File menu, the picker, `clave_open_window` and the E2E harness all come through it, via invoke `window:open`): a workspace already shown somewhere is focused, never duplicated.

**The renderer learns its own identity, and asks before switching.** Invoke `window:identity` → `{windowId, workspaceId, isPrimary, hostedWorkspaceIds}`, awaited at the top of the boot effect (`bootWorkspaces`); push `window:workspace-changed` re-delivers it whenever hosting moves. `activeWorkspaceId` in the renderer store keeps its name and now means "this window's workspace". Every switch (`setActiveWorkspace`, the first-workspace claim in `addWorkspace`, the fallback in `removeWorkspace`) goes through `window:set-workspace` FIRST: main refuses when another window shows the target (and brings that window forward), so the guard that keeps mirroring out of scope has one enforcement point.

**Teardown ladder** (`src/main/index.ts` `onWindowClosed`, replacing the `closed` handler at old lines 69–73): a non-last window closing detaches only the sessions it hosts (`ptyManager.kill(id, false)`: a tmux-backed session keeps running with its record intact; a plain one dies exactly as on close today, record kept), drops their bindings, unregisters the window, re-elects the primary, and pushes `session:rehome` (the session ids) to the new host. The last window's close is today's three calls verbatim. ssh and OpenClaw are disconnected only in the last-window branch.

**In plain words, until slice 2 lands:** a closed secondary window's tmux-backed sessions are **detached until the next app boot** — they keep running in tmux and come back as live survivors at the next launch, but no window re-adopts them in the running app. The `session:rehome` push is sent; nothing listens yet. Slice 2 ships the renderer half (adopting the pushed records). No release happens between the PR1 and PR2 merges (publisher duty, on the record).

**Spawn stamping** (`pty-handlers.ts`): `options.workspaceId ?? windowRegistry.getWorkspaceForWindow(sender) ?? lastActiveWorkspaceId`; `bindSession` at spawn, `unbindSession` on exit and on `pty:kill`. `records:list-adoptable` takes an optional `workspaceId`: a secondary window adopts and prompts for its own workspace only; the primary stays unfiltered (today's boot).

**Per-workspace sidebar layout.** `sidebar-layouts/<workspaceId>.json` under userData (same `{groups, displayOrder}` shape, same write-then-rename). `sidebar-layout:load(keys[])` returns the layouts of the workspaces the window hosts, concatenated (primary at boot = all; secondary = its own; `null` = the unscoped layout of no-workspace mode, which stays in today's `sidebar-layout.json`). `sidebar-layout:save(key, data)` writes ONE workspace's partition; the renderer (`partitionSidebarLayout`, `session-store.ts`) partitions by each group's/session's own stamp (unstamped → this window's workspace) and only sends partitions it hosts, only when that partition's JSON changed; main refuses a write from a non-host with a `console.error` naming both windows and `{ok:false, reason:'not-host', hostWindowId}` — never silently.

**The one-time migration** (`src/main/sidebar-layout-migration.ts`, pure; 17 vitest cases): on the first load with ≥1 registered workspace, the legacy file is partitioned — a group with a registered `workspaceId` goes there; otherwise by `resolveWorkspaceForCwd(cwd)`; otherwise to the fallback (last-active, else the first registered); every group is stamped with where it landed; `displayOrder` ids follow their group, or their session's record (stamped, else cwd-derived), else the fallback; each partition is merged by id into a per-workspace file that may already exist (a workspace registered mid-run wrote one). The legacy file is RENAMED to `sidebar-layout.json.migrated-backup`, never deleted; idempotent once it is gone. `resolveWorkspaceForCwd` now realpath-normalizes the registered root as well as the cwd (`/tmp` → `/private/tmp` on macOS made a symlinked root miss every one of its sessions; pre-existing, hit by the migration spec, fixed here since it is the placement rule).

**workspace-state.json, field by field.** `workspace:save` (whole file) is gone. `workspace:update-registry` (global), `workspace:update-pins(workspaceId | null | 'all', pins)` (replaces that partition only; `'all'` is the one-time localStorage import in the primary; both honour the hosting rule), `workspace:set-last-active`. `lastActiveWorkspaceId` replaces `activeWorkspaceId` as the read key; BOTH are written for one release so the previous build reads its active workspace after a downgrade (old key read when the new one is absent). Registry/pin changes broadcast `workspace:state-changed` to the OTHER windows, which fold in the registry whole and the pin partitions they do not host (keeping runtime state of pins they already know).

### File ownership (spec §7 + the four additions ruled on 2026-08-24)

`src/main/window-registry.ts` (+test, new) · `src/main/sidebar-layout-migration.ts` (+test, new) · `src/main/ipc-handlers/window-handlers.ts` (new — the identity/switch/open handlers, injected with `openWorkspaceWindow` so it never imports the entry) · `src/main/index.ts` · `src/main/sidebar-layout-manager.ts` · `src/main/workspace-manager.ts` · `src/main/ipc-handlers/{sidebar-layout,workspace,pty}-handlers.ts` · `src/preload/index.ts` + `index.d.ts` · `src/shared/workspace-types.ts` (`lastActiveWorkspaceId`, `WindowIdentity`) · `src/renderer/src/lib/workspace-actions.ts` · `src/renderer/src/store/{workspace,session}-store.ts` · `src/renderer/src/components/layout/AppShell.tsx` (boot effect: identity, hosted layout keys, scoped adoption) · `src/renderer/src/lib/sidebar-layout-partition.ts` (+ `.test.ts`, new — the pure renderer partition/merge) · `tests/e2e/harness.mjs` (two-window helpers) · `tests/e2e/multi-window-{core,migration,first-workspace}.spec.mjs` (new). `restoreGroups` was removed from `session-store.ts` (dead code). No `.clave` field touched (the six-mirror rule does not fire). No dependency added; no shared root file changed.

### Invariants (spec §6) covered here — the verifier's list is `invariants-slice-1.md` in the lane drop

1, 2 (killAll half), 3 (detach half), 4, 5, 6, 7, 12, 13, 15. Invariant 15's single-window regression floor is now exercised directly by `multi-window-first-workspace.spec.mjs` (the F1 regression) in addition to the 10 pre-existing single-window specs and the core spec's restart/switch. Not observable in this slice's E2E and flagged in the notes: invariant 2's ssh/openclaw half (code path only — the verifier probe-proved the shipped behaviour correct); the `workspace:update-pins` refusal is now reachable by direct IPC (validated); the `workspace:state-changed` fold in a second window's store.

### Gates (re-measured at freeze — see the numbers section below)

`npm run typecheck` · `npm run lint` (zero NEW errors: per-file error counts base vs head for every touched file, every new file clean; the baseline's 232 errors / 1310 warnings at f53b6b8 are pre-existing, 195 of them `explicit-function-return-type` in renderer components) · `npm test` · `npm run build` · `npm run test:e2e` (the 10 existing single-window specs + the 2 new ones), full logs kept in the implementer worktree's `.lane-logs/`, `uptime` recorded before and after the E2E run.

### Every new spec proven able to fail (per-script proof; adversarial mutation is the verifier's)

Each new E2E spec was shown to go red under ONE behaviour mutation, restored, green (the repo's "a verification script MUST be able to fail" rule) — this is the per-script proof, not a designed battery:

- **`multi-window-core.spec.mjs`** — mutate the non-last-close detach loop in `src/main/index.ts`, replacing `for (const id of hosted) ptyManager.kill(id, false)` with `ptyManager.killAll()`, then `npx electron-vite build && node tests/e2e/run.mjs multi-window-core`. Red: "A's terminal kept streaming across B's close", "A's session never received pty:exit". `git checkout -- src` → rebuild → green.
- **`multi-window-migration.spec.mjs`** — mutate the partition placement in `src/main/sidebar-layout-migration.ts`, replacing `const ws = place(raw)` with `const ws = ctx.fallbackWorkspaceId`, then `npx electron-vite build && node tests/e2e/run.mjs multi-window-migration`. Red: the cwd-placed group lands in the wrong workspace and both scoped listings fail. `git checkout -- src` → rebuild → green.
- **`multi-window-first-workspace.spec.mjs`** (the F1 regression) — this was proven red on the pre-fix build (`b4e0523`): "both groups still exist in the app after registering the first workspace" and "and they are now stamped with the new workspace" both failed (the groups were destroyed); green at the fix head. Independently, the pure-function seam is proven at the unit level: mutate `mergeLayoutForKeys`'s `keySet.has(g.workspaceId ?? null)` to treat an unstamped group as owned by a taken key and `sidebar-layout-partition.test.ts`'s "taking a string workspace keeps unstamped store groups untouched (F1)" goes red; restore → green.

The unit suites (`window-registry.test.ts` 28, `sidebar-layout-migration.test.ts` 17, `sidebar-layout-partition.test.ts` 10 incl. the F1 seam + null-key + write-path asymmetry) are ordinary assertion tests: each fails when its pure function is wrong. The invariant list and the observation harness for the verifier's own adversarial pass are in the lane drop (`invariants-slice-1.md`).

### Limitations and notes for the record

- Detached-until-next-boot for a closed secondary window's tmux sessions (above) until PR2.
- An in-window switch in a SECONDARY window shows the target workspace without its sessions until PR2 re-homes them (the primary is unaffected: it hosts every unshown workspace and loads every layout at boot, which is why the single-window flows are unchanged).
- Removing, from window A, the workspace window B shows: B folds the registry, finds its workspace gone, and lands on the first remaining workspace main lets it show (else the unscoped state). Edge case the spec does not cover; noted, not exercised.
- `sendTargetWindow` (Mission Control) still targets the first window — slice 2 per spec §3.7. Every `getMainWindow()` site is untouched here (slice 2 deletes it).
- E2E roots live under `/tmp/clave-e2e-mw-*` (the harness's convention); the PTYs live on the shared `clave` tmux socket, so each spec kills only tmux sessions whose name contains `clave-e2e` at start and end, never anything else and never with pkill.
- **Pre-existing flake, not this slice's** (ledger hypothesis for the verifier): `group-prompt.spec.mjs` (a launcher spec outside this slice's ownership) failed once in a full-suite run — a 30 s locator timeout clicking `[role="menuitem"]:has-text("Codex CLI")` after its fixed 800 ms wait (`group-prompt.spec.mjs:74-75`). Diagnosed to mechanism, not re-run to green: `git diff f53b6b8..<head>` is byte-empty over `SessionLauncher.tsx` / `launch-session.ts` / `launch-prefs.ts`; the spec passes 16/16 solo twice at load ~3–4; the full-suite re-run was clean. The dropdown's render under full-suite load exceeds the spec's fixed wait.

### Numbers (freeze — HEAD `60b9c9e63524d3f58057f4f40e8fc49f17ab495d`, 2026-08-24)

Re-measured at the frozen sha in the implementer worktree (never the main checkout), full logs in `.lane-logs/`:

- **`npm run typecheck`** — 0 errors.
- **`npm run lint`** — **0 new errors, 0 new warnings** across every touched/new file (per-file base-vs-head counts). The suite's overall 232 errors / ~1310 warnings are pre-existing at `f53b6b8` and untouched. The verifier independently confirmed 0 new / 0 new on all touched files.
- **`npm test`** (vitest) — **142 passed, 0 failed** (13 files); new/changed unit suites: `window-registry.test.ts` (28), `sidebar-layout-migration.test.ts` (17), `sidebar-layout-partition.test.ts` (10, incl. the F1 seam).
- **`npm run build`** — `electron-vite build` OK.
- **`npm run test:e2e`** — **208 passed, 0 failed** across all 13 specs (10 pre-existing single-window + `multi-window-core` + `multi-window-migration` + `multi-window-first-workspace`), load avg 5.2 → 5.8. Clean; the pre-existing `group-prompt` flake (noted above) did not recur.

Every number is measured at the frozen HEAD `60b9c9e`.
