### PR TITLE
fix(sessions): make agent launches shell-independent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Clave's companion agent plugin (`clave`, exposing `/clave:create-workspace` and 
 
 Three-process Electron app:
 
-- **Main** (`src/main/`): Electron window, node-pty, IPC handlers, domain managers. Agent PTYs spawn through launch profiles, adapted through `/bin/zsh -l -c` for macOS login-shell PATH resolution. IPC handlers are split into modular files under `ipc-handlers/`.
+- **Main** (`src/main/`): Electron window, node-pty, IPC handlers, domain managers. Agent PTYs spawn through launch profiles as `<shell> -l -c '<wrapper>'`, where the shell is the user's own while it speaks POSIX and Clave's (`/bin/zsh` on macOS, `/bin/sh` elsewhere) when it does not — Nushell and Fish cannot parse the wrapper (`src/main/shell-launch.ts`). IPC handlers are split into modular files under `ipc-handlers/`.
 - **Preload** (`src/preload/`): Typed `window.electronAPI` via contextBridge. All main↔renderer communication goes through IPC.
 - **Renderer** (`src/renderer/src/`): React + Zustand + xterm.js + Tailwind v4 + Framer Motion.
 

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -10,6 +10,7 @@ import { getMcpRuntime, writeSessionMcpConfig, deleteSessionMcpConfig } from './
 import { workspaceManager } from './workspace-manager'
 import { dismissSessionOffers } from './copy-offer-manager'
 import { launchProfileManager } from './launch-profile-manager'
