### PR TITLE
An emptied group keeps its place, on a "No sessions" row

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -599,6 +599,24 @@ body,
   color: var(--text-primary);
   background-color: var(--surface-100);
 }
+
+/* The row an emptied group shows in place of its sessions ("No sessions").
+   Cut to .sidebar-item's exact height and side padding so a group of none is
+   as tall as a group of one and nothing below it moves when the last tab
+   closes; centred, italic and tertiary so it reads as a note about the card,
+   not as a row to click. No hover state on purpose — it is not a control. */
+.sidebar-empty-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: var(--sidebar-row-h);
+  padding: 0 var(--sidebar-row-px);
+  font-size: 13px;
+  font-style: italic;
+  color: var(--text-tertiary);
+  user-select: none;
+  cursor: default;
+}
 .sidebar-item[data-selected="true"] {
   color: var(--text-primary);
   background-color: var(--surface-200);

--- a/src/renderer/src/components/layout/Sidebar.tsx
+++ b/src/renderer/src/components/layout/Sidebar.tsx
@@ -9,7 +9,6 @@ import {
   type GroupTerminalColor
 } from '../../store/session-store'
 import { resolveGroupLaunchCwd } from '../../store/group-defaults'
-import { groupHasContent } from '../../lib/sidebar-layout-partition'
 import { useWorkspaceStore, getWorkspaceById } from '../../store/workspace-store'
 import ColorPicker from '../ui/ColorPicker'
 import { SessionItem } from '../session/SessionItem'
@@ -537,10 +536,9 @@ export function Sidebar() {
           if (item.type === 'fileTab') return true
           if (item.type === 'group') {
             const group = groups.find((g) => g.id === item.groupId)
-            // A running quick-launch terminal keeps a group on screen even
-            // with no tabs left in it: its icon is the only handle on that
-            // process (PRDCT-1756).
-            if (!group || !groupHasContent(group)) return false
+            // An empty group stays on screen (it draws a "No sessions" row):
+            // closing the last tab must not make the group vanish with it.
+            if (!group) return false
             // Hide groups toggled off via pinned buttons
             if (hiddenGroupIds.has(item.groupId)) return false
             if (!inActiveWorkspace(group, activeWorkspaceId)) return false
@@ -1293,9 +1291,10 @@ export function Sidebar() {
           selectionAnchorRef.current = group.sessionIds[0]
         }
       } else {
-        const allSelected =
-          group.sessionIds.length > 0 &&
-          group.sessionIds.every((id) => state.selectedSessionIds.includes(id))
+        // Vacuously true for an empty group, on purpose: with nothing to
+        // select, a click on the header takes the "already selected" path —
+        // open its view if it has one, else fold and unfold the card.
+        const allSelected = group.sessionIds.every((id) => state.selectedSessionIds.includes(id))
         if (group.collapsed) {
           // Collapsed group: expand it and select
           toggleGroupCollapsed(group.id)
@@ -1536,12 +1535,12 @@ export function Sidebar() {
                         )
                       } else {
                         const group = groups.find((g) => g.id === item.groupId)
-                        if (!group || !groupHasContent(group)) return null
+                        if (!group) return null
                         const allGroupSelected =
                           group.sessionIds.length > 0 &&
                           group.sessionIds.every((id) => selectedSessionIds.includes(id))
                         const groupColorHex = resolveColorHex(group.color)
-                        const railShut = group.collapsed || group.sessionIds.length === 0
+                        const railEmpty = group.sessionIds.length === 0
                         return (
                           <div key={group.id}>
                             <DropGap active={gapBefore} />
@@ -1599,16 +1598,14 @@ export function Sidebar() {
                                 isDragging={draggedIds.includes(group.id)}
                                 dragActive={isDragging}
                               />
-                              {/* Shut for a group with no rows exactly as for a
-                                  collapsed one. The rail's 4px of padding and the
-                                  2px drop strip are there to hold rows off the
-                                  card's edges; with nothing between them they are
-                                  6px of dead space under the header, and the card
-                                  reads bottom-heavy — a group carrying terminals
-                                  and no sessions is where that shows. */}
+                              {/* Shut only when collapsed. A group with no rows
+                                  keeps its rail open on a "No sessions" row of
+                                  a session row's exact height, so an emptied
+                                  group stands as tall as a group of one and the
+                                  list does not jump when the last tab closes. */}
                               <div
                                 className="grid transition-[grid-template-rows,opacity,transform] duration-250 ease-out"
-                                style={{ gridTemplateRows: railShut ? '0fr' : '1fr', opacity: railShut ? 0 : 1, transform: railShut ? 'translateY(-4px)' : 'translateY(0)' }}
+                                style={{ gridTemplateRows: group.collapsed ? '0fr' : '1fr', opacity: group.collapsed ? 0 : 1, transform: group.collapsed ? 'translateY(-4px)' : 'translateY(0)' }}
                               >
                                 <div className="overflow-hidden">
                                   {/* px-1 narrows the child-tab highlight so it doesn't touch the group border.
@@ -1694,6 +1691,22 @@ export function Sidebar() {
                                         </div>
                                       )
                                     })}
+                                    {/* An emptied group keeps its place. The row
+                                        stands in for the session that is no longer
+                                        there — same height, so the card is as tall
+                                        as a group of one — and, while dragging, it
+                                        is the group's drop zone: a row dropped on
+                                        it joins the group (use-sidebar-dnd). */}
+                                    {railEmpty && (
+                                      <div
+                                        className="sidebar-empty-row"
+                                        data-sidebar-empty-group={group.id}
+                                        data-sidebar-drop-zone="group-end"
+                                        data-group-id={group.id}
+                                      >
+                                        No sessions
+                                      </div>
+                                    )}
                                     {/* The foot of the rail: while dragging, the
                                         "last position of the group" drop zone
                                         (use-sidebar-dnd) — the last row's bottom

--- a/src/renderer/src/hooks/use-sidebar-dnd.ts
+++ b/src/renderer/src/hooks/use-sidebar-dnd.ts
@@ -273,8 +273,14 @@ export function useSidebarDnd(opts: {
             newIndicator = { targetId: group.id, position: 'after' }
             break
           }
-          // The last row not being dragged; with none (the dragged row is the
-          // only one) the strip means "stay".
+          // An EMPTY group's zone is its "No sessions" row: a row dropped there
+          // joins the group (its first member). Otherwise the last row not
+          // being dragged; with none (the dragged row is the only one) the
+          // strip means "stay".
+          if (group.sessionIds.length === 0) {
+            newIndicator = { targetId: group.id, position: 'inside' }
+            break
+          }
           const anchor = [...group.sessionIds].reverse().find((sid) => !drag.ids.includes(sid))
           if (anchor) newIndicator = { targetId: anchor, position: 'after' }
           break

--- a/src/renderer/src/lib/sidebar-layout-partition.test.ts
+++ b/src/renderer/src/lib/sidebar-layout-partition.test.ts
@@ -3,7 +3,6 @@ import {
   mergeLayoutForKeys,
   absorbLayout,
   placeAdopted,
-  groupHasContent,
   type LayoutGroupLike,
   type LayoutSessionLike
 } from './sidebar-layout-partition'
@@ -56,19 +55,24 @@ describe('mergeLayoutForKeys', () => {
     expect(out.displayOrder).toEqual(['gB'])
   })
 
-  it('prunes a group whose members are gone everywhere, and detaches its dead terminal', () => {
+  // A group whose members are all gone comes back EMPTY, in its place. It used
+  // to be pruned, which is how closing a group's last tab made the group
+  // vanish after the next launch; an empty group is a normal state now (the
+  // sidebar draws it as a "No sessions" row) and only Delete / Ungroup remove it.
+  it('keeps a group whose members are gone everywhere as an empty group, and detaches its dead terminal', () => {
     const out = mergeLayoutForKeys(
       { groups: [], displayOrder: [], sessions: [] },
       [B],
       {
-        groups: [g('dead', ['gone'], B), g('live', ['ok'], B, [{ sessionId: 'gone-term' }])],
-        displayOrder: ['dead', 'live']
+        groups: [g('emptied', ['gone'], B), g('live', ['ok'], B, [{ sessionId: 'gone-term' }])],
+        displayOrder: ['emptied', 'live']
       },
       ['ok']
     )
-    expect(out.groups.map((x) => x.id)).toEqual(['live'])
-    expect(out.groups[0].terminals).toEqual([{ sessionId: null }])
-    expect(out.displayOrder).toEqual(['live'])
+    expect(out.groups.map((x) => x.id)).toEqual(['emptied', 'live'])
+    expect(out.groups[0].sessionIds).toEqual([])
+    expect(out.groups[1].terminals).toEqual([{ sessionId: null }])
+    expect(out.displayOrder).toEqual(['emptied', 'live'])
   })
 
   // ── PRDCT-1756: the group-drop that orphaned a running dev server. A group
@@ -92,7 +96,7 @@ describe('mergeLayoutForKeys', () => {
     expect(out.displayOrder).toEqual(['gB'])
   })
 
-  it('still drops a group with no members and no running terminal', () => {
+  it('keeps a group with no members and no running terminal, its dead terminal detached', () => {
     const out = mergeLayoutForKeys(
       { groups: [], displayOrder: [], sessions: [] },
       [B],
@@ -102,8 +106,8 @@ describe('mergeLayoutForKeys', () => {
       },
       []
     )
-    expect(out.groups).toEqual([])
-    expect(out.displayOrder).toEqual([])
+    expect(out.groups).toEqual([g('gB', [], B, [{ sessionId: null }])])
+    expect(out.displayOrder).toEqual(['gB'])
   })
 
   it('never surfaces a nested session at the top level, appends missed standalone sessions', () => {
@@ -251,18 +255,3 @@ describe('placeAdopted — an adopted tab never lands twice, never in a foreign 
   })
 })
 
-
-describe('groupHasContent — what the sidebar draws', () => {
-  it('a group with tabs shows', () => {
-    expect(groupHasContent({ sessionIds: ['a'], terminals: [] })).toBe(true)
-  })
-  it('a group with only a RUNNING terminal shows — its icon is the way back', () => {
-    expect(groupHasContent({ sessionIds: [], terminals: [{ sessionId: 'srv' }] })).toBe(true)
-  })
-  it('a group with only idle terminal configs stays hidden', () => {
-    expect(groupHasContent({ sessionIds: [], terminals: [{ sessionId: null }] })).toBe(false)
-  })
-  it('an empty group stays hidden', () => {
-    expect(groupHasContent({ sessionIds: [], terminals: [] })).toBe(false)
-  })
-})

--- a/src/renderer/src/lib/sidebar-layout-partition.ts
+++ b/src/renderer/src/lib/sidebar-layout-partition.ts
@@ -37,12 +37,21 @@ export type LayoutKey = string | null
  * file without it the moment this window persists. Only a session that is
  * gone everywhere prunes its group, exactly as boot restore does.
  *
- * The same shape the boot restore uses: a group with neither a surviving
- * member nor a running terminal is dropped, a terminal whose session is gone
- * is detached, the persisted order is kept minus dead references, surviving
- * standalone sessions of those workspaces the order missed are appended, then
- * kept groups not yet placed. Ids nested inside a kept group (a member, a group
- * terminal, a session view's hidden server) never surface at the top level.
+ * The same shape the boot restore uses: every group of those workspaces comes
+ * back, members pruned to the survivors (an emptied group is a group, see
+ * below), a terminal whose session is gone is detached, the persisted order is
+ * kept minus dead references, surviving standalone sessions of those
+ * workspaces the order missed are appended, then kept groups not yet placed.
+ * Ids nested inside a kept group (a member, a group terminal, a session view's
+ * hidden server) never surface at the top level.
+ *
+ * A group with no members left is KEPT, not pruned. Closing the last tab of a
+ * group used to make the group vanish with it — the user opens a group,
+ * closes its one session, and cannot find the group again — so an empty group
+ * is now a normal state: the sidebar draws it as a card holding a "No
+ * sessions" row, and only Delete / Ungroup take it away. (Before that, a
+ * group survived on a running quick-launch terminal alone, PRDCT-1756; it
+ * still does, as a special case of surviving on nothing.)
  */
 export function mergeLayoutForKeys<G extends LayoutGroupLike>(
   state: { groups: G[]; displayOrder: string[]; sessions: LayoutSessionLike[] },
@@ -83,11 +92,10 @@ export function mergeLayoutForKeys<G extends LayoutGroupLike>(
     const terminals = (g.terminals ?? []).map((t) =>
       t.sessionId && !alive.has(t.sessionId) ? { ...t, sessionId: null } : t
     )
-    // A group survives on a running quick-launch terminal alone (PRDCT-1756).
-    // Members-only was the rule, and it is what put a live `npm run dev` in
-    // the sidebar as a mystery tab: the group it belonged to was pruned for
-    // having no surviving MEMBER, and pruning it un-nested its terminal.
-    if (sessionIds.length === 0 && !terminals.some((t) => t.sessionId)) continue
+    // Never pruned for being empty: see the doc comment. (Members-only was
+    // once the rule, and it is what put a live `npm run dev` in the sidebar as
+    // a mystery tab, PRDCT-1756 — the group it belonged to was pruned for
+    // having no surviving member, and pruning it un-nested its terminal.)
     kept.push({ ...g, sessionIds, terminals })
   }
   const keptIds = new Set(kept.map((g) => g.id))
@@ -187,19 +195,4 @@ export function placeAdopted<G extends LayoutGroupLike>(
   }
   if (state.sessions.some((s) => s.view?.serverSessionId === sessionId)) return state.displayOrder
   return [...state.displayOrder, sessionId]
-}
-
-/**
- * Does this group have anything to show? A group renders when it holds tabs
- * OR when one of its quick-launch terminals is running (PRDCT-1756) — the
- * dev server is the only thing left of it and its icon is the way back to
- * the process. A group with neither is an empty shell and stays hidden, as
- * it always has. Mirrors the keep rule in mergeLayoutForKeys: what the merge
- * keeps in the layout is exactly what the sidebar draws.
- */
-export function groupHasContent(g: {
-  sessionIds: string[]
-  terminals: { sessionId: string | null }[]
-}): boolean {
-  return g.sessionIds.length > 0 || g.terminals.some((t) => !!t.sessionId)
 }

--- a/src/renderer/src/store/session-store.ts
+++ b/src/renderer/src/store/session-store.ts
@@ -1137,7 +1137,9 @@ export const useSessionStore = create<SessionState>((set) => ({
             sessionId: t.sessionId && validSessionIds.has(t.sessionId) ? t.sessionId : null
           }))
         }))
-        .filter((g) => g.sessionIds.length > 0)
+      // A restored group whose members have since closed comes back empty —
+      // an empty group is a normal state, exactly as closing its last tab
+      // leaves it (see mergeLayoutForKeys).
       const restoredGroupIds = new Set(restoredGroups.map((g) => g.id))
       const displayOrder = snap.displayOrder.filter(
         (id) => validSessionIds.has(id) || restoredGroupIds.has(id)

--- a/tests/e2e/empty-group.spec.mjs
+++ b/tests/e2e/empty-group.spec.mjs
@@ -1,0 +1,179 @@
+/**
+ * An emptied group keeps its place.
+ *
+ * Closing a group's last tab used to make the group vanish with it: the user
+ * opens a group, closes its one session, and cannot find the group again.
+ * The group had not been deleted — it was in the store, hidden for holding
+ * nothing, and pruned for good at the next launch. An empty group is a
+ * normal state now, in the real app:
+ *
+ *  1. The card stays, its rail holding a "No sessions" row instead of the
+ *     tab — and it is EXACTLY as tall as it was with one session, so nothing
+ *     below it jumps when the last tab closes.
+ *  2. The header still works: a click folds the empty card, another unfolds it.
+ *  3. The row is the group's drop zone: a loose tab dragged onto it joins the
+ *     group, and the row makes way for it.
+ *  4. The next launch brings the empty group back, empty (the boot merge no
+ *     longer prunes it).
+ *
+ * Fails if the old behaviour comes back at any of those four points: a card
+ * that disappears, a card that shrinks to its header, a drop that does
+ * nothing, or a group missing after the restart.
+ */
+import { mkdirSync } from 'node:fs'
+import { launchApp, seedWorkspaces, seedTrustedRoots, userDataDir, callMcp, until } from './harness.mjs'
+
+const DIR = userDataDir('empty-group')
+const ROOT = '/tmp/clave-e2e-empty-group-root'
+const WS = {
+  id: 'abababab-0000-4000-8000-00000000000a',
+  name: 'Empty',
+  rootDir: ROOT,
+  createdAt: 1
+}
+
+const cardSel = (groupId) => `.group-scope:has([data-sidebar-item-id="${groupId}"][data-sidebar-item-type="group"])`
+const rowSel = (id) => `[data-sidebar-item-id="${id}"]`
+const emptyRowSel = (groupId) => `[data-sidebar-empty-group="${groupId}"]`
+
+/** The card of `groupId` as the user sees it: whether it is drawn, its height,
+ *  the member rows in its rail, and the placeholder's text if it shows one. */
+function card(win, groupId) {
+  return win.evaluate(
+    ({ cardSel, emptyRowSel }) => {
+      const el = document.querySelector(cardSel)
+      if (!el) return null
+      const rect = el.getBoundingClientRect()
+      const empty = el.querySelector(emptyRowSel)
+      return {
+        height: Math.round(rect.height),
+        rows: [...el.querySelectorAll('.group-rail [data-sidebar-item-id]')].map((r) => r.dataset.sidebarItemId),
+        placeholder: empty ? (empty.textContent || '').trim() : null,
+        placeholderHeight: empty ? Math.round(empty.getBoundingClientRect().height) : null
+      }
+    },
+    { cardSel: cardSel(groupId), emptyRowSel: emptyRowSel(groupId) }
+  )
+}
+
+async function centerOf(win, selector) {
+  const box = await win.locator(selector).boundingBox()
+  if (!box) throw new Error(`no box for ${selector}`)
+  return { x: box.x + box.width / 2, y: box.y + box.height / 2 }
+}
+
+/** A real pointer drag from `from` to `to`, past the 5px threshold in steps,
+ *  hovering long enough for the debounced drop indicator before releasing. */
+async function drag(win, from, to) {
+  await win.mouse.move(from.x, from.y)
+  await win.mouse.down()
+  const steps = 12
+  for (let i = 1; i <= steps; i++) {
+    await win.mouse.move(from.x + ((to.x - from.x) * i) / steps, from.y + ((to.y - from.y) * i) / steps)
+    await win.waitForTimeout(20)
+  }
+  await win.waitForTimeout(500)
+  await win.mouse.up()
+  await win.waitForTimeout(600)
+}
+
+export async function run(t) {
+  mkdirSync(ROOT, { recursive: true })
+  seedWorkspaces(DIR, { workspaces: [WS], activeWorkspaceId: WS.id, fresh: true })
+  seedTrustedRoots(DIR, [ROOT])
+
+  let { app, win } = await launchApp(DIR)
+  try {
+    // ── The group, with one tab: the reference height ──
+    const group = await callMcp(app, 'createGroup', { name: 'Lane' })
+    await win.waitForTimeout(400)
+    const fresh = await card(win, group.groupId)
+    t.check(
+      'a group created empty is drawn at once, on its "No sessions" row',
+      fresh?.placeholder === 'No sessions' && fresh.rows.length === 0,
+      fresh
+    )
+
+    const member = await callMcp(app, 'openSession', { cwd: ROOT, mode: 'terminal', name: 'only-tab' })
+    await callMcp(app, 'moveSession', { sessionId: member.sessionId, groupId: group.groupId })
+    await win.waitForTimeout(800)
+    const withOne = await card(win, group.groupId)
+    t.check(
+      'the group holds its one tab and no placeholder',
+      withOne?.rows.length === 1 && withOne.placeholder === null,
+      withOne
+    )
+    const rowHeight = await win.evaluate(
+      (sel) => Math.round(document.querySelector(sel)?.getBoundingClientRect().height ?? 0),
+      `${rowSel(member.sessionId)} .sidebar-item`
+    )
+
+    // ── 1. Close the last tab: the card stays, same height ──
+    await callMcp(app, 'closeSession', { sessionId: member.sessionId })
+    await win.waitForTimeout(1000)
+    const listed = await callMcp(app, 'list', {})
+    t.check(
+      'the group is still in the layout after its last tab closed',
+      listed.groups.some((g) => g.id === group.groupId && g.sessionIds.length === 0),
+      listed.groups
+    )
+    const emptied = await card(win, group.groupId)
+    t.check('the card is still drawn', !!emptied, 'no card for the group')
+    t.equal('and it says "No sessions"', emptied?.placeholder, 'No sessions')
+    t.equal('the placeholder row is exactly one session row tall', emptied?.placeholderHeight, rowHeight)
+    t.equal('so the empty card is exactly as tall as it was with one tab', emptied?.height, withOne?.height)
+
+    // ── 2. The header still folds and unfolds the empty card ──
+    await win.click(rowSel(group.groupId))
+    await win.waitForTimeout(600)
+    const folded = await card(win, group.groupId)
+    t.check('a click on the header folds the empty card', !!folded && folded.height < emptied.height, {
+      folded: folded?.height,
+      open: emptied?.height
+    })
+    await win.click(rowSel(group.groupId))
+    await win.waitForTimeout(600)
+    const unfolded = await card(win, group.groupId)
+    t.equal('and a second click unfolds it to the same height', unfolded?.height, emptied?.height)
+
+    // ── 3. The row is the drop zone: a loose tab dropped on it joins ──
+    const loose = await callMcp(app, 'openSession', { cwd: ROOT, mode: 'terminal', name: 'loose-tab' })
+    await win.waitForTimeout(800)
+    await drag(win, await centerOf(win, rowSel(loose.sessionId)), await centerOf(win, emptyRowSel(group.groupId)))
+    const joined = await card(win, group.groupId)
+    t.check(
+      'the tab dropped on "No sessions" joined the group, and the row made way',
+      joined?.rows.join(',') === loose.sessionId && joined.placeholder === null,
+      joined
+    )
+    t.equal('the card is as tall with the new tab as with the placeholder', joined?.height, emptied?.height)
+
+    // ── 4. The restart: the empty group comes back, empty ──
+    await callMcp(app, 'closeSession', { sessionId: loose.sessionId })
+    await win.waitForTimeout(1500)
+    await app.close()
+    app = null
+    await new Promise((r) => setTimeout(r, 1500))
+
+    const second = await launchApp(DIR, { settleMs: 6000 })
+    app = second.app
+    win = second.win
+    const back = await until(async () => {
+      const list = await callMcp(app, 'list', {})
+      return list.groups.some((g) => g.id === group.groupId) ? list : null
+    })
+    t.check(
+      'the empty group is back after the restart',
+      !!back && back.groups.find((g) => g.id === group.groupId)?.sessionIds.length === 0,
+      back?.groups
+    )
+    const rebooted = await card(win, group.groupId)
+    t.check(
+      'drawn on its "No sessions" row, at the same height',
+      rebooted?.placeholder === 'No sessions' && rebooted.height === emptied?.height,
+      { rebooted, expected: emptied?.height }
+    )
+  } finally {
+    if (app) await app.close()
+  }
+}


### PR DESCRIPTION
## What

Closing a group's last tab made the group vanish with it: the store kept it, the sidebar hid it for holding nothing, and the boot merge pruned it for good at the next launch. You open a group, close its one session, and cannot find the group again.

An empty group is now a normal state:

- The sidebar draws it as a card whose rail holds a centred, italic **"No sessions"** row cut to a session row's exact height, so a group of none is exactly as tall as a group of one and nothing below it jumps when the last tab closes (`sidebar-empty-row` in `main.css`).
- The header still folds and unfolds the empty card.
- The row is the group's drop zone: a tab dropped on it joins the group (`use-sidebar-dnd.ts`).
- The boot merge (`mergeLayoutForKeys`) and the sidebar undo keep empty groups; `groupHasContent` is retired.
- Only Delete / Ungroup take an empty group away. Dragging the last row out of a group still dissolves it, as before.
- A group an agent creates through Clave now shows at once, on its "No sessions" row, instead of staying invisible until filled.

## Verification

- Typecheck clean, 501 unit tests pass, no new lint errors on the touched files.
- New `tests/e2e/empty-group.spec.mjs` pins the close, the height parity, the fold, the drop and the restart. Mutating the boot keep-rule back to pruning turns its restart checks red.
- `sidebar-dnd`, `group-dissolve`, `hidden-session-restore`, `group-placement`, `switcher-collapse` and `multi-window-core` still pass.
- Screenshot of the real app: a one-tab group and an emptied group both measure 72px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XobpiExVZjJybEDBAYyYo4
