### PR TITLE
feat(keymaps): add configurable command sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ## [Unreleased]
 
+### Added
+- **Keymaps are editable, live, and can form commands** — Settings → Keymaps lists every Clave-owned shortcut, records up to two bindings per action, supports raw JSON plus import/export, and applies a valid draft to every open window only when Save is pressed. Existing shortcuts remain the defaults. `Ctrl+B` is the default command-mode master key: press it and then `C` within 300ms to start a Claude session; unmatched keys are consumed and leave command mode. Bindings can be removed or reset individually, the master key can be disabled, and invalid or conflicting configuration never replaces the last valid keymap. Menu accelerators and in-app shortcut labels follow the active configuration.
+
 ## [1.79.0] — 2026-08-28
 
 ### Added
@@ -18,7 +21,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versions use [Se
 
 ### Fixed
 - **The copy button on an open file copies the file** — opening a document and pressing copy put its *path* on the clipboard, on all three file surfaces: the preview sheet, the file tab, and the diff tab. That is the one thing the tree's right-click menu already offers twice, as a relative path and an absolute one, so the one gesture with an obvious meaning on an open document was spending itself on the only thing already covered. Copy now hands over what you are looking at — the file's text in the sheet and the tab, unsaved edits included, since it copies the live buffer rather than the disk, and the patch as git printed it in a diff — and flashes a check to say it happened, because a clipboard write is otherwise invisible. It is off, and says so, for what has no text to give: binaries, images, a file that failed to load.
-
 
 ## [1.78.0] — 2026-08-25
 

--- a/src/main/app-menu.ts
+++ b/src/main/app-menu.ts
@@ -3,6 +3,8 @@ import { focusedOrPrimaryWindow, bringForward } from './window-routing'
 import { windowRegistry } from './window-registry'
 import { workspaceManager } from './workspace-manager'
 import { checkForUpdatesNow, openUpdaterLog, RELEASES_URL } from './auto-updater'
+import { getStoredKeymapConfig } from './ipc-handlers/keymap-handlers'
+import type { KeymapActionId } from '../shared/keymaps'
 
 const REPO_URL = 'https://github.com/codika-io/clave'
 // electron-builder's productName, stated rather than read: `app.name` is the
@@ -43,6 +45,22 @@ export interface AppMenuDeps {
 }
 
 export function buildAppMenu(deps: AppMenuDeps): void {
+  const keymaps = getStoredKeymapConfig()
+  const acceleratorFor = (actionId: KeymapActionId): string | undefined => {
+    const binding = keymaps.bindings[actionId].find(
+      (candidate) => !candidate.includes(' ') && candidate !== 'Master'
+    )
+    if (!binding) return undefined
+    return binding
+      .split('+')
+      .map((token) => {
+        if (token === 'Mod') return 'Command'
+        if (token === 'Ctrl') return 'Control'
+        if (token === 'Alt') return 'Alt'
+        return token
+      })
+      .join('+')
+  }
   // File › New Window: the app once more, on the workspace of the window
   // the user is looking at (else the last-active one). ⌘⇧N is free: ⌘N is
   // the renderer's new-session shortcut.
@@ -74,7 +92,7 @@ export function buildAppMenu(deps: AppMenuDeps): void {
         { type: 'separator' },
         {
           label: 'Settings…',
-          accelerator: 'Command+,',
+          accelerator: acceleratorFor('openSettings'),
           // Displayed but not registered: the renderer already owns ⌘, and
           // should keep owning it, so the two cannot fight.
           registerAccelerator: false,
@@ -95,7 +113,8 @@ export function buildAppMenu(deps: AppMenuDeps): void {
       submenu: [
         {
           label: 'New Window',
-          accelerator: 'CommandOrControl+Shift+N',
+          accelerator: acceleratorFor('newWindow'),
+          registerAccelerator: false,
           click: newWindow
         }
       ]
@@ -135,7 +154,11 @@ export function buildAppMenu(deps: AppMenuDeps): void {
         { role: 'zoom' },
         // ⌘W closes a file tab when one is focused and falls through to the
         // window otherwise — the behaviour the default menu already gave us.
-        { role: 'close' },
+        {
+          role: 'close',
+          accelerator: acceleratorFor('closeFocused'),
+          registerAccelerator: false
+        },
         { type: 'separator' },
         { role: 'front' }
       ]

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -282,7 +282,7 @@ app.whenReady().then(() => {
     optimizer.watchWindowShortcuts(window)
   })
 
-  registerIpcHandlers()
+  registerIpcHandlers({ onChanged: () => buildAppMenu({ openWindow }) })
   registerWindowHandlers({ openWindow })
   registerMcpWindowOpener(openWindow)
   installPreviewProtocol()
@@ -339,3 +339,4 @@ app.on('window-all-closed', () => {
     app.quit()
   }
 })
+

--- a/src/main/ipc-handlers/clave-file-handlers.ts
+++ b/src/main/ipc-handlers/clave-file-handlers.ts
@@ -714,3 +714,10 @@ const preferencesManager = new PreferencesManager()
 export function getPreference(key: string): unknown {
   return preferencesManager.get(key)
 }
+
+
+/** Persist one app preference from a main-process feature. */
+export function setPreference(key: string, value: unknown): void {
+  preferencesManager.set(key, value)
+}
+

--- a/src/main/ipc-handlers/index.ts
+++ b/src/main/ipc-handlers/index.ts
@@ -22,8 +22,9 @@ import { registerWorkspaceHandlers } from './workspace-handlers'
 import { registerExchangeHandlers } from './exchange-handlers'
 import { registerPreviewHandlers } from './preview-handlers'
 import { registerHistoryHandlers } from './history-handlers'
+import { registerKeymapHandlers, type KeymapHandlerDeps } from './keymap-handlers'
 
-export function registerIpcHandlers(): void {
+export function registerIpcHandlers(deps: KeymapHandlerDeps = {}): void {
   registerAppHandlers()
   registerUsageHandlers()
   registerGitHandlers()
@@ -48,4 +49,5 @@ export function registerIpcHandlers(): void {
   registerExchangeHandlers()
   registerPreviewHandlers()
   registerHistoryHandlers()
+  registerKeymapHandlers(deps)
 }

--- a/src/main/ipc-handlers/keymap-handlers.ts
+++ b/src/main/ipc-handlers/keymap-handlers.ts
@@ -1,0 +1,72 @@
+import * as fs from 'fs'
+import { BrowserWindow, dialog, ipcMain } from 'electron'
+import {
+  parseKeymapOverrides,
+  resolveKeymapConfig,
+  type KeymapOverridesV1,
+  type ResolvedKeymapConfig
+} from '../../shared/keymaps'
+import { getPreference, setPreference } from './clave-file-handlers'
+
+export const KEYMAP_PREFERENCE_KEY = 'keymapOverrides'
+
+export interface KeymapHandlerDeps {
+  onChanged?: () => void
+}
+
+/** Read only a validated persisted value. A damaged or future-version file can
+ * never replace the code defaults in the running app. */
+export function getStoredKeymapOverrides(): KeymapOverridesV1 | null {
+  const raw = getPreference(KEYMAP_PREFERENCE_KEY)
+  if (raw === null) return null
+  const parsed = parseKeymapOverrides(raw)
+  if (!parsed.ok) {
+    console.error('[keymaps] Ignoring invalid persisted configuration', parsed.errors)
+    return null
+  }
+  return parsed.value
+}
+
+export function getStoredKeymapConfig(): ResolvedKeymapConfig {
+  return resolveKeymapConfig(getStoredKeymapOverrides())
+}
+
+export function registerKeymapHandlers(deps: KeymapHandlerDeps = {}): void {
+  ipcMain.handle('keymaps:load', () => getStoredKeymapOverrides())
+
+  ipcMain.handle('keymaps:save', (_event, raw: unknown): KeymapOverridesV1 => {
+    const parsed = parseKeymapOverrides(raw)
+    if (!parsed.ok) {
+      throw new Error(parsed.errors.map((error) => `${error.path}: ${error.message}`).join('\n'))
+    }
+    setPreference(KEYMAP_PREFERENCE_KEY, parsed.value)
+    for (const window of BrowserWindow.getAllWindows()) {
+      if (!window.isDestroyed()) window.webContents.send('keymaps:changed', parsed.value)
+    }
+    deps.onChanged?.()
+    return parsed.value
+  })
+
+  ipcMain.handle('keymaps:import', async (event): Promise<string | null> => {
+    const window = BrowserWindow.fromWebContents(event.sender)
+    const result = await dialog.showOpenDialog(window!, {
+      properties: ['openFile'],
+      filters: [{ name: 'Clave keymaps', extensions: ['json'] }]
+    })
+    if (result.canceled || result.filePaths.length === 0) return null
+    return fs.readFileSync(result.filePaths[0], 'utf-8')
+  })
+
+  ipcMain.handle('keymaps:export', async (event, json: string): Promise<boolean> => {
+    const window = BrowserWindow.fromWebContents(event.sender)
+    const result = await dialog.showSaveDialog(window!, {
+      defaultPath: 'clave-keymaps.json',
+      filters: [{ name: 'Clave keymaps', extensions: ['json'] }]
+    })
+    if (result.canceled || !result.filePath) return false
+    const temporaryPath = `${result.filePath}.tmp`
+    fs.writeFileSync(temporaryPath, json, 'utf-8')
+    fs.renameSync(temporaryPath, result.filePath)
+    return true
+  })
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -751,6 +751,11 @@ export interface ElectronAPI {
   readImageAsDataUrl: (absolutePath: string) => Promise<string | null>
   preferencesGet: (key: string) => Promise<unknown>
   preferencesSet: (key: string, value: unknown) => Promise<void>
+  keymapsLoad: () => Promise<unknown>
+  keymapsSave: (value: unknown) => Promise<unknown>
+  keymapsImport: () => Promise<string | null>
+  keymapsExport: (json: string) => Promise<boolean>
+  onKeymapsChanged: (callback: (value: unknown) => void) => () => void
   trustWorkspaceRoot: (root: string) => Promise<void>
   untrustWorkspaceRoot: (root: string) => Promise<void>
   listTrustedRoots: () => Promise<string[]>
@@ -794,3 +799,4 @@ declare global {
     electronAPI: ElectronAPI
   }
 }
+

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -493,6 +493,12 @@ const electronAPI = {
   preferencesGet: (key: string) => ipcRenderer.invoke('preferences:get', key),
   preferencesSet: (key: string, value: unknown) =>
     ipcRenderer.invoke('preferences:set', key, value),
+  keymapsLoad: () => ipcRenderer.invoke('keymaps:load'),
+  keymapsSave: (value: unknown) => ipcRenderer.invoke('keymaps:save', value),
+  keymapsImport: () => ipcRenderer.invoke('keymaps:import') as Promise<string | null>,
+  keymapsExport: (json: string) => ipcRenderer.invoke('keymaps:export', json) as Promise<boolean>,
+  onKeymapsChanged: (callback: (value: unknown) => void) =>
+    createIpcListener<[unknown]>('keymaps:changed', callback),
   trustWorkspaceRoot: (root: string) =>
     ipcRenderer.invoke('clave:trust-root', root) as Promise<void>,
   untrustWorkspaceRoot: (root: string) =>

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -2623,6 +2623,74 @@ body,
 
 /* ── Settings ── */
 
+/* Command-mode readout. It sits above every app panel but below native chrome,
+   and uses the same material as menus because it is equally transient. */
+.keymap-command-hud {
+  position: fixed;
+  z-index: 80;
+  top: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.375rem 0.625rem;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-secondary);
+  pointer-events: none;
+}
+.keymap-command-hud[data-state="matched"] {
+  color: var(--color-status-ready);
+}
+.keymap-command-hud[data-state="cancelled"] {
+  color: var(--text-tertiary);
+}
+
+.keymap-row {
+  min-height: var(--control-h-lg);
+}
+.keymap-bindings {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+.keymap-binding {
+  min-width: 4.5rem;
+  height: var(--control-h-md);
+  padding: 0 0.5rem;
+  border: 1px solid var(--border-subtle-color);
+  border-radius: var(--radius-lg);
+  background-color: var(--surface-100);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  transition: color 150ms, border-color 150ms, background-color 150ms;
+}
+.keymap-binding:hover,
+.keymap-binding:focus-visible {
+  color: var(--text-primary);
+  border-color: var(--color-accent);
+  outline: none;
+}
+.keymap-json {
+  min-height: 28rem;
+  resize: vertical;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+}
+.keymap-message {
+  padding: 0.625rem 0.75rem;
+  border: 1px solid var(--border-subtle-color);
+  border-radius: var(--radius-lg);
+  background-color: var(--surface-100);
+  color: var(--text-secondary);
+  font-size: 12px;
+  white-space: pre-wrap;
+}
+.keymap-message[data-tone="error"] {
+  color: var(--color-destructive);
+}
+
 /* Section label above each settings card (small, regular case) */
 .settings-section-title {
   display: block;
@@ -2891,3 +2959,4 @@ button.extension-card:hover {
   border-radius: var(--radius-lg);
   font-size: 13px;
 }
+

--- a/src/renderer/src/components/layout/AppShell.tsx
+++ b/src/renderer/src/components/layout/AppShell.tsx
@@ -1,5 +1,5 @@
 import { emitTabClosed } from '../../lib/exchange-capture'
-import { useEffect, useCallback, useRef, useState } from 'react'
+import { useEffect, useCallback, useMemo, useRef, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import {
   useSessionStore,
@@ -14,7 +14,7 @@ import { useAgentStore } from '../../store/agent-store'
 import { Sidebar } from './Sidebar'
 import { useFullScreen } from '../../hooks/use-fullscreen'
 import { launchSession } from '../../lib/launch-session'
-import { loadLaunchPrefs, type AgentSetup } from '../../store/launch-prefs'
+import { loadLaunchPrefs } from '../../store/launch-prefs'
 import { TerminalGrid } from './TerminalGrid'
 import { SettingsPanel } from '../settings/SettingsPanel'
 import { SettingsSidebar } from '../settings/SettingsSidebar'
@@ -55,6 +55,10 @@ import { ToolbarWorkspacePopover } from './ToolbarWorkspacePopover'
 import { resolveColorHex } from '../../store/session-types'
 import { getTerminalIconComponent } from '../ui/GroupCommandDialog'
 import { ToolbarTerminalPopover } from './ToolbarTerminalPopover'
+import { ConfirmDialog } from '../ui/ConfirmDialog'
+import { useKeymapManager, type KeymapActionHandlers } from '../../hooks/use-keymap-manager'
+import { KeymapCommandHud } from '../ui/KeymapCommandHud'
+import { connectKeymapStore, useShortcutLabel } from '../../store/keymap-store'
 
 const sidebarTransition = {
   duration: 0.2,
@@ -68,16 +72,6 @@ let tmuxAdoptionStarted = false
 /** Same latch pattern for the MCP command dispatcher: exactly one subscriber
  *  per process, or concurrent tool calls would get duplicate responses. */
 let mcpDispatcherStarted = false
-
-/** ⌘-key → what it launches. `null` is a plain terminal (no agent), which is
- *  why the lookup tests `!== undefined` rather than truthiness. */
-const LAUNCH_SHORTCUTS: Record<string, AgentSetup | null> = {
-  KeyT: null,
-  KeyN: { kind: 'claude', dangerousMode: false },
-  KeyD: { kind: 'claude', dangerousMode: true },
-  KeyI: { kind: 'antigravity', dangerousMode: false },
-  KeyU: { kind: 'codex', dangerousMode: false }
-}
 
 export function AppShell() {
   const sidebarOpen = useSessionStore((s) => s.sidebarOpen)
@@ -97,10 +91,14 @@ export function AppShell() {
   const activeView = useSessionStore((s) => s.activeView)
   const previewFile = useSessionStore((s) => s.previewFile)
   const previewSource = useSessionStore((s) => s.previewSource)
+  const filePaletteShortcut = useShortcutLabel('openFilePalette')
+  const sidePanelShortcut = useShortcutLabel('toggleSidePanel')
 
   const addSession = useSessionStore((s) => s.addSession)
   const removeSession = useSessionStore((s) => s.removeSession)
   const removeFileTab = useSessionStore((s) => s.removeFileTab)
+  const resetSessions = useSessionStore((s) => s.resetSessions)
+  const [resetConfirmOpen, setResetConfirmOpen] = useState(false)
 
   useWorkTracker()
 
@@ -129,7 +127,9 @@ export function AppShell() {
     // groups land first so the adopted members find their group.
     window.electronAPI?.onSessionRehome?.(({ sessionIds, layout, focus }) => {
       if (layout) {
-        useSessionStore.getState().absorbLayout(layout as { groups: SessionGroup[]; displayOrder: string[] })
+        useSessionStore
+          .getState()
+          .absorbLayout(layout as { groups: SessionGroup[]; displayOrder: string[] })
       }
       void adoptRehomed(sessionIds, useWorkspaceStore.getState().activeWorkspaceId, focus === true)
     })
@@ -335,160 +335,128 @@ export function AppShell() {
     [setFileTreeWidth]
   )
 
-  // Global keyboard shortcuts
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.metaKey && e.key === 'p') {
-        e.preventDefault()
-        toggleFilePalette()
+  const keymapActions = useMemo<KeymapActionHandlers>(() => {
+    const launch = (
+      setup: Parameters<typeof launchSession>[0]['setup'],
+      cwd: 'workspace-root' | 'ask',
+      remember = setup !== null
+    ): void => {
+      void launchSession({ setup, cwd: { kind: cwd }, remember })
+    }
+    const selectByIndex = (index: number): void => {
+      const state = useSessionStore.getState()
+      const ids = getVisibleFlatOrder(state, useWorkspaceStore.getState().activeWorkspaceId)
+      if (index < ids.length) state.selectSession(ids[index], false)
+    }
+    const cycleSession = (direction: 1 | -1): void => {
+      const state = useSessionStore.getState()
+      const ids = getVisibleFlatOrder(state, useWorkspaceStore.getState().activeWorkspaceId)
+      if (ids.length === 0) return
+      const current = ids.indexOf(state.focusedSessionId ?? '')
+      const next =
+        current < 0
+          ? direction === 1
+            ? 0
+            : ids.length - 1
+          : (current + direction + ids.length) % ids.length
+      state.selectSession(ids[next], false)
+    }
+    const togglePanel = (tab: 'git' | 'help'): void => {
+      const state = useSessionStore.getState()
+      if (state.fileTreeOpen && state.sidePanelTab === tab) state.toggleFileTree()
+      else {
+        if (!state.fileTreeOpen) state.toggleFileTree()
+        useSessionStore.getState().setSidePanelTab(tab)
       }
-      if (e.metaKey && e.key === 'e') {
-        e.preventDefault()
-        toggleFileTree()
-      }
-      // Cmd+B: Toggle left sidebar
-      if (e.metaKey && !e.shiftKey && e.key === 'b') {
-        e.preventDefault()
-        toggleSidebar()
-      }
-      // Cmd+Shift+G: Open right sidebar with Git tab
-      if (e.metaKey && e.shiftKey && e.key === 'g') {
-        e.preventDefault()
-        const state = useSessionStore.getState()
-        if (state.fileTreeOpen && state.sidePanelTab === 'git') {
-          toggleFileTree()
-        } else {
-          if (!state.fileTreeOpen) toggleFileTree()
-          useSessionStore.getState().setSidePanelTab('git')
-        }
-      }
-      // Cmd+Shift+H: the session history, on All (a group's own context menu
-      // opens it on that group).
-      if (e.metaKey && e.shiftKey && e.code === 'KeyH') {
-        e.preventDefault()
+    }
+    const actions = {
+      newTerminal: () => launch(null, 'workspace-root', false),
+      newTerminalAtFolder: () => launch(null, 'ask', false),
+      newClaude: () => launch({ kind: 'claude', dangerousMode: false }, 'workspace-root'),
+      newClaudeAtFolder: () => launch({ kind: 'claude', dangerousMode: false }, 'ask'),
+      newDangerousClaude: () => launch({ kind: 'claude', dangerousMode: true }, 'workspace-root'),
+      newDangerousClaudeAtFolder: () => launch({ kind: 'claude', dangerousMode: true }, 'ask'),
+      newClaudeAgents: () =>
+        launch({ kind: 'claude-agents', dangerousMode: false }, 'workspace-root'),
+      newClaudeAgentsAtFolder: () => launch({ kind: 'claude-agents', dangerousMode: false }, 'ask'),
+      newAntigravity: () => launch({ kind: 'antigravity', dangerousMode: false }, 'workspace-root'),
+      newAntigravityAtFolder: () => launch({ kind: 'antigravity', dangerousMode: false }, 'ask'),
+      newCodex: () => launch({ kind: 'codex', dangerousMode: false }, 'workspace-root'),
+      newCodexAtFolder: () => launch({ kind: 'codex', dangerousMode: false }, 'ask'),
+      toggleSidebar: () => toggleSidebar(),
+      toggleSidePanel: () => toggleFileTree(),
+      openFilePalette: () => toggleFilePalette(),
+      openGitPanel: () => togglePanel('git'),
+      openHistory: () => {
         const history = useHistoryStore.getState()
         if (history.open) history.closeHistory()
         else history.openHistory(null)
-        return
-      }
-      // Cmd+? (Cmd+Shift+/) — open help panel
-      if (e.metaKey && e.shiftKey && e.key === '/') {
-        e.preventDefault()
-        const {
-          fileTreeOpen: helpFileTreeOpen,
-          toggleFileTree: helpToggleFileTree,
-          sidePanelTab,
-          setSidePanelTab
-        } = useSessionStore.getState()
-        if (helpFileTreeOpen && sidePanelTab === 'help') {
-          helpToggleFileTree()
-        } else {
-          if (!helpFileTreeOpen) helpToggleFileTree()
-          setSidePanelTab('help')
-        }
-        return
-      }
-      // New-session shortcuts. They start at the WORKSPACE ROOT — the folder
-      // dialog is no longer on the common path — and Option is the escape hatch
-      // that asks where: ⌘N launches at the root, ⌥⌘N opens the picker.
-      //
-      // Matched on e.code, not e.key: Option rewrites e.key on macOS (⌥N is a
-      // dead key producing '˜'), so an e.key match would never fire with Option
-      // held. e.code loses the implicit "Shift makes it uppercase" guard the old
-      // lowercase comparisons had, so !e.shiftKey is now explicit.
-      if (e.metaKey && !e.shiftKey && LAUNCH_SHORTCUTS[e.code] !== undefined) {
-        e.preventDefault()
-        void launchSession({
-          setup: LAUNCH_SHORTCUTS[e.code],
-          cwd: e.altKey ? { kind: 'ask' } : { kind: 'workspace-root' },
-          remember: LAUNCH_SHORTCUTS[e.code] !== null
-        })
-      }
-      // Cmd+Shift+A: New Claude Agents session (`claude agents`)
-      if (e.metaKey && e.shiftKey && e.code === 'KeyA') {
-        e.preventDefault()
-        void launchSession({
-          setup: { kind: 'claude-agents', dangerousMode: false },
-          cwd: e.altKey ? { kind: 'ask' } : { kind: 'workspace-root' },
-          remember: true
-        })
-      }
-      // Cmd+W: Close focused file tab
-      if (e.metaKey && e.key === 'w') {
-        const sid = useSessionStore.getState().focusedSessionId
-        if (sid && isFileTabId(sid)) {
-          e.preventDefault()
-          removeFileTab(sid)
-        }
-      }
-      // Cmd+Delete: Close focused session
-      if (e.metaKey && e.key === 'Backspace') {
-        e.preventDefault()
-        const sid = useSessionStore.getState().focusedSessionId
-        if (sid) {
-          if (isFileTabId(sid)) {
-            removeFileTab(sid)
-          } else {
-            const current = useSessionStore.getState()
-            const closing = current.sessions.find((s) => s.id === sid)
-            if (closing) emitTabClosed(closing, current.groups, 'user', null)
-            window.electronAPI.killSession(sid).catch(() => {})
-            removeSession(sid)
-          }
-        }
-      }
-      // Cmd+,: Open settings
-      if (e.metaKey && e.key === ',') {
-        e.preventDefault()
-        useSessionStore.getState().setActiveView('settings')
-      }
-      // Cmd+F: Focus sidebar search (open sidebar if closed)
-      if (e.metaKey && !e.shiftKey && e.key === 'f') {
-        e.preventDefault()
+      },
+      openHelp: () => togglePanel('help'),
+      openSettings: () => useSessionStore.getState().setActiveView('settings'),
+      focusSidebarSearch: () => {
         const state = useSessionStore.getState()
         if (!state.sidebarOpen) state.toggleSidebar()
-        // Small delay to let sidebar mount before focusing
-        setTimeout(() => {
-          const input = document.querySelector<HTMLInputElement>('[data-sidebar-search]')
-          input?.focus()
-        }, 50)
-      }
-      // Cmd+Ctrl+] / Cmd+Ctrl+[: cycle the active workspace
-      if (e.metaKey && e.ctrlKey && (e.key === ']' || e.key === '[')) {
-        e.preventDefault()
-        cycleWorkspace(e.key === ']' ? 1 : -1)
-        return
-      }
-      // Cmd+1-9: Switch to session by index (within the active workspace)
-      if (e.metaKey && !e.shiftKey && !e.ctrlKey && e.key >= '1' && e.key <= '9') {
-        e.preventDefault()
-        const state = useSessionStore.getState()
-        const flatIds = getVisibleFlatOrder(state, useWorkspaceStore.getState().activeWorkspaceId)
-        const idx = parseInt(e.key) - 1
-        if (idx < flatIds.length) {
-          state.selectSession(flatIds[idx], false)
+        setTimeout(
+          () => document.querySelector<HTMLInputElement>('[data-sidebar-search]')?.focus(),
+          50
+        )
+      },
+      closeFocused: () => {
+        const sid = useSessionStore.getState().focusedSessionId
+        if (sid && isFileTabId(sid)) removeFileTab(sid)
+        else window.close()
+      },
+      killFocusedSession: () => {
+        const sid = useSessionStore.getState().focusedSessionId
+        if (!sid) return
+        if (isFileTabId(sid)) removeFileTab(sid)
+        else {
+          const current = useSessionStore.getState()
+          const closing = current.sessions.find((session) => session.id === sid)
+          if (closing) emitTabClosed(closing, current.groups, 'user', null)
+          void window.electronAPI.killSession(sid).catch(() => {})
+          removeSession(sid)
         }
-      }
-      // Cmd+Shift+] / Cmd+Shift+[: Next / previous session (active workspace)
-      if (e.metaKey && e.shiftKey && (e.key === ']' || e.key === '[')) {
-        e.preventDefault()
+      },
+      previousWorkspace: () => cycleWorkspace(-1),
+      nextWorkspace: () => cycleWorkspace(1),
+      previousSession: () => cycleSession(-1),
+      nextSession: () => cycleSession(1),
+      selectSession1: () => selectByIndex(0),
+      selectSession2: () => selectByIndex(1),
+      selectSession3: () => selectByIndex(2),
+      selectSession4: () => selectByIndex(3),
+      selectSession5: () => selectByIndex(4),
+      selectSession6: () => selectByIndex(5),
+      selectSession7: () => selectByIndex(6),
+      selectSession8: () => selectByIndex(7),
+      selectSession9: () => selectByIndex(8),
+      groupSelectedSessions: () => {
         const state = useSessionStore.getState()
-        const flatIds = getVisibleFlatOrder(state, useWorkspaceStore.getState().activeWorkspaceId)
-        if (flatIds.length === 0) return
-        const currentIdx = flatIds.indexOf(state.focusedSessionId ?? '')
-        let nextIdx: number
-        if (e.key === ']') {
-          nextIdx = currentIdx < 0 ? 0 : (currentIdx + 1) % flatIds.length
-        } else {
-          nextIdx =
-            currentIdx < 0 ? flatIds.length - 1 : (currentIdx - 1 + flatIds.length) % flatIds.length
-        }
-        state.selectSession(flatIds[nextIdx], false)
-      }
-    }
-    window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [toggleFilePalette, toggleFileTree, toggleSidebar, removeSession, removeFileTab])
+        if (state.selectedSessionIds.length > 0) state.createGroup(state.selectedSessionIds)
+      },
+      ungroupSelectedSessions: () => {
+        const state = useSessionStore.getState()
+        const group = state.groups.find(
+          (candidate) =>
+            state.selectedSessionIds.length > 0 &&
+            state.selectedSessionIds.every((id) => candidate.sessionIds.includes(id))
+        )
+        if (group) state.ungroupSessions(group.id)
+      },
+      resetSessions: () => {
+        if (useSessionStore.getState().sessions.length > 0) setResetConfirmOpen(true)
+      },
+      undoSidebar: () => {
+        const state = useSessionStore.getState()
+        if (state.sidebarUndoStack.length > 0) state.undoSidebar()
+      },
+      newWindow: () => void window.electronAPI.windowOpen()
+    } satisfies KeymapActionHandlers
+    return actions
+  }, [removeFileTab, removeSession, toggleFilePalette, toggleFileTree, toggleSidebar])
+  const commandHud = useKeymapManager(keymapActions)
 
   // Sync data-theme attribute to root element
   useEffect(() => {
@@ -510,6 +478,7 @@ export function AppShell() {
   // The pull is the point — a push-only updater loses the "an update exists"
   // fact for 30 minutes if the renderer was not listening when it fired.
   useEffect(() => connectUpdaterStore(), [])
+  useEffect(() => connectKeymapStore(), [])
 
   // Open Settings → Updates when asked from the native menu.
   useEffect(() => {
@@ -747,7 +716,7 @@ export function AppShell() {
               <button
                 onClick={toggleFilePalette}
                 className="btn-icon btn-icon-md flex-shrink-0"
-                title="Search files (Cmd+P)"
+                title={`Search files${filePaletteShortcut ? ` (${filePaletteShortcut})` : ''}`}
               >
                 <MagnifyingGlassIcon className="w-4 h-4" />
               </button>
@@ -755,7 +724,7 @@ export function AppShell() {
               <button
                 onClick={toggleFileTree}
                 className={cn('btn-icon btn-icon-md flex-shrink-0', fileTreeOpen && '!text-accent')}
-                title="File tree (Cmd+E)"
+                title={`File tree${sidePanelShortcut ? ` (${sidePanelShortcut})` : ''}`}
               >
                 <Bars3BottomLeftIcon className="w-4 h-4 scale-x-[-1]" />
               </button>
@@ -831,6 +800,17 @@ export function AppShell() {
       <MissionControlOverlay />
       <SessionHistoryDialog />
       <RestorePromptDialog />
+      <KeymapCommandHud hud={commandHud} />
+      <ConfirmDialog
+        isOpen={resetConfirmOpen}
+        title="Reset sessions"
+        message="Close all sessions and start fresh?"
+        onConfirm={() => {
+          setResetConfirmOpen(false)
+          void resetSessions()
+        }}
+        onCancel={() => setResetConfirmOpen(false)}
+      />
     </div>
   )
 }

--- a/src/renderer/src/components/layout/SessionLauncher.tsx
+++ b/src/renderer/src/components/layout/SessionLauncher.tsx
@@ -31,6 +31,7 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuSubContent
 } from '../ui/dropdown-menu'
+import { useShortcutLabel } from '../../store/keymap-store'
 
 /** What the caret's remote entries hand back to the sidebar, which owns the
  *  remote directory picker (remote launches never touch the local cwd rules). */
@@ -116,6 +117,12 @@ export function SessionLauncher({ onRemoteLaunch }: SessionLauncherProps): React
   const byWorkspace = useLaunchPrefsStore((s) => s.byWorkspace)
   void byWorkspace
   const setup = getLastAgentSetup(activeWorkspaceId)
+  const terminalShortcut = useShortcutLabel('newTerminal')
+  const claudeShortcut = useShortcutLabel('newClaude')
+  const dangerousShortcut = useShortcutLabel('newDangerousClaude')
+  const agentsShortcut = useShortcutLabel('newClaudeAgents')
+  const antigravityShortcut = useShortcutLabel('newAntigravity')
+  const codexShortcut = useShortcutLabel('newCodex')
 
   const connectedRemoteLocations = locations.filter(
     (l) => l.type === 'remote' && l.status === 'connected'
@@ -209,7 +216,7 @@ export function SessionLauncher({ onRemoteLaunch }: SessionLauncherProps): React
           <button
             disabled={busy}
             className="launcher-btn"
-            title={'New terminal — workspace root (⌥ to choose a folder)'}
+            title={`New terminal — workspace root${terminalShortcut ? ` (${terminalShortcut})` : ''}; ⌥ to choose a folder`}
             onClick={(e) => void run({ setup: null, cwd: cwdFor(e) })}
           >
             <CommandLineIcon className="w-3.5 h-3.5 flex-shrink-0 text-text-tertiary" />
@@ -259,9 +266,19 @@ export function SessionLauncher({ onRemoteLaunch }: SessionLauncherProps): React
               >
                 {hasRemoteLocations && <DropdownMenuLabel>This Mac</DropdownMenuLabel>}
 
-                {renderClaudeEntry('claude', 'Claude Code', '⌘N', false)}
-                {renderClaudeEntry('claude', 'Claude Code (skip permissions)', '⌘D', true)}
-                {renderClaudeEntry('claude-agents', 'Claude Agents', '⌘⇧A', false)}
+                {renderClaudeEntry('claude', 'Claude Code', claudeShortcut ?? undefined, false)}
+                {renderClaudeEntry(
+                  'claude',
+                  'Claude Code (skip permissions)',
+                  dangerousShortcut ?? undefined,
+                  true
+                )}
+                {renderClaudeEntry(
+                  'claude-agents',
+                  'Claude Agents',
+                  agentsShortcut ?? undefined,
+                  false
+                )}
                 <DropdownMenuItem
                   onSelect={() =>
                     launchAgent(
@@ -272,7 +289,9 @@ export function SessionLauncher({ onRemoteLaunch }: SessionLauncherProps): React
                 >
                   <AntigravityLogo className="w-3.5 h-3.5 flex-shrink-0 text-text-tertiary" />
                   <span className="flex-1">Antigravity CLI</span>
-                  <DropdownMenuShortcut>{'⌘I'}</DropdownMenuShortcut>
+                  {antigravityShortcut && (
+                    <DropdownMenuShortcut>{antigravityShortcut}</DropdownMenuShortcut>
+                  )}
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onSelect={() =>
@@ -281,7 +300,7 @@ export function SessionLauncher({ onRemoteLaunch }: SessionLauncherProps): React
                 >
                   <CodexLogo className="w-3.5 h-3.5 flex-shrink-0 text-text-tertiary" />
                   <span className="flex-1">Codex CLI</span>
-                  <DropdownMenuShortcut>{'⌘U'}</DropdownMenuShortcut>
+                  {codexShortcut && <DropdownMenuShortcut>{codexShortcut}</DropdownMenuShortcut>}
                 </DropdownMenuItem>
 
                 {connectedRemoteLocations.map((loc) => (

--- a/src/renderer/src/components/layout/Sidebar.tsx
+++ b/src/renderer/src/components/layout/Sidebar.tsx
@@ -38,6 +38,7 @@ import { useFullScreen } from '../../hooks/use-fullscreen'
 import { SidebarFooter, UpdateBanner } from './SidebarFooter'
 import { Wordmark, WordmarkBy } from './Wordmark'
 import { ScrollArea } from '../ui/scroll-area'
+import { shortcutLabel } from '../../store/keymap-store'
 import {
   PencilSquareIcon,
   TrashIcon,
@@ -159,7 +160,6 @@ export function Sidebar() {
   const displayOrder = useSessionStore((s) => s.displayOrder)
   const createGroup = useSessionStore((s) => s.createGroup)
   const ungroupSessions = useSessionStore((s) => s.ungroupSessions)
-  const undoSidebar = useSessionStore((s) => s.undoSidebar)
   const deleteGroup = useSessionStore((s) => s.deleteGroup)
   const setGroupColor = useSessionStore((s) => s.setGroupColor)
   const toggleGroupCollapsed = useSessionStore((s) => s.toggleGroupCollapsed)
@@ -176,7 +176,6 @@ export function Sidebar() {
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null)
   const [renamingId, setRenamingId] = useState<string | null>(null)
   const [deleteConfirmSessionId, setDeleteConfirmSessionId] = useState<string | null>(null)
-  const [resetConfirmOpen, setResetConfirmOpen] = useState(false)
   const [terminalDialogState, setTerminalDialogState] = useState<{
     groupId: string
     terminalId: string | null // null = adding new
@@ -236,13 +235,6 @@ export function Sidebar() {
     }
   }, [addSession])
 
-  const resetSessions = useSessionStore((s) => s.resetSessions)
-
-  const handleResetSessions = useCallback(async () => {
-    setResetConfirmOpen(false)
-    await resetSessions()
-  }, [resetSessions])
-
   // Selection anchor for Cmd+Shift range select (Finder behavior)
   const selectionAnchorRef = useRef<string | null>(null)
 
@@ -276,55 +268,6 @@ export function Sidebar() {
     const isGroup = groups.some((g) => g.id === draggedIds[0])
     return isGroup ? draggedIds[0] : null
   }, [isDragging, draggedIds, groups])
-
-  // Cmd+G to group, Cmd+Alt+G to ungroup, Cmd+Shift+Delete to reset
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.metaKey && !e.shiftKey && !e.altKey && e.key.toLowerCase() === 'g') {
-        // Cmd+G: group selected sessions
-        e.preventDefault()
-        const state = useSessionStore.getState()
-        if (state.selectedSessionIds.length >= 1) {
-          createGroup(state.selectedSessionIds)
-        }
-      }
-      if (e.metaKey && e.altKey && e.key.toLowerCase() === 'g') {
-        // Cmd+Alt+G: ungroup
-        e.preventDefault()
-        const state = useSessionStore.getState()
-        const containingGroup = state.groups.find(
-          (g) =>
-            state.selectedSessionIds.length > 0 &&
-            state.selectedSessionIds.every((sid) => g.sessionIds.includes(sid))
-        )
-        if (containingGroup) {
-          ungroupSessions(containingGroup.id)
-        }
-      }
-      // Cmd+Shift+Delete: reset all sessions
-      if (e.metaKey && e.shiftKey && e.key === 'Backspace') {
-        e.preventDefault()
-        if (useSessionStore.getState().sessions.length > 0) {
-          setResetConfirmOpen(true)
-        }
-      }
-      // Cmd+Z: undo last sidebar group/move/rename action
-      if (e.metaKey && !e.shiftKey && !e.altKey && e.key.toLowerCase() === 'z') {
-        const target = e.target as HTMLElement | null
-        const tag = target?.tagName
-        const editable =
-          tag === 'INPUT' ||
-          tag === 'TEXTAREA' ||
-          (target instanceof HTMLElement && target.isContentEditable)
-        if (editable) return
-        if (useSessionStore.getState().sidebarUndoStack.length === 0) return
-        e.preventDefault()
-        undoSidebar()
-      }
-    }
-    window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [createGroup, ungroupSessions, undoSidebar])
 
   // Load Claude account profiles. (Workspace boot + .clave file watchers moved
   // to AppShell's sequential boot effect — adoption needs the registry first.)
@@ -1115,7 +1058,7 @@ export function Sidebar() {
         items.push({
           label: 'Group',
           icon: <Squares2X2Icon className="w-3.5 h-3.5" />,
-          shortcut: '\u2318G',
+          shortcut: shortcutLabel('groupSelectedSessions') ?? undefined,
           onClick: () => createGroup(state.selectedSessionIds)
         })
       }
@@ -1185,7 +1128,7 @@ export function Sidebar() {
           {
             label: 'History',
             icon: <ClockIcon className="w-3.5 h-3.5" />,
-            shortcut: '\u2318\u21e7H',
+            shortcut: shortcutLabel('openHistory') ?? undefined,
             onClick: () => useHistoryStore.getState().openHistory(groupId)
           },
           group?.view
@@ -1868,15 +1811,6 @@ export function Sidebar() {
         onCancel={() => setDeleteConfirmSessionId(null)}
       />
 
-      {/* Reset sessions confirmation */}
-      <ConfirmDialog
-        isOpen={resetConfirmOpen}
-        title="Reset sessions"
-        message="Close all sessions and start fresh?"
-        onConfirm={handleResetSessions}
-        onCancel={() => setResetConfirmOpen(false)}
-      />
-
       {/* Group terminal configuration dialog */}
       <GroupCommandDialog
         isOpen={terminalDialogState !== null}
@@ -2056,3 +1990,4 @@ function PinnedSection({
     </>
   )
 }
+

--- a/src/renderer/src/components/layout/SidebarFooter.tsx
+++ b/src/renderer/src/components/layout/SidebarFooter.tsx
@@ -17,6 +17,7 @@ import { formatDuration } from '../work-tracker/utils'
 import { UserIconDisplay } from '../ui/UserIconDisplay'
 import { BrandField } from '../ui/BrandField'
 import { cn } from '../../lib/utils'
+import { useShortcutLabel } from '../../store/keymap-store'
 
 export function UpdateBanner(): React.ReactElement {
   const phase = useUpdaterStore((s) => s.phase)
@@ -182,6 +183,8 @@ export function SidebarFooter(): React.ReactElement {
   const avatarField = useUserStore((s) => s.avatarField)
   const avatarSeed = useUserStore((s) => s.avatarSeed)
   const openSettings = useSessionStore((s) => s.openSettings)
+  const settingsShortcut = useShortcutLabel('openSettings')
+  const settingsTitle = `Settings${settingsShortcut ? ` (${settingsShortcut})` : ''}`
 
   const phase = useUpdaterStore((s) => s.phase)
   const version = useUpdaterStore((s) => s.availableVersion)
@@ -235,7 +238,7 @@ export function SidebarFooter(): React.ReactElement {
         <button
           onClick={() => openSettings()}
           className="relative flex-shrink-0"
-          title="Settings (⌘,)"
+          title={settingsTitle}
         >
           <UserIconDisplay icon={avatarIcon} field={avatarField} seed={avatarSeed} size="xs" />
           {/* Update dot indicator when dismissed */}
@@ -255,7 +258,7 @@ export function SidebarFooter(): React.ReactElement {
         <button
           onClick={() => openSettings()}
           className="sidebar-footer-name"
-          title="Settings (⌘,)"
+          title={settingsTitle}
         >
           {name}
         </button>
@@ -263,7 +266,7 @@ export function SidebarFooter(): React.ReactElement {
         <button
           onClick={() => openSettings()}
           className="sidebar-footer-btn"
-          title="Settings (⌘,)"
+          title={settingsTitle}
           aria-label="Settings"
         >
           <Cog6ToothIcon className="w-4 h-4" />

--- a/src/renderer/src/components/settings/KeymapSettings.tsx
+++ b/src/renderer/src/components/settings/KeymapSettings.tsx
@@ -1,0 +1,463 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  ArrowDownTrayIcon,
+  ArrowPathIcon,
+  CodeBracketIcon,
+  MagnifyingGlassIcon,
+  PlusIcon,
+  TrashIcon
+} from '@heroicons/react/24/outline'
+import {
+  KEYMAP_ACTIONS,
+  KEYMAP_SEQUENCE_TIMEOUT_MS,
+  MAX_BINDINGS_PER_ACTION,
+  canonicalizeBinding,
+  formatKeyBinding,
+  keyEventToChord,
+  overridesFromResolved,
+  parseKeymapOverrides,
+  resolveKeymapConfig,
+  type KeymapActionId,
+  type ResolvedKeymapConfig
+} from '../../../../shared/keymaps'
+import { saveKeymapOverrides, useKeymapStore } from '../../store/keymap-store'
+import { SettingsCard, SettingsSection } from './primitives'
+
+type EditorMode = 'actions' | 'json'
+
+interface RecordingTarget {
+  actionId?: KeymapActionId
+  index?: number
+  master?: true
+  steps: string[]
+}
+
+function cloneConfig(config: ResolvedKeymapConfig): ResolvedKeymapConfig {
+  return {
+    ...config,
+    bindings: Object.fromEntries(
+      Object.entries(config.bindings).map(([actionId, bindings]) => [actionId, [...bindings]])
+    ) as ResolvedKeymapConfig['bindings']
+  }
+}
+
+function jsonFor(config: ResolvedKeymapConfig): string {
+  return `${JSON.stringify(overridesFromResolved(config), null, 2)}\n`
+}
+
+export function KeymapSettings(): React.JSX.Element {
+  const loadError = useKeymapStore((state) => state.error)
+  const [draft, setDraft] = useState(() => cloneConfig(useKeymapStore.getState().config))
+  const [rawJson, setRawJson] = useState(() => jsonFor(useKeymapStore.getState().config))
+  const [mode, setMode] = useState<EditorMode>('actions')
+  const [query, setQuery] = useState('')
+  const [dirty, setDirty] = useState(false)
+  const [errors, setErrors] = useState<string[]>([])
+  const [notice, setNotice] = useState<string | null>(null)
+  const [recording, setRecording] = useState<RecordingTarget | null>(null)
+  const recordingTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return useKeymapStore.subscribe((state, previous) => {
+      if (dirty || state.config === previous.config) return
+      setDraft(cloneConfig(state.config))
+      setRawJson(jsonFor(state.config))
+    })
+  }, [dirty])
+
+  useEffect(
+    () => () => {
+      if (recordingTimer.current) clearTimeout(recordingTimer.current)
+    },
+    []
+  )
+
+  const filteredActions = useMemo(() => {
+    const needle = query.trim().toLowerCase()
+    return needle
+      ? KEYMAP_ACTIONS.filter(
+          (action) =>
+            action.label.toLowerCase().includes(needle) ||
+            action.category.toLowerCase().includes(needle)
+        )
+      : KEYMAP_ACTIONS
+  }, [query])
+
+  const updateDraft = (next: ResolvedKeymapConfig): void => {
+    setDraft(next)
+    setDirty(true)
+    setErrors([])
+    setNotice(null)
+  }
+
+  const clearRecordingTimer = (): void => {
+    if (recordingTimer.current) clearTimeout(recordingTimer.current)
+    recordingTimer.current = null
+  }
+
+  const finishRecording = (target: RecordingTarget): void => {
+    clearRecordingTimer()
+    if (target.master) {
+      const chord = target.steps[0]
+      if (chord) updateDraft({ ...draft, masterKey: chord })
+      setRecording(null)
+      return
+    }
+    if (!target.actionId || target.index === undefined || target.steps.length === 0) {
+      setRecording(null)
+      return
+    }
+    const binding =
+      target.steps[0] === draft.masterKey
+        ? ['Master', ...target.steps.slice(1)].join(' ')
+        : target.steps.join(' ')
+    try {
+      const canonical = canonicalizeBinding(binding)
+      const next = cloneConfig(draft)
+      next.bindings[target.actionId][target.index] = canonical
+      updateDraft(next)
+    } catch (error) {
+      setErrors([error instanceof Error ? error.message : 'Invalid binding'])
+    }
+    setRecording(null)
+  }
+
+  const recordKey = (event: React.KeyboardEvent, target: RecordingTarget): void => {
+    event.preventDefault()
+    event.stopPropagation()
+    if (event.key === 'Escape') {
+      setRecording(null)
+      clearRecordingTimer()
+      return
+    }
+    const chord = keyEventToChord(event.nativeEvent)
+    if (!chord) return
+    if (target.master) {
+      finishRecording({ ...target, steps: [chord] })
+      return
+    }
+
+    const steps = [...target.steps, chord]
+    const next = { ...target, steps }
+    setRecording(next)
+    if (recordingTimer.current) clearTimeout(recordingTimer.current)
+    if (steps.length === 1 && chord !== draft.masterKey) {
+      finishRecording(next)
+      return
+    }
+    recordingTimer.current = setTimeout(() => finishRecording(next), KEYMAP_SEQUENCE_TIMEOUT_MS)
+  }
+
+  const startBinding = (actionId: KeymapActionId, index: number): void => {
+    clearRecordingTimer()
+    setRecording({ actionId, index, steps: [] })
+    setTimeout(() => {
+      document.querySelector<HTMLElement>(`[data-recording="${actionId}-${index}"]`)?.focus()
+    }, 0)
+  }
+
+  const removeBinding = (actionId: KeymapActionId, index: number): void => {
+    const next = cloneConfig(draft)
+    next.bindings[actionId].splice(index, 1)
+    updateDraft(next)
+  }
+
+  const resetAction = (actionId: KeymapActionId): void => {
+    const defaults = resolveKeymapConfig()
+    const next = cloneConfig(draft)
+    next.bindings[actionId] = [...defaults.bindings[actionId]]
+    updateDraft(next)
+  }
+
+  const parseRawDraft = (): ResolvedKeymapConfig | null => {
+    try {
+      const raw = JSON.parse(rawJson) as unknown
+      const parsed = parseKeymapOverrides(raw)
+      if (!parsed.ok) {
+        setErrors(parsed.errors.map((error) => `${error.path}: ${error.message}`))
+        return null
+      }
+      return resolveKeymapConfig(parsed.value)
+    } catch (error) {
+      setErrors([error instanceof Error ? error.message : 'Invalid JSON'])
+      return null
+    }
+  }
+
+  const switchMode = (nextMode: EditorMode): void => {
+    if (nextMode === mode) return
+    clearRecordingTimer()
+    setRecording(null)
+    if (nextMode === 'json') {
+      setRawJson(jsonFor(draft))
+      setMode('json')
+      setErrors([])
+      return
+    }
+    const parsed = parseRawDraft()
+    if (!parsed) return
+    setDraft(parsed)
+    setMode('actions')
+    setErrors([])
+  }
+
+  const save = async (): Promise<void> => {
+    const next = mode === 'json' ? parseRawDraft() : draft
+    if (!next) return
+    const result = await saveKeymapOverrides(overridesFromResolved(next))
+    if (!result.ok) {
+      setErrors(result.errors.map((error) => `${error.path}: ${error.message}`))
+      return
+    }
+    const accepted = resolveKeymapConfig(result.value)
+    setDraft(cloneConfig(accepted))
+    setRawJson(jsonFor(accepted))
+    setDirty(false)
+    setErrors([])
+    setNotice('Keymaps saved and active in every window.')
+  }
+
+  const importJson = async (): Promise<void> => {
+    try {
+      const imported = await window.electronAPI.keymapsImport()
+      if (imported === null) return
+      setRawJson(imported)
+      setMode('json')
+      setDirty(true)
+      setErrors([])
+      setNotice('Imported as a draft. Review it, then press Save.')
+    } catch (error) {
+      setErrors([error instanceof Error ? error.message : 'Import failed'])
+    }
+  }
+
+  const exportJson = async (): Promise<void> => {
+    const next = mode === 'json' ? parseRawDraft() : draft
+    if (!next) return
+    try {
+      const wrote = await window.electronAPI.keymapsExport(jsonFor(next))
+      if (wrote) setNotice('Keymaps exported.')
+    } catch (error) {
+      setErrors([error instanceof Error ? error.message : 'Export failed'])
+    }
+  }
+
+  return (
+    <>
+      <div className="flex items-center justify-between gap-3 mb-6">
+        <div>
+          <h2 className="text-lg font-semibold text-text-primary">Keymaps</h2>
+          <p className="text-xs text-text-tertiary mt-1">
+            Changes stay in this draft until Save. Each action accepts at most two bindings.
+          </p>
+        </div>
+        <div className="flex items-center gap-1">
+          <button onClick={() => void importJson()} className="btn-secondary btn-compact">
+            <ArrowDownTrayIcon className="w-3.5 h-3.5" /> Import
+          </button>
+          <button onClick={() => void exportJson()} className="btn-secondary btn-compact">
+            <ArrowDownTrayIcon className="w-3.5 h-3.5 rotate-180" /> Export
+          </button>
+        </div>
+      </div>
+
+      <div className="space-y-7">
+        <SettingsSection
+          title="Command mode"
+          description={`Press the master key, then a command sequence. Each next key has ${KEYMAP_SEQUENCE_TIMEOUT_MS}ms to match.`}
+        >
+          <SettingsCard>
+            <div className="settings-row">
+              <div>
+                <p className="settings-row-title">Master key</p>
+                <p className="settings-row-description">
+                  Unset it to disable command mode without changing direct shortcuts.
+                </p>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <button
+                  data-keymap-recorder
+                  data-recording="master"
+                  onClick={() => {
+                    clearRecordingTimer()
+                    setRecording({ master: true, steps: [] })
+                  }}
+                  onKeyDown={(event) => recording?.master && recordKey(event, recording)}
+                  className="keymap-binding"
+                >
+                  {recording?.master
+                    ? 'Press a chord…'
+                    : draft.masterKey
+                      ? formatKeyBinding(draft.masterKey, draft.masterKey)
+                      : 'Disabled'}
+                </button>
+                {draft.masterKey && (
+                  <button
+                    onClick={() => updateDraft({ ...draft, masterKey: null })}
+                    className="btn-icon btn-icon-xs"
+                    title="Disable command mode"
+                    aria-label="Disable command mode"
+                  >
+                    <TrashIcon className="w-3.5 h-3.5" />
+                  </button>
+                )}
+              </div>
+            </div>
+          </SettingsCard>
+        </SettingsSection>
+
+        <SettingsSection title="Bindings">
+          <div className="flex items-center gap-2 mb-2.5">
+            <div className="search-field flex-1">
+              <MagnifyingGlassIcon className="w-3.5 h-3.5" />
+              <input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search actions"
+                aria-label="Search keymap actions"
+              />
+            </div>
+            <div className="launcher-panel">
+              <div className="launcher-row">
+                <button
+                  onClick={() => switchMode('actions')}
+                  className="panel-tab"
+                  data-selected={mode === 'actions' ? 'true' : undefined}
+                >
+                  Actions
+                </button>
+                <span className="panel-sep" />
+                <button
+                  onClick={() => switchMode('json')}
+                  className="panel-tab"
+                  data-selected={mode === 'json' ? 'true' : undefined}
+                >
+                  <CodeBracketIcon className="w-3.5 h-3.5" /> JSON
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {mode === 'actions' ? (
+            <SettingsCard>
+              {filteredActions.map((action) => {
+                const bindings = draft.bindings[action.id]
+                const adding =
+                  recording?.actionId === action.id && recording.index === bindings.length
+                return (
+                  <div className="settings-row keymap-row" key={action.id}>
+                    <div className="min-w-0">
+                      <p className="settings-row-title">{action.label}</p>
+                      <p className="settings-row-description">{action.category}</p>
+                    </div>
+                    <div className="keymap-bindings">
+                      {bindings.map((binding, index) => {
+                        const active =
+                          recording?.actionId === action.id && recording.index === index
+                        return (
+                          <div className="flex items-center gap-0.5" key={`${action.id}-${index}`}>
+                            <button
+                              data-keymap-recorder
+                              data-recording={`${action.id}-${index}`}
+                              onClick={() => startBinding(action.id, index)}
+                              onKeyDown={(event) =>
+                                active && recording && recordKey(event, recording)
+                              }
+                              className="keymap-binding"
+                            >
+                              {active
+                                ? recording.steps.length > 0
+                                  ? formatKeyBinding(recording.steps.join(' '), draft.masterKey)
+                                  : 'Press keys…'
+                                : formatKeyBinding(binding, draft.masterKey)}
+                            </button>
+                            <button
+                              onClick={() => removeBinding(action.id, index)}
+                              className="btn-icon btn-icon-xs"
+                              title="Remove binding"
+                              aria-label={`Remove binding for ${action.label}`}
+                            >
+                              <TrashIcon className="w-3 h-3" />
+                            </button>
+                          </div>
+                        )
+                      })}
+                      {adding && recording && (
+                        <button
+                          data-keymap-recorder
+                          data-recording={`${action.id}-${bindings.length}`}
+                          onKeyDown={(event) => recordKey(event, recording)}
+                          className="keymap-binding"
+                        >
+                          {recording.steps.length > 0
+                            ? formatKeyBinding(recording.steps.join(' '), draft.masterKey)
+                            : 'Press keys…'}
+                        </button>
+                      )}
+                      {bindings.length < MAX_BINDINGS_PER_ACTION && !adding && (
+                        <button
+                          onClick={() => startBinding(action.id, bindings.length)}
+                          className="btn-icon btn-icon-xs"
+                          title="Add binding"
+                          aria-label={`Add binding for ${action.label}`}
+                        >
+                          <PlusIcon className="w-3.5 h-3.5" />
+                        </button>
+                      )}
+                      <button
+                        onClick={() => resetAction(action.id)}
+                        className="btn-icon btn-icon-xs"
+                        title="Reset action"
+                        aria-label={`Reset ${action.label}`}
+                      >
+                        <ArrowPathIcon className="w-3.5 h-3.5" />
+                      </button>
+                    </div>
+                  </div>
+                )
+              })}
+            </SettingsCard>
+          ) : (
+            <textarea
+              data-keymap-recorder
+              value={rawJson}
+              onChange={(event) => {
+                setRawJson(event.target.value)
+                setDirty(true)
+                setErrors([])
+              }}
+              spellCheck={false}
+              className="textarea-field keymap-json"
+              aria-label="Raw keymap JSON"
+            />
+          )}
+        </SettingsSection>
+
+        {(loadError || errors.length > 0) && (
+          <div className="keymap-message" data-tone="error">
+            {(errors.length > 0 ? errors : [loadError]).map((error) => (
+              <p key={error}>{error}</p>
+            ))}
+          </div>
+        )}
+        {notice && <div className="keymap-message">{notice}</div>}
+
+        <div className="flex items-center justify-between gap-3">
+          <button
+            onClick={() => {
+              const defaults = resolveKeymapConfig()
+              updateDraft(defaults)
+              setRawJson(jsonFor(defaults))
+            }}
+            className="btn-secondary"
+          >
+            <ArrowPathIcon className="w-3.5 h-3.5" /> Reset all
+          </button>
+          <button onClick={() => void save()} className="btn-primary" disabled={!dirty}>
+            Save keymaps
+          </button>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/renderer/src/components/settings/SettingsPanel.tsx
+++ b/src/renderer/src/components/settings/SettingsPanel.tsx
@@ -22,6 +22,7 @@ import { UpdatesTab } from './UpdatesTab'
 import { UsagePanel } from '../usage/UsagePanel'
 import { SettingsSection, SettingsCard, SettingsRow, ToggleRow } from './primitives'
 import { cn } from '../../lib/utils'
+import { KeymapSettings } from './KeymapSettings'
 
 const themes: { id: Theme; label: string; colors: { bg: string; surface: string; text: string; border: string } }[] = [
   {
@@ -198,9 +199,10 @@ export function SettingsPanel() {
 
   return (
     <div className="flex-1 overflow-y-auto p-8">
-      <div className="max-w-xl mx-auto w-full">
+      <div className={cn(settingsSection === 'keymaps' ? 'max-w-3xl' : 'max-w-xl', 'mx-auto w-full')}>
         {settingsSection === 'general' && <GeneralSettings />}
         {settingsSection === 'appearance' && <AppearanceSettings />}
+        {settingsSection === 'keymaps' && <KeymapSettings />}
         {settingsSection === 'updates' && <UpdatesTab />}
         {settingsSection === 'usage' && <UsageSettings />}
       </div>
@@ -984,3 +986,4 @@ function WorkspacesSection() {
     </SettingsSection>
   )
 }
+

--- a/src/renderer/src/components/settings/SettingsSidebar.tsx
+++ b/src/renderer/src/components/settings/SettingsSidebar.tsx
@@ -3,7 +3,8 @@ import {
   AdjustmentsHorizontalIcon,
   SwatchIcon,
   ArrowDownTrayIcon,
-  ChartBarIcon
+  ChartBarIcon,
+  CommandLineIcon
 } from '@heroicons/react/24/outline'
 import { useUpdaterStore } from '../../store/updater-store'
 import { useSessionStore, type SettingsSection } from '../../store/session-store'
@@ -11,6 +12,7 @@ import { useSessionStore, type SettingsSection } from '../../store/session-store
 const SECTIONS: { id: SettingsSection; label: string; icon: React.ComponentType<React.SVGProps<SVGSVGElement>> }[] = [
   { id: 'general', label: 'General', icon: AdjustmentsHorizontalIcon },
   { id: 'appearance', label: 'Appearance', icon: SwatchIcon },
+  { id: 'keymaps', label: 'Keymaps', icon: CommandLineIcon },
   { id: 'updates', label: 'Software Update', icon: ArrowDownTrayIcon },
   { id: 'usage', label: 'Usage', icon: ChartBarIcon }
 ]
@@ -65,3 +67,4 @@ export function SettingsSidebar() {
     </div>
   )
 }
+

--- a/src/renderer/src/components/ui/KeymapCommandHud.tsx
+++ b/src/renderer/src/components/ui/KeymapCommandHud.tsx
@@ -1,0 +1,10 @@
+import type { CommandHud } from '../../hooks/use-keymap-manager'
+
+export function KeymapCommandHud({ hud }: { hud: CommandHud | null }): React.JSX.Element | null {
+  if (!hud) return null
+  return (
+    <div className="keymap-command-hud menu-surface menu-pop-mount" data-state={hud.state}>
+      {hud.text}
+    </div>
+  )
+}

--- a/src/renderer/src/help/shortcuts.md
+++ b/src/renderer/src/help/shortcuts.md
@@ -1,15 +1,31 @@
 # Keyboard Shortcuts
 
+These are Clave's defaults. Open **Settings → Keymaps** to see or change the active bindings. Changes take effect in every open window when you press Save.
+
+## Command mode
+
+`Ctrl+B` enters command mode. The next key must arrive within 300ms. A matched command runs; an unmatched or late key is consumed and exits command mode.
+
+| Shortcut | Action |
+|---|---|
+| Ctrl+B C | New Claude Code session |
+
+Unset the master key in Settings to disable command mode. Direct shortcuts keep working.
+
 ## Sessions
 
 | Shortcut | Action |
 |---|---|
 | Cmd+N | New Claude Code session |
 | Cmd+T | New terminal session |
-| Cmd+D | New dangerous mode session |
+| Cmd+D | New Claude session without permission prompts |
+| Cmd+Shift+A | New Claude Agents session |
 | Cmd+I | New Antigravity CLI session |
+| Cmd+U | New Codex CLI session |
+| Cmd+Option plus a launch shortcut | Choose the new session's folder |
 | Cmd+Backspace | Kill focused session |
-| Cmd+1-9 | Switch to session by index |
+| Cmd+W | Close focused file tab, or the window when no file tab is focused |
+| Cmd+1–9 | Switch to session by index |
 | Cmd+Shift+] | Next session |
 | Cmd+Shift+[ | Previous session |
 
@@ -19,13 +35,23 @@
 |---|---|
 | Cmd+B | Toggle left sidebar |
 | Cmd+E | Toggle right sidebar |
-| Cmd+P | File palette (quick search) |
+| Cmd+P | File palette |
+| Cmd+F | Focus sidebar search |
 | Cmd+, | Open settings |
-| Cmd+Shift+G | Open git panel |
+| Cmd+Shift+G | Open Git panel |
+| Cmd+Shift+H | Open session history |
 | Cmd+? | Open help panel |
+| Cmd+Ctrl+] | Next workspace |
+| Cmd+Ctrl+[ | Previous workspace |
 
-## Files
+## Sidebar and application
 
 | Shortcut | Action |
 |---|---|
-| Cmd+W | Close focused file tab |
+| Cmd+G | Group selected sessions |
+| Cmd+Option+G | Ungroup selected sessions |
+| Cmd+Shift+Backspace | Reset all sessions after confirmation |
+| Cmd+Z | Undo the last sidebar change |
+| Cmd+Shift+N | New window |
+
+Code editor, terminal editing, and standard macOS shortcuts are not managed by Clave's keymap editor.

--- a/src/renderer/src/hooks/use-keymap-manager.tsx
+++ b/src/renderer/src/hooks/use-keymap-manager.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useRef, useState } from 'react'
+import {
+  KEYMAP_ACTIONS,
+  KEYMAP_SEQUENCE_TIMEOUT_MS,
+  KeymapMatcher,
+  formatKeyBinding,
+  keyEventToChord,
+  type KeymapActionId
+} from '../../../shared/keymaps'
+import { useKeymapStore } from '../store/keymap-store'
+
+export type KeymapActionHandlers = Record<KeymapActionId, (event: KeyboardEvent) => void>
+
+export interface CommandHud {
+  text: string
+  state: 'pending' | 'matched' | 'cancelled'
+}
+
+const ACTIONS_BY_ID = new Map(KEYMAP_ACTIONS.map((action) => [action.id, action]))
+
+function editableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  if (target.closest('.xterm')) return false
+  return (
+    target.tagName === 'INPUT' ||
+    target.tagName === 'TEXTAREA' ||
+    target.tagName === 'SELECT' ||
+    target.isContentEditable
+  )
+}
+
+function localKeyContext(target: EventTarget | null): boolean {
+  if (document.querySelector('[role="dialog"], .modal-card, .menu-surface--sheet')) return true
+  return (
+    target instanceof HTMLElement && !!target.closest('[data-keymap-recorder], [data-keymap-local]')
+  )
+}
+
+export function useKeymapManager(actions: KeymapActionHandlers): CommandHud | null {
+  const config = useKeymapStore((state) => state.config)
+  const matcherRef = useRef(new KeymapMatcher(config))
+  const commandActiveRef = useRef(false)
+  const deadlineTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [hud, setHud] = useState<CommandHud | null>(null)
+
+  useEffect(() => {
+    matcherRef.current.setConfig(config)
+    commandActiveRef.current = false
+    if (deadlineTimerRef.current) clearTimeout(deadlineTimerRef.current)
+    const clearHud = setTimeout(() => setHud(null), 0)
+    return () => clearTimeout(clearHud)
+  }, [config])
+
+  useEffect(() => {
+    const clearHideTimer = (): void => {
+      if (hideTimerRef.current) clearTimeout(hideTimerRef.current)
+      hideTimerRef.current = null
+    }
+    const showTemporary = (next: CommandHud): void => {
+      clearHideTimer()
+      setHud(next)
+      hideTimerRef.current = setTimeout(() => setHud(null), 700)
+    }
+    const run = (actionId: KeymapActionId, event: KeyboardEvent | null): void => {
+      const action = ACTIONS_BY_ID.get(actionId)
+      if (action?.scope === 'app' && editableTarget(event?.target ?? null)) return
+      if (event) actions[actionId](event)
+      else actions[actionId](new KeyboardEvent('keydown'))
+    }
+    const scheduleExpiry = (event: KeyboardEvent): void => {
+      if (deadlineTimerRef.current) clearTimeout(deadlineTimerRef.current)
+      deadlineTimerRef.current = setTimeout(() => {
+        const result = matcherRef.current.expire(Date.now())
+        commandActiveRef.current = false
+        if (result.kind === 'matched') {
+          run(result.actionId, event)
+          showTemporary({
+            text: ACTIONS_BY_ID.get(result.actionId)?.label ?? result.actionId,
+            state: 'matched'
+          })
+        } else if (result.kind === 'cancelled') {
+          showTemporary({
+            text: `No command for ${formatKeyBinding(result.sequence, config.masterKey)}`,
+            state: 'cancelled'
+          })
+        }
+      }, KEYMAP_SEQUENCE_TIMEOUT_MS)
+    }
+
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.repeat || event.isComposing || localKeyContext(event.target)) return
+      const chord = keyEventToChord(event)
+      if (!chord) return
+
+      if (!commandActiveRef.current && config.masterKey === chord && editableTarget(event.target))
+        return
+      if (commandActiveRef.current && editableTarget(event.target)) {
+        matcherRef.current.reset()
+        commandActiveRef.current = false
+        setHud(null)
+        return
+      }
+
+      const wasCommand = commandActiveRef.current
+      const result = matcherRef.current.handleChord(chord, Date.now())
+      if (result.kind === 'none') return
+
+      if (result.kind === 'matched') {
+        const definition = ACTIONS_BY_ID.get(result.actionId)
+        if (definition?.scope === 'app' && editableTarget(event.target)) return
+      }
+
+      event.preventDefault()
+      event.stopPropagation()
+
+      if (result.kind === 'pending') {
+        commandActiveRef.current = true
+        clearHideTimer()
+        setHud({ text: formatKeyBinding(result.sequence, config.masterKey), state: 'pending' })
+        scheduleExpiry(event)
+        return
+      }
+
+      if (deadlineTimerRef.current) clearTimeout(deadlineTimerRef.current)
+      commandActiveRef.current = false
+      if (result.kind === 'matched') {
+        run(result.actionId, event)
+        if (wasCommand) {
+          showTemporary({
+            text: ACTIONS_BY_ID.get(result.actionId)?.label ?? result.actionId,
+            state: 'matched'
+          })
+        } else {
+          setHud(null)
+        }
+      } else {
+        showTemporary({
+          text: `No command for ${formatKeyBinding(result.sequence, config.masterKey)}`,
+          state: 'cancelled'
+        })
+      }
+    }
+
+    const reset = (): void => {
+      matcherRef.current.reset()
+      commandActiveRef.current = false
+      if (deadlineTimerRef.current) clearTimeout(deadlineTimerRef.current)
+      setHud(null)
+    }
+
+    window.addEventListener('keydown', onKeyDown, true)
+    window.addEventListener('blur', reset)
+    return () => {
+      window.removeEventListener('keydown', onKeyDown, true)
+      window.removeEventListener('blur', reset)
+      if (deadlineTimerRef.current) clearTimeout(deadlineTimerRef.current)
+      clearHideTimer()
+    }
+  }, [actions, config])
+
+  return hud
+}

--- a/src/renderer/src/store/keymap-store.ts
+++ b/src/renderer/src/store/keymap-store.ts
@@ -1,0 +1,105 @@
+import { create } from 'zustand'
+import {
+  formatKeyBinding,
+  parseKeymapOverrides,
+  resolveKeymapConfig,
+  type KeymapActionId,
+  type KeymapOverridesV1,
+  type KeymapValidationError,
+  type ResolvedKeymapConfig
+} from '../../../shared/keymaps'
+
+interface KeymapState {
+  config: ResolvedKeymapConfig
+  overrides: KeymapOverridesV1
+  loaded: boolean
+  error: string | null
+}
+
+const EMPTY_OVERRIDES: KeymapOverridesV1 = { version: 1 }
+
+export const useKeymapStore = create<KeymapState>(() => ({
+  config: resolveKeymapConfig(),
+  overrides: EMPTY_OVERRIDES,
+  loaded: false,
+  error: null
+}))
+
+function validationMessage(errors: KeymapValidationError[]): string {
+  return errors.map((error) => `${error.path}: ${error.message}`).join('\n')
+}
+
+function applyRaw(raw: unknown): boolean {
+  const candidate = raw === null ? EMPTY_OVERRIDES : raw
+  const parsed = parseKeymapOverrides(candidate)
+  if (!parsed.ok) {
+    useKeymapStore.setState({ loaded: true, error: validationMessage(parsed.errors) })
+    return false
+  }
+  useKeymapStore.setState({
+    config: resolveKeymapConfig(parsed.value),
+    overrides: parsed.value,
+    loaded: true,
+    error: null
+  })
+  return true
+}
+
+export async function loadKeymaps(): Promise<void> {
+  try {
+    applyRaw((await window.electronAPI?.keymapsLoad?.()) ?? null)
+  } catch (error) {
+    useKeymapStore.setState({
+      loaded: true,
+      error: error instanceof Error ? error.message : 'Failed to load keymaps'
+    })
+  }
+}
+
+/** Connect one renderer window to main's accepted configuration. The pull
+ * closes the startup race; the push keeps every already-open window current. */
+export function connectKeymapStore(): () => void {
+  void loadKeymaps()
+  return (
+    window.electronAPI?.onKeymapsChanged?.((raw) => {
+      applyRaw(raw)
+    }) ?? (() => {})
+  )
+}
+
+export async function saveKeymapOverrides(
+  raw: unknown
+): Promise<
+  | { ok: true; value: KeymapOverridesV1 }
+  | { ok: false; errors: KeymapValidationError[] | [{ path: '$'; message: string }] }
+> {
+  const parsed = parseKeymapOverrides(raw)
+  if (!parsed.ok) return parsed
+  try {
+    const accepted = await window.electronAPI.keymapsSave(parsed.value)
+    const acceptedParsed = parseKeymapOverrides(accepted)
+    if (!acceptedParsed.ok) return acceptedParsed
+    applyRaw(acceptedParsed.value)
+    return { ok: true, value: acceptedParsed.value }
+  } catch (error) {
+    return {
+      ok: false,
+      errors: [
+        { path: '$', message: error instanceof Error ? error.message : 'Failed to save keymaps' }
+      ]
+    }
+  }
+}
+
+export function shortcutLabel(actionId: KeymapActionId): string | null {
+  const { config } = useKeymapStore.getState()
+  const binding = config.bindings[actionId][0]
+  return binding ? formatKeyBinding(binding, config.masterKey) : null
+}
+
+export function useShortcutLabel(actionId: KeymapActionId): string | null {
+  return useKeymapStore((state) => {
+    const binding = state.config.bindings[actionId][0]
+    return binding ? formatKeyBinding(binding, state.config.masterKey) : null
+  })
+}

--- a/src/renderer/src/store/session-types.ts
+++ b/src/renderer/src/store/session-types.ts
@@ -339,7 +339,7 @@ export interface FileTab {
 
 export type ActiveView = 'terminals' | 'settings' | 'agents' | 'extensions'
 
-export type SettingsSection = 'general' | 'appearance' | 'updates' | 'usage'
+export type SettingsSection = 'general' | 'appearance' | 'keymaps' | 'updates' | 'usage'
 
 export type ExtensionsSection = 'marketplaces' | 'mcp'
 
@@ -411,3 +411,4 @@ export interface PinnedGroup {
   activeGroupId: string | null
   visible: boolean
 }
+

--- a/src/shared/keymaps.test.ts
+++ b/src/shared/keymaps.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest'
+import {
+  KEYMAP_ACTIONS,
+  KEYMAP_SEQUENCE_TIMEOUT_MS,
+  KeymapMatcher,
+  canonicalizeBinding,
+  formatKeyBinding,
+  keyEventToChord,
+  overridesFromResolved,
+  parseKeymapOverrides,
+  resolveKeymapConfig
+} from './keymaps'
+
+describe('keymap defaults', () => {
+  it('keeps every existing Clave app shortcut and adds the command prefix', () => {
+    const config = resolveKeymapConfig()
+
+    expect(config.masterKey).toBe('Ctrl+B')
+    expect(config.bindings.newTerminal).toContain('Mod+T')
+    expect(config.bindings.newClaude).toEqual(['Mod+N', 'Master C'])
+    expect(config.bindings.newDangerousClaude).toContain('Mod+D')
+    expect(config.bindings.newClaudeAgents).toContain('Mod+Shift+A')
+    expect(config.bindings.newAntigravity).toContain('Mod+I')
+    expect(config.bindings.newCodex).toContain('Mod+U')
+    expect(config.bindings.resetSessions).toEqual(['Mod+Shift+Backspace'])
+    expect(config.bindings.killFocusedSession).toEqual(['Mod+Backspace'])
+    expect(config.bindings.newClaudeAtFolder).toEqual(['Mod+Alt+N'])
+    expect(KEYMAP_ACTIONS).toHaveLength(40)
+  })
+})
+
+describe('keymap syntax', () => {
+  it('canonicalizes capital letters without implying Shift', () => {
+    expect(canonicalizeBinding('ctrl+b')).toBe('Ctrl+B')
+    expect(canonicalizeBinding('ctrl+shift+b')).toBe('Ctrl+Shift+B')
+    expect(canonicalizeBinding(' master   c  n ')).toBe('Master C N')
+    expect(() => canonicalizeBinding('Master C Master')).toThrow(
+      'Master can only be the first sequence step'
+    )
+  })
+
+  it('normalizes a macOS keyboard event with exact modifiers', () => {
+    expect(
+      keyEventToChord({ key: 'b', metaKey: false, ctrlKey: true, altKey: false, shiftKey: false })
+    ).toBe('Ctrl+B')
+    expect(
+      keyEventToChord({ key: 'B', metaKey: false, ctrlKey: true, altKey: false, shiftKey: true })
+    ).toBe('Ctrl+Shift+B')
+    expect(
+      keyEventToChord({ key: '?', metaKey: true, ctrlKey: false, altKey: false, shiftKey: true })
+    ).toBe('Mod+Shift+/')
+  })
+
+  it('formats Mod and Master for the current macOS UI', () => {
+    expect(formatKeyBinding('Mod+Shift+A', 'Ctrl+B')).toBe('⌘⇧A')
+    expect(formatKeyBinding('Master C', 'Ctrl+B')).toBe('⌃B C')
+  })
+})
+
+describe('keymap validation', () => {
+  it('accepts versioned overrides, unbound actions, and two bindings', () => {
+    const parsed = parseKeymapOverrides({
+      version: 1,
+      masterKey: null,
+      bindings: { newClaude: [], newTerminal: ['Mod+T', 'Master T'] }
+    })
+
+    expect(parsed).toEqual({
+      ok: true,
+      value: {
+        version: 1,
+        masterKey: null,
+        bindings: { newClaude: [], newTerminal: ['Mod+T', 'Master T'] }
+      }
+    })
+  })
+
+  it('reports unknown actions, excess bindings, malformed sequences, and conflicts together', () => {
+    const parsed = parseKeymapOverrides({
+      version: 1,
+      bindings: {
+        unknownAction: ['Mod+Q'],
+        newClaude: ['Mod+N', 'Master C', 'Master N'],
+        newTerminal: ['Ctrl+B C'],
+        newCodex: ['Mod+N']
+      }
+    })
+
+    expect(parsed.ok).toBe(false)
+    if (parsed.ok) return
+    expect(parsed.errors.map((error) => error.message)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('Unknown action'),
+        expect.stringContaining('at most 2'),
+        expect.stringContaining('must start with Master'),
+        expect.stringContaining('already assigned')
+      ])
+    )
+  })
+
+  it('stores only differences from the code defaults', () => {
+    const config = resolveKeymapConfig({
+      version: 1,
+      masterKey: 'Ctrl+K',
+      bindings: { newClaude: ['Mod+J'] }
+    })
+
+    expect(overridesFromResolved(config)).toEqual({
+      version: 1,
+      masterKey: 'Ctrl+K',
+      bindings: { newClaude: ['Mod+J'] }
+    })
+  })
+})
+
+describe('command mode matching', () => {
+  it('matches direct chords immediately and requires exact modifiers', () => {
+    const matcher = new KeymapMatcher(resolveKeymapConfig())
+
+    expect(matcher.handleChord('Mod+N', 0)).toEqual({ kind: 'matched', actionId: 'newClaude' })
+    expect(matcher.handleChord('Mod+Ctrl+N', 1)).toEqual({ kind: 'none' })
+  })
+
+  it('enters through Master, consumes an unmatched key, and exits', () => {
+    const matcher = new KeymapMatcher(resolveKeymapConfig())
+
+    expect(matcher.handleChord('Ctrl+B', 0)).toEqual({ kind: 'pending', sequence: 'Ctrl+B' })
+    expect(matcher.handleChord('X', 20)).toEqual({ kind: 'cancelled', sequence: 'Ctrl+B X' })
+    expect(matcher.handleChord('C', 30)).toEqual({ kind: 'none' })
+  })
+
+  it('matches command sequences and exits after the 300ms inter-key deadline', () => {
+    const config = resolveKeymapConfig({
+      version: 1,
+      bindings: {
+        newClaude: ['Master C'],
+        newTerminal: ['Master C N']
+      }
+    })
+    const matcher = new KeymapMatcher(config)
+
+    expect(matcher.handleChord('Ctrl+B', 0).kind).toBe('pending')
+    expect(matcher.handleChord('C', 10)).toEqual({ kind: 'pending', sequence: 'Ctrl+B C' })
+    expect(matcher.expire(10 + KEYMAP_SEQUENCE_TIMEOUT_MS - 1).kind).toBe('pending')
+    expect(matcher.expire(10 + KEYMAP_SEQUENCE_TIMEOUT_MS)).toEqual({
+      kind: 'matched',
+      actionId: 'newClaude'
+    })
+
+    expect(matcher.handleChord('Ctrl+B', 400).kind).toBe('pending')
+    expect(matcher.handleChord('C', 410).kind).toBe('pending')
+    expect(matcher.handleChord('N', 420)).toEqual({ kind: 'matched', actionId: 'newTerminal' })
+  })
+
+  it('disables command mode when masterKey is unset but keeps direct bindings', () => {
+    const matcher = new KeymapMatcher(resolveKeymapConfig({ version: 1, masterKey: null }))
+
+    expect(matcher.handleChord('Ctrl+B', 0)).toEqual({ kind: 'none' })
+    expect(matcher.handleChord('Mod+N', 1)).toEqual({ kind: 'matched', actionId: 'newClaude' })
+  })
+})

--- a/src/shared/keymaps.ts
+++ b/src/shared/keymaps.ts
@@ -1,0 +1,569 @@
+export const KEYMAP_CONFIG_VERSION = 1 as const
+export const KEYMAP_SEQUENCE_TIMEOUT_MS = 300
+export const MAX_BINDINGS_PER_ACTION = 2
+
+export const KEYMAP_ACTION_IDS = [
+  'newTerminal',
+  'newTerminalAtFolder',
+  'newClaude',
+  'newClaudeAtFolder',
+  'newDangerousClaude',
+  'newDangerousClaudeAtFolder',
+  'newClaudeAgents',
+  'newClaudeAgentsAtFolder',
+  'newAntigravity',
+  'newAntigravityAtFolder',
+  'newCodex',
+  'newCodexAtFolder',
+  'toggleSidebar',
+  'toggleSidePanel',
+  'openFilePalette',
+  'openGitPanel',
+  'openHistory',
+  'openHelp',
+  'openSettings',
+  'focusSidebarSearch',
+  'closeFocused',
+  'killFocusedSession',
+  'previousWorkspace',
+  'nextWorkspace',
+  'previousSession',
+  'nextSession',
+  'selectSession1',
+  'selectSession2',
+  'selectSession3',
+  'selectSession4',
+  'selectSession5',
+  'selectSession6',
+  'selectSession7',
+  'selectSession8',
+  'selectSession9',
+  'groupSelectedSessions',
+  'ungroupSelectedSessions',
+  'resetSessions',
+  'undoSidebar',
+  'newWindow'
+] as const
+
+export type KeymapActionId = (typeof KEYMAP_ACTION_IDS)[number]
+export type KeymapScope = 'global' | 'app'
+
+export interface KeymapActionDefinition {
+  id: KeymapActionId
+  label: string
+  category: 'Sessions' | 'Navigation' | 'Sidebar' | 'Application'
+  scope: KeymapScope
+  defaultBindings: readonly string[]
+}
+
+export interface KeymapOverridesV1 {
+  version: typeof KEYMAP_CONFIG_VERSION
+  masterKey?: string | null
+  bindings?: Partial<Record<KeymapActionId, string[]>>
+}
+
+export interface ResolvedKeymapConfig {
+  version: typeof KEYMAP_CONFIG_VERSION
+  masterKey: string | null
+  bindings: Record<KeymapActionId, string[]>
+}
+
+export interface KeymapValidationError {
+  path: string
+  message: string
+}
+
+export type KeymapValidationResult =
+  | { ok: true; value: KeymapOverridesV1 }
+  | { ok: false; errors: KeymapValidationError[] }
+
+export interface KeyEventLike {
+  key: string
+  code?: string
+  metaKey: boolean
+  ctrlKey: boolean
+  altKey: boolean
+  shiftKey: boolean
+}
+
+export type KeymapMatchResult =
+  | { kind: 'none' }
+  | { kind: 'pending'; sequence: string }
+  | { kind: 'matched'; actionId: KeymapActionId }
+  | { kind: 'cancelled'; sequence: string }
+
+export const KEYMAP_ACTIONS: readonly KeymapActionDefinition[] = [
+  action('newTerminal', 'New terminal', 'Sessions', 'global', ['Mod+T']),
+  action('newTerminalAtFolder', 'New terminal in chosen folder', 'Sessions', 'global', [
+    'Mod+Alt+T'
+  ]),
+  action('newClaude', 'New Claude Code session', 'Sessions', 'global', ['Mod+N', 'Master C']),
+  action('newClaudeAtFolder', 'New Claude Code session in chosen folder', 'Sessions', 'global', [
+    'Mod+Alt+N'
+  ]),
+  action(
+    'newDangerousClaude',
+    'New Claude session without permission prompts',
+    'Sessions',
+    'global',
+    ['Mod+D']
+  ),
+  action(
+    'newDangerousClaudeAtFolder',
+    'New Claude session without permission prompts in chosen folder',
+    'Sessions',
+    'global',
+    ['Mod+Alt+D']
+  ),
+  action('newClaudeAgents', 'New Claude Agents session', 'Sessions', 'global', ['Mod+Shift+A']),
+  action(
+    'newClaudeAgentsAtFolder',
+    'New Claude Agents session in chosen folder',
+    'Sessions',
+    'global',
+    ['Mod+Alt+Shift+A']
+  ),
+  action('newAntigravity', 'New Antigravity session', 'Sessions', 'global', ['Mod+I']),
+  action(
+    'newAntigravityAtFolder',
+    'New Antigravity session in chosen folder',
+    'Sessions',
+    'global',
+    ['Mod+Alt+I']
+  ),
+  action('newCodex', 'New Codex session', 'Sessions', 'global', ['Mod+U']),
+  action('newCodexAtFolder', 'New Codex session in chosen folder', 'Sessions', 'global', [
+    'Mod+Alt+U'
+  ]),
+  action('closeFocused', 'Close focused tab or window', 'Sessions', 'global', ['Mod+W']),
+  action('killFocusedSession', 'Kill focused session', 'Sessions', 'global', ['Mod+Backspace']),
+  action('previousSession', 'Previous session', 'Sessions', 'global', ['Mod+Shift+[']),
+  action('nextSession', 'Next session', 'Sessions', 'global', ['Mod+Shift+]']),
+  action('selectSession1', 'Select session 1', 'Sessions', 'global', ['Mod+1']),
+  action('selectSession2', 'Select session 2', 'Sessions', 'global', ['Mod+2']),
+  action('selectSession3', 'Select session 3', 'Sessions', 'global', ['Mod+3']),
+  action('selectSession4', 'Select session 4', 'Sessions', 'global', ['Mod+4']),
+  action('selectSession5', 'Select session 5', 'Sessions', 'global', ['Mod+5']),
+  action('selectSession6', 'Select session 6', 'Sessions', 'global', ['Mod+6']),
+  action('selectSession7', 'Select session 7', 'Sessions', 'global', ['Mod+7']),
+  action('selectSession8', 'Select session 8', 'Sessions', 'global', ['Mod+8']),
+  action('selectSession9', 'Select session 9', 'Sessions', 'global', ['Mod+9']),
+  action('toggleSidebar', 'Toggle left sidebar', 'Navigation', 'global', ['Mod+B']),
+  action('toggleSidePanel', 'Toggle right side panel', 'Navigation', 'global', ['Mod+E']),
+  action('openFilePalette', 'Open file palette', 'Navigation', 'global', ['Mod+P']),
+  action('openGitPanel', 'Open Git panel', 'Navigation', 'global', ['Mod+Shift+G']),
+  action('openHistory', 'Open session history', 'Navigation', 'global', ['Mod+Shift+H']),
+  action('openHelp', 'Open help', 'Navigation', 'global', ['Mod+Shift+/']),
+  action('openSettings', 'Open settings', 'Navigation', 'global', ['Mod+,']),
+  action('focusSidebarSearch', 'Focus sidebar search', 'Navigation', 'global', ['Mod+F']),
+  action('previousWorkspace', 'Previous workspace', 'Navigation', 'global', ['Mod+Ctrl+[']),
+  action('nextWorkspace', 'Next workspace', 'Navigation', 'global', ['Mod+Ctrl+]']),
+  action('groupSelectedSessions', 'Group selected sessions', 'Sidebar', 'global', ['Mod+G']),
+  action('ungroupSelectedSessions', 'Ungroup selected sessions', 'Sidebar', 'global', [
+    'Mod+Alt+G'
+  ]),
+  action('resetSessions', 'Reset all sessions', 'Sidebar', 'global', ['Mod+Shift+Backspace']),
+  action('undoSidebar', 'Undo sidebar change', 'Sidebar', 'app', ['Mod+Z']),
+  action('newWindow', 'New window', 'Application', 'global', ['Mod+Shift+N'])
+]
+
+const ACTION_IDS = new Set<string>(KEYMAP_ACTION_IDS)
+const DEFAULT_MASTER_KEY = 'Ctrl+B'
+const MODIFIER_ORDER = ['Mod', 'Ctrl', 'Alt', 'Shift'] as const
+const MODIFIER_ALIASES: Record<string, (typeof MODIFIER_ORDER)[number]> = {
+  mod: 'Mod',
+  meta: 'Mod',
+  cmd: 'Mod',
+  command: 'Mod',
+  ctrl: 'Ctrl',
+  control: 'Ctrl',
+  alt: 'Alt',
+  option: 'Alt',
+  shift: 'Shift'
+}
+const NAMED_KEYS: Record<string, string> = {
+  backspace: 'Backspace',
+  delete: 'Delete',
+  enter: 'Enter',
+  return: 'Enter',
+  escape: 'Escape',
+  esc: 'Escape',
+  tab: 'Tab',
+  space: 'Space',
+  spacebar: 'Space',
+  arrowup: 'ArrowUp',
+  arrowdown: 'ArrowDown',
+  arrowleft: 'ArrowLeft',
+  arrowright: 'ArrowRight',
+  home: 'Home',
+  end: 'End',
+  pageup: 'PageUp',
+  pagedown: 'PageDown'
+}
+const SHIFTED_KEY_BASE: Record<string, string> = {
+  '~': '`',
+  '!': '1',
+  '@': '2',
+  '#': '3',
+  $: '4',
+  '%': '5',
+  '^': '6',
+  '&': '7',
+  '*': '8',
+  '(': '9',
+  ')': '0',
+  _: '-',
+  '+': '=',
+  '{': '[',
+  '}': ']',
+  '|': '\\',
+  ':': ';',
+  '"': "'",
+  '<': ',',
+  '>': '.',
+  '?': '/'
+}
+
+function action(
+  id: KeymapActionId,
+  label: string,
+  category: KeymapActionDefinition['category'],
+  scope: KeymapScope,
+  defaultBindings: readonly string[]
+): KeymapActionDefinition {
+  return { id, label, category, scope, defaultBindings }
+}
+
+function canonicalKey(raw: string): string {
+  const trimmed = raw.trim()
+  if (!trimmed) throw new Error('A chord needs a key')
+  const named = NAMED_KEYS[trimmed.toLowerCase()]
+  if (named) return named
+  if (trimmed.length === 1) return /[a-z]/i.test(trimmed) ? trimmed.toUpperCase() : trimmed
+  if (/^f([1-9]|1[0-9]|2[0-4])$/i.test(trimmed)) return trimmed.toUpperCase()
+  throw new Error(`Unknown key "${trimmed}"`)
+}
+
+export function canonicalizeChord(chord: string): string {
+  const tokens = chord
+    .split('+')
+    .map((token) => token.trim())
+    .filter(Boolean)
+  if (tokens.length === 0) throw new Error('A chord cannot be empty')
+
+  const modifiers = new Set<(typeof MODIFIER_ORDER)[number]>()
+  let key: string | null = null
+  for (const token of tokens) {
+    const modifier = MODIFIER_ALIASES[token.toLowerCase()]
+    if (modifier) {
+      if (modifiers.has(modifier)) throw new Error(`Duplicate modifier "${modifier}"`)
+      modifiers.add(modifier)
+      continue
+    }
+    if (key !== null) throw new Error('A chord can contain only one key')
+    key = canonicalKey(token)
+  }
+  if (key === null) throw new Error('A chord needs a non-modifier key')
+  return [...MODIFIER_ORDER.filter((modifier) => modifiers.has(modifier)), key].join('+')
+}
+
+export function canonicalizeBinding(binding: string): string {
+  const steps = binding.trim().split(/\s+/).filter(Boolean)
+  if (steps.length === 0) throw new Error('A binding cannot be empty')
+  return steps
+    .map((step, index) => {
+      if (step.toLowerCase() === 'master') {
+        if (index > 0) throw new Error('Master can only be the first sequence step')
+        return 'Master'
+      }
+      if (index > 0 && step.toLowerCase().startsWith('master+')) {
+        throw new Error('Master is a sequence step, not a modifier')
+      }
+      return canonicalizeChord(step)
+    })
+    .join(' ')
+}
+
+export function keyEventToChord(event: KeyEventLike): string | null {
+  if (['Meta', 'Control', 'Alt', 'Shift'].includes(event.key)) return null
+  const deadKeyFallback = event.code?.match(/^Key([A-Z])$/)?.[1]
+  if ((event.key === 'Dead' || event.key === 'Unidentified') && !deadKeyFallback) return null
+  let key: string
+  try {
+    const eventKey = event.shiftKey ? (SHIFTED_KEY_BASE[event.key] ?? event.key) : event.key
+    key = canonicalKey(deadKeyFallback ?? (eventKey === ' ' ? 'Space' : eventKey))
+  } catch {
+    return null
+  }
+  const parts: string[] = []
+  if (event.metaKey) parts.push('Mod')
+  if (event.ctrlKey) parts.push('Ctrl')
+  if (event.altKey) parts.push('Alt')
+  if (event.shiftKey) parts.push('Shift')
+  parts.push(key)
+  return parts.join('+')
+}
+
+function formatChord(chord: string): string {
+  const tokens = chord.split('+')
+  const key = tokens.pop() ?? ''
+  return (
+    tokens
+      .map((token) => {
+        if (token === 'Mod') return '⌘'
+        if (token === 'Ctrl') return '⌃'
+        if (token === 'Alt') return '⌥'
+        if (token === 'Shift') return '⇧'
+        return token
+      })
+      .join('') + (key === 'Space' ? 'Space' : key)
+  )
+}
+
+export function formatKeyBinding(binding: string, masterKey: string | null): string {
+  return canonicalizeBinding(binding)
+    .split(' ')
+    .map((step) =>
+      step === 'Master' ? (masterKey ? formatChord(masterKey) : 'Master') : formatChord(step)
+    )
+    .join(' ')
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function defaults(): ResolvedKeymapConfig {
+  return {
+    version: KEYMAP_CONFIG_VERSION,
+    masterKey: DEFAULT_MASTER_KEY,
+    bindings: Object.fromEntries(
+      KEYMAP_ACTIONS.map((definition) => [definition.id, [...definition.defaultBindings]])
+    ) as Record<KeymapActionId, string[]>
+  }
+}
+
+export function parseKeymapOverrides(raw: unknown): KeymapValidationResult {
+  const errors: KeymapValidationError[] = []
+  if (!isRecord(raw))
+    return { ok: false, errors: [{ path: '$', message: 'Configuration must be an object' }] }
+
+  for (const key of Object.keys(raw)) {
+    if (!['version', 'masterKey', 'bindings'].includes(key)) {
+      errors.push({ path: key, message: `Unknown configuration field "${key}"` })
+    }
+  }
+  if (raw.version !== KEYMAP_CONFIG_VERSION) {
+    errors.push({ path: 'version', message: `Version must be ${KEYMAP_CONFIG_VERSION}` })
+  }
+
+  let masterKey: string | null | undefined
+  if (raw.masterKey !== undefined) {
+    if (raw.masterKey === null) masterKey = null
+    else if (typeof raw.masterKey !== 'string') {
+      errors.push({ path: 'masterKey', message: 'masterKey must be a chord or null' })
+    } else {
+      try {
+        masterKey = canonicalizeChord(raw.masterKey)
+      } catch (error) {
+        errors.push({ path: 'masterKey', message: (error as Error).message })
+      }
+    }
+  }
+
+  const bindings: Partial<Record<KeymapActionId, string[]>> = {}
+  if (raw.bindings !== undefined && !isRecord(raw.bindings)) {
+    errors.push({ path: 'bindings', message: 'bindings must be an object' })
+  } else if (isRecord(raw.bindings)) {
+    for (const [actionId, rawBindings] of Object.entries(raw.bindings)) {
+      if (!ACTION_IDS.has(actionId)) {
+        errors.push({ path: `bindings.${actionId}`, message: `Unknown action "${actionId}"` })
+        continue
+      }
+      if (
+        !Array.isArray(rawBindings) ||
+        rawBindings.some((binding) => typeof binding !== 'string')
+      ) {
+        errors.push({
+          path: `bindings.${actionId}`,
+          message: 'Action bindings must be an array of strings'
+        })
+        continue
+      }
+      if (rawBindings.length > MAX_BINDINGS_PER_ACTION) {
+        errors.push({
+          path: `bindings.${actionId}`,
+          message: `An action may have at most ${MAX_BINDINGS_PER_ACTION} bindings`
+        })
+      }
+      const parsedBindings: string[] = []
+      for (let index = 0; index < rawBindings.length; index++) {
+        try {
+          const binding = canonicalizeBinding(rawBindings[index])
+          const steps = binding.split(' ')
+          if (steps.length > 1 && steps[0] !== 'Master') {
+            throw new Error('A multi-key sequence must start with Master')
+          }
+          if (binding === 'Master') throw new Error('Master cannot be assigned as an action')
+          parsedBindings.push(binding)
+        } catch (error) {
+          errors.push({ path: `bindings.${actionId}.${index}`, message: (error as Error).message })
+        }
+      }
+      bindings[actionId as KeymapActionId] = parsedBindings
+    }
+  }
+
+  const candidate: KeymapOverridesV1 = { version: KEYMAP_CONFIG_VERSION }
+  if (masterKey !== undefined) candidate.masterKey = masterKey
+  if (Object.keys(bindings).length > 0) candidate.bindings = bindings
+
+  const resolved = resolveKeymapConfig(candidate)
+  const owners = new Map<string, KeymapActionId>()
+  for (const actionId of KEYMAP_ACTION_IDS) {
+    for (const binding of resolved.bindings[actionId]) {
+      const owner = owners.get(binding)
+      if (owner) {
+        errors.push({
+          path: `bindings.${actionId}`,
+          message: `Binding "${binding}" is already assigned to ${owner}`
+        })
+      } else {
+        owners.set(binding, actionId)
+      }
+      if (resolved.masterKey && binding === resolved.masterKey) {
+        errors.push({
+          path: `bindings.${actionId}`,
+          message: `Binding "${binding}" is reserved for masterKey`
+        })
+      }
+    }
+  }
+
+  return errors.length > 0 ? { ok: false, errors } : { ok: true, value: candidate }
+}
+
+export function resolveKeymapConfig(overrides?: KeymapOverridesV1 | null): ResolvedKeymapConfig {
+  const config = defaults()
+  if (!overrides) return config
+  if (overrides.masterKey !== undefined) config.masterKey = overrides.masterKey
+  for (const [actionId, bindings] of Object.entries(overrides.bindings ?? {})) {
+    if (ACTION_IDS.has(actionId) && bindings) {
+      config.bindings[actionId as KeymapActionId] = [...bindings]
+    }
+  }
+  return config
+}
+
+function equalBindings(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((binding, index) => binding === right[index])
+}
+
+export function overridesFromResolved(config: ResolvedKeymapConfig): KeymapOverridesV1 {
+  const base = defaults()
+  const overrides: KeymapOverridesV1 = { version: KEYMAP_CONFIG_VERSION }
+  if (config.masterKey !== base.masterKey) overrides.masterKey = config.masterKey
+  const bindings: Partial<Record<KeymapActionId, string[]>> = {}
+  for (const actionId of KEYMAP_ACTION_IDS) {
+    if (!equalBindings(config.bindings[actionId], base.bindings[actionId])) {
+      bindings[actionId] = [...config.bindings[actionId]]
+    }
+  }
+  if (Object.keys(bindings).length > 0) overrides.bindings = bindings
+  return overrides
+}
+
+interface CompiledCommand {
+  actionId: KeymapActionId
+  steps: string[]
+}
+
+export class KeymapMatcher {
+  private config: ResolvedKeymapConfig
+  private direct = new Map<string, KeymapActionId>()
+  private commands: CompiledCommand[] = []
+  private pending: string[] | null = null
+  private deadline = 0
+  private pendingAction: KeymapActionId | null = null
+
+  constructor(config: ResolvedKeymapConfig) {
+    this.config = config
+    this.compile()
+  }
+
+  setConfig(config: ResolvedKeymapConfig): void {
+    this.config = config
+    this.reset()
+    this.compile()
+  }
+
+  private compile(): void {
+    this.direct.clear()
+    this.commands = []
+    for (const actionId of KEYMAP_ACTION_IDS) {
+      for (const binding of this.config.bindings[actionId]) {
+        const steps = binding.split(' ')
+        if (steps[0] === 'Master') {
+          if (this.config.masterKey) {
+            this.commands.push({ actionId, steps: [this.config.masterKey, ...steps.slice(1)] })
+          }
+        } else if (steps.length === 1) {
+          this.direct.set(steps[0], actionId)
+        }
+      }
+    }
+  }
+
+  handleChord(chord: string, now: number): KeymapMatchResult {
+    const canonical = canonicalizeChord(chord)
+    if (!this.pending) {
+      if (this.config.masterKey && canonical === this.config.masterKey) {
+        this.pending = [canonical]
+        this.deadline = now + KEYMAP_SEQUENCE_TIMEOUT_MS
+        this.pendingAction = null
+        return { kind: 'pending', sequence: this.pending.join(' ') }
+      }
+      const actionId = this.direct.get(canonical)
+      return actionId ? { kind: 'matched', actionId } : { kind: 'none' }
+    }
+
+    this.pending.push(canonical)
+    const candidates = this.commands.filter(
+      (command) =>
+        command.steps.length >= this.pending!.length &&
+        this.pending!.every((step, index) => command.steps[index] === step)
+    )
+    if (candidates.length === 0) {
+      const sequence = this.pending.join(' ')
+      this.reset()
+      return { kind: 'cancelled', sequence }
+    }
+
+    const exact = candidates.find((command) => command.steps.length === this.pending!.length)
+    const hasLonger = candidates.some((command) => command.steps.length > this.pending!.length)
+    if (exact && !hasLonger) {
+      const actionId = exact.actionId
+      this.reset()
+      return { kind: 'matched', actionId }
+    }
+
+    this.pendingAction = exact?.actionId ?? null
+    this.deadline = now + KEYMAP_SEQUENCE_TIMEOUT_MS
+    return { kind: 'pending', sequence: this.pending.join(' ') }
+  }
+
+  expire(now: number): KeymapMatchResult {
+    if (!this.pending) return { kind: 'none' }
+    if (now < this.deadline) return { kind: 'pending', sequence: this.pending.join(' ') }
+    const sequence = this.pending.join(' ')
+    const actionId = this.pendingAction
+    this.reset()
+    return actionId ? { kind: 'matched', actionId } : { kind: 'cancelled', sequence }
+  }
+
+  reset(): void {
+    this.pending = null
+    this.deadline = 0
+    this.pendingAction = null
+  }
+}

--- a/tests/e2e/keymaps.spec.mjs
+++ b/tests/e2e/keymaps.spec.mjs
@@ -1,0 +1,145 @@
+/**
+ * The configurable keymap boundary: defaults enter command mode, Save is the
+ * only activation point, main broadcasts accepted overrides to every renderer,
+ * and the native menu reads the same accepted configuration.
+ */
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { launchApp, openWindow, seedWorkspaces, userDataDir } from './harness.mjs'
+
+const DIR = userDataDir('keymaps')
+const ROOT = '/tmp/clave-e2e-keymaps-root'
+const IMPORT_FILE = `${DIR}/import-keymaps.json`
+const EXPORT_FILE = `${DIR}/exported-keymaps.json`
+const WORKSPACE = {
+  id: 'aaaaaaaa-0000-4000-8000-0000000000aa',
+  name: 'Keymaps',
+  rootDir: ROOT,
+  profileFile: null,
+  createdAt: 1
+}
+
+export async function run(t) {
+  mkdirSync(ROOT, { recursive: true })
+  seedWorkspaces(DIR, { workspaces: [WORKSPACE], activeWorkspaceId: WORKSPACE.id, fresh: true })
+  writeFileSync(
+    IMPORT_FILE,
+    JSON.stringify({ version: 1, bindings: { openSettings: ['Mod+K'] } }, null, 2)
+  )
+  const { app, win } = await launchApp(DIR)
+
+  try {
+    await win.keyboard.press('Meta+,')
+    await win.getByRole('button', { name: 'Keymaps' }).click()
+    await win.waitForTimeout(300)
+
+    const initial = await win.locator('body').innerText()
+    t.check(
+      'Settings exposes the keymap editor',
+      initial.includes('Keymaps') && initial.includes('Master key')
+    )
+    t.check('the default master key is Ctrl+B', initial.includes('⌃B'), initial)
+    t.check('the editor says changes wait for Save', initial.includes('Changes stay in this draft'))
+
+    const terminalRow = win.locator('.keymap-row').filter({ hasText: 'New terminal' }).first()
+    await terminalRow.locator('.keymap-binding').first().click()
+    await win.keyboard.press('Meta+J')
+    t.check('the action editor records a chord', (await terminalRow.innerText()).includes('⌘J'))
+    await terminalRow.getByRole('button', { name: 'Reset New terminal' }).click()
+    t.check('an action can reset to its default', (await terminalRow.innerText()).includes('⌘T'))
+
+    // Open the second renderer before changing anything. The save must update it
+    // without a reload or a new-window bootstrap read.
+    const { page: second } = await openWindow(app, win, WORKSPACE.id, { settleMs: 1200 })
+
+    await app.evaluate(async ({ dialog }, importFile) => {
+      dialog.showOpenDialog = async () => ({ canceled: false, filePaths: [importFile] })
+    }, IMPORT_FILE)
+    await win.getByRole('button', { name: 'Import' }).click()
+    await win.waitForTimeout(150)
+    t.check(
+      'Import stages JSON without activating it',
+      (await win.locator('body').innerText()).includes('Imported as a draft')
+    )
+
+    // It is still a draft. The old key opens Settings in the second window.
+    await second.keyboard.press('Meta+,')
+    await second.waitForTimeout(250)
+    t.check(
+      'editing JSON does not activate it before Save',
+      (await second.locator('body').innerText()).includes('General')
+    )
+    await second.getByRole('button', { name: 'Back to sessions' }).click()
+
+    await win.getByRole('button', { name: 'Save keymaps' }).click()
+    await win.waitForTimeout(350)
+    t.check(
+      'Save reports immediate all-window activation',
+      (await win.locator('body').innerText()).includes('active in every window')
+    )
+
+    await second.keyboard.press('Meta+K')
+    await second.waitForTimeout(250)
+    t.check(
+      'an already-open second window uses the new binding immediately',
+      (await second.locator('body').innerText()).includes('General')
+    )
+
+    const menuAccelerator = await app.evaluate(({ Menu }) => {
+      const menu = Menu.getApplicationMenu()
+      const settings = menu?.items[0]?.submenu?.items.find((item) => item.label === 'Settings…')
+      return settings?.accelerator ?? null
+    })
+    t.equal(
+      'the native menu label is rebuilt from the accepted binding',
+      menuAccelerator,
+      'Command+K'
+    )
+
+    await app.evaluate(async ({ dialog }, exportFile) => {
+      dialog.showSaveDialog = async () => ({ canceled: false, filePath: exportFile })
+    }, EXPORT_FILE)
+    await win.getByRole('button', { name: 'Export' }).click()
+    t.equal(
+      'Export writes the validated override document',
+      JSON.parse(readFileSync(EXPORT_FILE, 'utf-8')).bindings.openSettings[0],
+      'Mod+K'
+    )
+
+    await win
+      .getByRole('textbox', { name: 'Raw keymap JSON' })
+      .fill(
+        JSON.stringify(
+          { version: 1, bindings: { newTerminal: ['Mod+K'], openSettings: ['Mod+K'] } },
+          null,
+          2
+        )
+      )
+    await win.getByRole('button', { name: 'Save keymaps' }).click()
+    t.check(
+      'invalid conflicts are rejected at Save',
+      (await win.locator('body').innerText()).includes('already assigned')
+    )
+    await second.getByRole('button', { name: 'Back to sessions' }).click()
+    await second.keyboard.press('Meta+K')
+    await second.waitForTimeout(250)
+    t.check(
+      'a rejected save leaves the last valid keymap active',
+      (await second.locator('body').innerText()).includes('General')
+    )
+
+    await win.getByRole('button', { name: 'Back to sessions' }).click()
+    await win.keyboard.press('Control+B')
+    t.check(
+      'the master key enters visible command mode',
+      await win.evaluate(() => document.querySelector('.keymap-command-hud') !== null)
+    )
+    await win.keyboard.press('Escape')
+    await win.keyboard.press('Control+B')
+    await win.keyboard.press('c')
+    await win.waitForTimeout(3500)
+    const rows = await win.locator('[data-sidebar-item-type="session"]').count()
+    t.check('Ctrl+B C launches a Claude session', rows > 0, rows)
+  } finally {
+    await app.close()
+  }
+}

--- a/tests/e2e/new-document.spec.mjs
+++ b/tests/e2e/new-document.spec.mjs
@@ -44,7 +44,7 @@ export async function run(t) {
     // A session, so the tree has a cwd; then the tree.
     await win.click('.launcher-row button')
     await win.waitForTimeout(4000)
-    await win.click('button[title="File tree (Cmd+E)"]')
+    await win.click('button[title^="File tree"]')
     await win.waitForTimeout(1200)
 
     await treeContextMenu(win, 'New File')


### PR DESCRIPTION
## Related issue

Requested directly; no linked issue.

## What changed

- adds a versioned keymap configuration manager with all existing Clave shortcuts as defaults
- adds Settings → Keymaps with action search, recording, two bindings per action, reset/unbind, raw JSON, and staged import/export
- applies validated changes on Save to every open window and rebuilds native menu accelerators and in-app labels
- adds Ctrl+B command mode with arbitrary Master-prefixed sequences, a 300ms inter-key deadline, and a visible command HUD
- keeps the last valid configuration when validation fails and resolves the old kill/reset shortcut collision

## How to test

- npm run build
- npm test -- --run (335 passed)
- node tests/e2e/run.mjs keymaps (15 passed)
- node tests/e2e/run.mjs new-document (10 passed)
- scoped ESLint and Prettier checks pass for the new keymap modules

The complete Electron suite reached 742 passes. Four existing terminal-render assertions in message-trail and multi-window-core still return null/-1 when those specs are rerun alone; the keymap and updated tooltip flows are green.