+import { resolvePosixShellLaunch } from './shell-launch'
 import {
   buildAgentArgv,
   type AgentKind,
@@ -716,6 +717,7 @@ class PtyManager {
     }
 
     let shellArgs: string[]
+    let posixAgentCommand: string | undefined
     if (isWindows) {
       // Windows: cmd.exe with /c to exec the command directly (no echoed prompt).
       if (usePiMode) {
@@ -748,8 +750,8 @@ class PtyManager {
         shellArgs = ['/c', ...parts]
       }
     } else {
-      // POSIX: -l -c '<cmd>' runs the command non-interactively (no echo, no
-      // prompt, no rc-file chatter like the macOS bash→zsh notice).
+      // POSIX agent commands run non-interactively through Clave's command
+      // shell. Plain terminals still open the user's login shell.
       if (!kind) {
         shellArgs = ['-l']
       } else {
@@ -793,16 +795,21 @@ class PtyManager {
         if (kind === 'pi') assignments.push(`CLAVE_AGENT_STATE_FILE=${shellSingleQuote(stateFilePath(id))}`)
         const rendered = `${assignments.join(' ')} ${argv.map(shellSingleQuote).join(' ')}`
         const failure = `__clave_status=$?; if [ $__clave_status -ne 0 ]; then printf '\\r\\n[Clave] Agent command exited with status %d\\r\\nCommand: %s\\r\\n' $__clave_status ${shellSingleQuote(argv.map(shellSingleQuote).join(' '))}; fi; exit $__clave_status`
-        shellArgs = ['-l', '-c', `${rendered}; ${failure}`]
+        posixAgentCommand = `${rendered}; ${failure}`
+        shellArgs = []
       }
     }
 
-    // By default we spawn the user's shell directly. When tmux mode is opted in
-    // (and tmux is installed), we instead spawn a tmux client that runs the very
-    // same shell command inside a persistent, named tmux session.
-    const shellName = getUserShell()
+    // Plain terminals belong to the user's shell. Agent commands use Clave's
+    // POSIX command shell, so selecting Nushell or Fish cannot make the wrapper
+    // a syntax error. tmux receives the same resolved file and arguments.
+    const userShell = getUserShell()
+    const directLaunch = isWindows
+      ? { file: userShell, args: shellArgs }
+      : resolvePosixShellLaunch(userShell, posixAgentCommand)
+    const shellName = directLaunch.file
     let spawnFile = shellName
-    let spawnArgs = shellArgs
+    let spawnArgs = directLaunch.args
     let tmuxName: string | undefined
 
     // Adoption/relaunch rewrites the record from scratch, so carry the tab's
@@ -882,7 +889,7 @@ class PtyManager {
         // run the shell command. Attaching never re-runs the command. Fresh names
         // are guaranteed not to collide with a survivor, so `-A` only reattaches
         // on the explicit adoption path.
-        tmuxArgs.push('new-session', '-A', '-s', tmuxName, shellName, ...shellArgs)
+        tmuxArgs.push('new-session', '-A', '-s', tmuxName, shellName, ...directLaunch.args)
         spawnFile = tmuxPath
         spawnArgs = tmuxArgs
       }

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -716,7 +716,9 @@ class PtyManager {
       throw new Error('Invalid Pi thinking level')
     }
 
-    let shellArgs: string[]
+    // Windows spawns the user shell with these args. POSIX renders the agent
+    // wrapper instead and lets resolvePosixShellLaunch pick file and args.
+    let shellArgs: string[] = []
     let posixAgentCommand: string | undefined
     if (isWindows) {
       // Windows: cmd.exe with /c to exec the command directly (no echoed prompt).
@@ -750,11 +752,9 @@ class PtyManager {
         shellArgs = ['/c', ...parts]
       }
     } else {
-      // POSIX agent commands run non-interactively through Clave's command
-      // shell. Plain terminals still open the user's login shell.
-      if (!kind) {
-        shellArgs = ['-l']
-      } else {
+      // POSIX agent commands run non-interactively (no echo, no prompt, no
+      // rc-file chatter). Plain terminals open the user's login shell.
+      if (kind) {
         const profile = launchProfile!
         if ((kind === 'claude' || kind === 'pi') && options?.resumeSessionId && !isValidClaudeSessionId(options.resumeSessionId)) {
           throw new Error('Invalid resume session id')
@@ -796,13 +796,13 @@ class PtyManager {
         const rendered = `${assignments.join(' ')} ${argv.map(shellSingleQuote).join(' ')}`
         const failure = `__clave_status=$?; if [ $__clave_status -ne 0 ]; then printf '\\r\\n[Clave] Agent command exited with status %d\\r\\nCommand: %s\\r\\n' $__clave_status ${shellSingleQuote(argv.map(shellSingleQuote).join(' '))}; fi; exit $__clave_status`
         posixAgentCommand = `${rendered}; ${failure}`
-        shellArgs = []
       }
     }
 
-    // Plain terminals belong to the user's shell. Agent commands use Clave's
-    // POSIX command shell, so selecting Nushell or Fish cannot make the wrapper
-    // a syntax error. tmux receives the same resolved file and arguments.
+    // Plain terminals belong to the user's shell, and so do agent commands
+    // while that shell speaks POSIX. Selecting Nushell or Fish diverts the
+    // wrapper to a shell that can parse it instead of making it a syntax
+    // error. tmux receives the same resolved file and arguments.
     const userShell = getUserShell()
     const directLaunch = isWindows
       ? { file: userShell, args: shellArgs }

--- a/src/main/shell-launch.test.ts
+++ b/src/main/shell-launch.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { resolvePosixShellLaunch } from './shell-launch'
+
+describe('resolvePosixShellLaunch', () => {
+  it.each(['/opt/homebrew/bin/nu', '/opt/homebrew/bin/fish'])(
+    'opens a plain terminal with the user shell %s',
+    (userShell) => {
+      expect(resolvePosixShellLaunch(userShell, undefined, 'darwin')).toEqual({
+        file: userShell,
+        args: ['-l']
+      })
+    }
+  )
+
+  it.each(['/opt/homebrew/bin/nu', '/opt/homebrew/bin/fish'])(
+    'keeps the POSIX agent wrapper away from the user shell %s',
+    (userShell) => {
+      expect(resolvePosixShellLaunch(userShell, 'agent command', 'darwin')).toEqual({
+        file: '/bin/zsh',
+        args: ['-l', '-c', 'agent command']
+      })
+    }
+  )
+
+  it('uses the portable command shell outside macOS', () => {
+    expect(resolvePosixShellLaunch('/usr/bin/nu', 'agent command', 'linux')).toEqual({
+      file: '/bin/sh',
+      args: ['-c', 'agent command']
+    })
+  })
+})

--- a/src/main/shell-launch.test.ts
+++ b/src/main/shell-launch.test.ts
@@ -1,31 +1,49 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { resolvePosixShellLaunch } from './shell-launch'
 
-describe('resolvePosixShellLaunch', () => {
-  it.each(['/opt/homebrew/bin/nu', '/opt/homebrew/bin/fish'])(
-    'opens a plain terminal with the user shell %s',
-    (userShell) => {
-      expect(resolvePosixShellLaunch(userShell, undefined, 'darwin')).toEqual({
-        file: userShell,
-        args: ['-l']
-      })
-    }
-  )
+const POSIX = ['/bin/sh', '/bin/bash', '/bin/zsh', '/opt/homebrew/bin/bash', '/usr/bin/dash']
+const NON_POSIX = ['/opt/homebrew/bin/nu', '/opt/homebrew/bin/fish', '/usr/bin/xonsh', '/bin/tcsh']
 
-  it.each(['/opt/homebrew/bin/nu', '/opt/homebrew/bin/fish'])(
-    'keeps the POSIX agent wrapper away from the user shell %s',
-    (userShell) => {
-      expect(resolvePosixShellLaunch(userShell, 'agent command', 'darwin')).toEqual({
-        file: '/bin/zsh',
+describe('resolvePosixShellLaunch', () => {
+  it.each([...POSIX, ...NON_POSIX])('opens a plain terminal with the user shell %s', (userShell) => {
+    expect(resolvePosixShellLaunch(userShell, undefined, 'darwin')).toEqual({
+      file: userShell,
+      args: ['-l']
+    })
+  })
+
+  it.each(POSIX)('keeps a POSIX user shell %s in charge of the agent wrapper', (userShell) => {
+    for (const platform of ['darwin', 'linux'] as const) {
+      expect(resolvePosixShellLaunch(userShell, 'agent command', platform)).toEqual({
+        file: userShell,
         args: ['-l', '-c', 'agent command']
       })
     }
-  )
+  })
 
-  it('uses the portable command shell outside macOS', () => {
-    expect(resolvePosixShellLaunch('/usr/bin/nu', 'agent command', 'linux')).toEqual({
+  it.each(NON_POSIX)('keeps the POSIX agent wrapper away from the user shell %s', (userShell) => {
+    expect(resolvePosixShellLaunch(userShell, 'agent command', 'darwin')).toEqual({
+      file: '/bin/zsh',
+      args: ['-l', '-c', 'agent command']
+    })
+    expect(resolvePosixShellLaunch(userShell, 'agent command', 'linux')).toEqual({
       file: '/bin/sh',
-      args: ['-c', 'agent command']
+      args: ['-l', '-c', 'agent command']
+    })
+  })
+
+  describe('platform default', () => {
+    const realPlatform = process.platform
+    afterEach(() => Object.defineProperty(process, 'platform', { value: realPlatform }))
+
+    // The production call site passes no platform; a wrong default would
+    // pick the mac adapter on Linux and every explicit-platform case above
+    // would still be green.
+    it('reads process.platform when no platform is given', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' })
+      expect(resolvePosixShellLaunch('/usr/bin/nu', 'agent command').file).toBe('/bin/sh')
+      Object.defineProperty(process, 'platform', { value: 'darwin' })
+      expect(resolvePosixShellLaunch('/usr/bin/nu', 'agent command').file).toBe('/bin/zsh')
     })
   })
 })

--- a/src/main/shell-launch.ts
+++ b/src/main/shell-launch.ts
@@ -1,13 +1,24 @@
+import { basename } from 'node:path'
+
 export interface ShellLaunch {
   file: string
   args: string[]
 }
 
 /**
+ * Shells whose command language is POSIX sh. They parse Clave's agent wrapper
+ * as written, so the user's own shell stays in charge — and with it the
+ * profile that sets their PATH order (`path_helper` on macOS reorders PATH on
+ * every login; a bash user's `.bash_profile` puts it back, their absent
+ * `.zprofile` would not).
+ */
+const POSIX_SHELLS = new Set(['sh', 'bash', 'zsh', 'dash', 'ksh', 'mksh', 'ash'])
+
+/**
  * Keep the user's shell for interactive terminal tabs, where its own language
- * and configuration belong. Agent launches use a shell Clave controls because
- * their wrapper is POSIX syntax and must not be parsed by Nushell, Fish, or any
- * other user-selected shell.
+ * and configuration belong. Agent launches keep it too when it speaks POSIX;
+ * otherwise (Nushell, Fish, xonsh, csh…) the wrapper goes to a shell Clave
+ * controls, because their parsers reject it and the agent never starts.
  */
 export function resolvePosixShellLaunch(
   userShell: string,
@@ -16,7 +27,10 @@ export function resolvePosixShellLaunch(
 ): ShellLaunch {
   if (command === undefined) return { file: userShell, args: ['-l'] }
 
-  return platform === 'darwin'
-    ? { file: '/bin/zsh', args: ['-l', '-c', command] }
-    : { file: '/bin/sh', args: ['-c', command] }
+  const file = POSIX_SHELLS.has(basename(userShell))
+    ? userShell
+    : platform === 'darwin'
+      ? '/bin/zsh'
+      : '/bin/sh'
+  return { file, args: ['-l', '-c', command] }
 }

--- a/src/main/shell-launch.ts
+++ b/src/main/shell-launch.ts
@@ -1,0 +1,22 @@
+export interface ShellLaunch {
+  file: string
+  args: string[]
+}
+
+/**
+ * Keep the user's shell for interactive terminal tabs, where its own language
+ * and configuration belong. Agent launches use a shell Clave controls because
+ * their wrapper is POSIX syntax and must not be parsed by Nushell, Fish, or any
+ * other user-selected shell.
+ */
+export function resolvePosixShellLaunch(
+  userShell: string,
+  command?: string,
+  platform: NodeJS.Platform = process.platform
+): ShellLaunch {
+  if (command === undefined) return { file: userShell, args: ['-l'] }
+
+  return platform === 'darwin'
+    ? { file: '/bin/zsh', args: ['-l', '-c', command] }
+    : { file: '/bin/sh', args: ['-c', command] }
+}

--- a/tests/e2e/agent-launch-profiles.spec.mjs
+++ b/tests/e2e/agent-launch-profiles.spec.mjs
@@ -3,11 +3,20 @@
  * main-process persistence, launcher, and keyboard shortcut.
  */
 import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { agentButtonLabel, launchApp, seedWorkspaces, until, userDataDir } from './harness.mjs'
+import {
+  agentButtonLabel,
+  callMcp,
+  killLeakedE2eTmux,
+  launchApp,
+  seedWorkspaces,
+  until,
+  userDataDir
+} from './harness.mjs'
 
 const DIR = userDataDir('agent-launch-profiles')
 const ROOT = '/tmp/clave-e2e-agent-launch-profiles-root'
 const PI_ROOT = '/tmp/clave-e2e-agent-launch-profiles-pi'
+const USER_SHELL = `${ROOT}/fake-user-shell.sh`
 const RECORDER = `${ROOT}/fake-codex.sh`
 const RECORDED = `${ROOT}/fake-codex.argv`
 const WORKSPACE = {
@@ -20,6 +29,21 @@ const WORKSPACE = {
 
 export async function run(t) {
   mkdirSync(ROOT, { recursive: true })
+  // Nushell and Fish cannot parse the POSIX command wrapper Clave uses for
+  // agent launches. This stand-in still supports Clave's environment probe and
+  // plain interactive terminals, but fails if Clave asks it to parse a command.
+  writeFileSync(
+    USER_SHELL,
+    [
+      '#!/bin/sh',
+      'if [ "$1" = "-lic" ]; then exec /bin/zsh "$@"; fi',
+      'if [ "$1" = "-l" ] && [ "$#" -eq 1 ]; then exec /bin/zsh -l; fi',
+      'echo "user shell cannot parse POSIX agent commands" >&2',
+      'exit 91',
+      ''
+    ].join('\n')
+  )
+  chmodSync(USER_SHELL, 0o755)
   // A profile is only real if its command is what actually runs. This stands in
   // for the agent binary and writes the argv it was handed, one token per line,
   // so the assertion is on the spawned process rather than on the stored JSON.
@@ -29,7 +53,7 @@ export async function run(t) {
       '#!/bin/sh',
       `: > ${RECORDED}`,
       `for a in "$@"; do echo "$a" >> ${RECORDED}; done`,
-      'sleep 30',
+      'sleep 60',
       ''
     ].join('\n')
   )
@@ -43,13 +67,13 @@ export async function run(t) {
     fresh: true
   })
 
-  const { app, win } = await launchApp(DIR, {
-    env: {
-      CLAVE_PI_ROOT: PI_ROOT,
-      // Pi's own test-only override keeps the real ~/.pi session store untouched.
-      PI_CODING_AGENT_SESSION_DIR: PI_ROOT
-    }
-  })
+  const launchEnv = {
+    CLAVE_PI_ROOT: PI_ROOT,
+    SHELL: USER_SHELL,
+    // Pi's own test-only override keeps the real ~/.pi session store untouched.
+    PI_CODING_AGENT_SESSION_DIR: PI_ROOT
+  }
+  let { app, win } = await launchApp(DIR, { env: launchEnv })
   try {
     await app.evaluate(({ BrowserWindow }) => {
       BrowserWindow.getAllWindows()[0].webContents.send('menu:open-settings-section', 'agents')
@@ -144,7 +168,17 @@ export async function run(t) {
         existsSync(RECORDED) ? readFileSync(RECORDED, 'utf-8').split('\n').filter(Boolean) : null,
       { tries: 40, gapMs: 250 }
     ).catch(() => null)
-    t.check('the profile command was the process Clave spawned', argv !== null, argv)
+    const terminalText = argv
+      ? null
+      : await win
+          .locator('.xterm-rows')
+          .last()
+          .textContent()
+          .catch(() => null)
+    t.check('the profile command was the process Clave spawned', argv !== null, {
+      argv,
+      terminalText
+    })
     if (argv) {
       t.equal(
         'every profile token arrived as its own argument, spaces intact',
@@ -152,7 +186,35 @@ export async function run(t) {
         'run|--|--flag|a value with spaces'
       )
     }
-  } finally {
+
+    const beforeRestart = await callMcp(app, 'list', {})
+    const launchedSession = beforeRestart.sessions.find((session) => session.mode === 'codex')
+    t.check('the cross-shell agent is alive before restart', launchedSession?.alive === true, {
+      launchedSession,
+      sessions: beforeRestart.sessions
+    })
+
     await app.close()
+    app = null
+    const relaunched = await launchApp(DIR, { env: launchEnv, settleMs: 6000 })
+    app = relaunched.app
+    win = relaunched.win
+
+    const restoredSession = launchedSession
+      ? await until(async () => {
+          const list = await callMcp(app, 'list', {})
+          return list.sessions.find(
+            (session) => session.id === launchedSession.id && session.alive === true
+          )
+        })
+      : null
+    t.check(
+      'the same cross-shell agent session reattaches after restart',
+      !!launchedSession && restoredSession?.id === launchedSession.id,
+      { launchedSession, restoredSession }
+    )
+  } finally {
+    if (app) await app.close()
+    killLeakedE2eTmux()
   }
 }

--- a/tests/e2e/agent-launch-profiles.spec.mjs
+++ b/tests/e2e/agent-launch-profiles.spec.mjs
@@ -30,8 +30,9 @@ const WORKSPACE = {
 export async function run(t) {
   mkdirSync(ROOT, { recursive: true })
   // Nushell and Fish cannot parse the POSIX command wrapper Clave uses for
-  // agent launches. This stand-in still supports Clave's environment probe and
-  // plain interactive terminals, but fails if Clave asks it to parse a command.
+  // agent launches. This stand-in (a name off the POSIX allowlist, like theirs)
+  // still supports Clave's environment probe and plain interactive terminals,
+  // but fails if Clave asks it to parse a command.
   writeFileSync(
     USER_SHELL,
     [


### PR DESCRIPTION
## Summary

- keep plain terminal tabs on the user's configured shell
- run Clave's POSIX agent wrapper through a known command shell instead of `$SHELL`
- use the same resolved executable and arguments for direct and tmux-backed launches
- cover non-POSIX shells plus restart reattachment in unit and Electron tests

## Root cause

`pty-manager` generated a POSIX command containing environment assignments, `$?`, `[ ... ]`, and `then`/`fi`, then asked the user's `$SHELL` to parse it. Nushell and Fish reject that syntax, so the PTY exited before the agent started. Both new launches and relaunches used this path.

## Acceptance criteria

- Plain terminals still open the user's configured shell.
- New agent sessions start when `$SHELL` is non-POSIX.
- Tmux-backed agent sessions use the same shell-independent launch plan.
- A live session reattaches with the same id after Clave restarts.
- Linux uses `/bin/sh -c`; macOS keeps the documented `/bin/zsh -l -c` adapter.

## Verification

- `npm test`: 367 passed
- `npm run typecheck`: passed
- `npm run build`: passed
- `node tests/e2e/run.mjs agent-launch-profiles`: 13 passed
- Full `npm run test:e2e` under the host's Nushell: 821 passed, 5 failed in two existing specs that type zsh-only fixture commands into plain user-shell terminals
- `SHELL=/bin/zsh node tests/e2e/run.mjs message-trail`: 18 passed
- `SHELL=/bin/zsh node tests/e2e/run.mjs multi-window-core`: 52 passed
- `npm run lint`: blocked by the existing `dev` baseline, currently 212 errors and 1,450 warnings; the touched-file check has the same one existing `pty-manager` error and 39 warnings as the parent revision

## Follow-up

The secret-action executor has a separate security-sensitive call that still asks `$SHELL` to parse a command string. It is intentionally outside this session-lifecycle fix and should receive its own focused change and tests.
