### PR TITLE
[minor] The repository lives at antasphere/clave: release, updater and links follow the move

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           chmod 600 ~/.ssh/release_key
           ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
           git config core.sshCommand "ssh -i ~/.ssh/release_key -o IdentitiesOnly=yes"
-          git remote set-url --push origin git@github.com:codika-io/clave.git
+          git remote set-url --push origin git@github.com:antasphere/clave.git
 
       - name: Determine bump level
         id: bump

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Mac desktop app for managing multiple coding-agent CLI sessions in parallel. Provider-agnostic: it orchestrates Claude Code (Cmd+N), Antigravity CLI (Cmd+I), Codex CLI (Cmd+U), and Pi (Cmd+Shift+P) sessions side by side, plus plain terminals (Cmd+T) and remote agents over OpenClaw. Electron + React + TypeScript.
 
-Clave's companion agent plugin (`clave`, exposing `/clave:create-workspace` and `/clave:recover-sessions`) ships from `plugin/` in this repo — see `plugin/CLAUDE.md`. It is installed with `npx plugins add codika-io/clave`, resolved through `.claude-plugin/marketplace.json` at the root. The Electron app reads installed plugins from `~/.claude/plugins/` at runtime and never reads `plugin/` directly; the folder is here so a `.clave` format change and the skill that describes it land in the same commit (see the schema sync rule below).
+Clave's companion agent plugin (`clave`, exposing `/clave:create-workspace` and `/clave:recover-sessions`) ships from `plugin/` in this repo — see `plugin/CLAUDE.md`. It is installed with `npx plugins add antasphere/clave`, resolved through `.claude-plugin/marketplace.json` at the root. The Electron app reads installed plugins from `~/.claude/plugins/` at runtime and never reads `plugin/` directly; the folder is here so a `.clave` format change and the skill that describes it land in the same commit (see the schema sync rule below).
 
 ## Commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing! Please read this guide before starting
 
 ## Reporting bugs
 
-Open a [bug report](https://github.com/codika-io/clave/issues/new?template=bug_report.md) with:
+Open a [bug report](https://github.com/antasphere/clave/issues/new?template=bug_report.md) with:
 
 - Your Clave version (Help → About) and macOS version
 - Steps to reproduce
@@ -13,7 +13,7 @@ Open a [bug report](https://github.com/codika-io/clave/issues/new?template=bug_r
 
 ## Suggesting features
 
-Open a [feature request](https://github.com/codika-io/clave/issues/new?template=feature_request.md) describing the problem you're trying to solve and your proposed solution.
+Open a [feature request](https://github.com/antasphere/clave/issues/new?template=feature_request.md) describing the problem you're trying to solve and your proposed solution.
 
 ## The golden rule: propose before you build
 
@@ -52,7 +52,7 @@ This flow exists because Clave has a deliberately narrow scope. Features that se
 ## Development setup
 
 ```bash
-git clone https://github.com/codika-io/clave.git
+git clone https://github.com/antasphere/clave.git
 cd clave
 npm install
 npm run dev

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <img width="80" height="80" alt="Clave" src="resources/icon.png" />
 
-[![License](https://img.shields.io/github/license/codika-io/clave?labelColor=333333&color=666666)](LICENSE)
-[![Downloads](https://img.shields.io/github/downloads/codika-io/clave/total?labelColor=333333&color=666666)](https://github.com/codika-io/clave/releases)
-[![GitHub Stars](https://img.shields.io/github/stars/codika-io/clave?labelColor=333333&color=666666)](https://github.com/codika-io/clave)
+[![License](https://img.shields.io/github/license/antasphere/clave?labelColor=333333&color=666666)](LICENSE)
+[![Downloads](https://img.shields.io/github/downloads/antasphere/clave/total?labelColor=333333&color=666666)](https://github.com/antasphere/clave/releases)
+[![GitHub Stars](https://img.shields.io/github/stars/antasphere/clave?labelColor=333333&color=666666)](https://github.com/antasphere/clave)
 
 **Clave is a macOS desktop app for managing multiple coding-agent sessions in parallel.**
 
@@ -22,7 +22,7 @@ Provider-agnostic: run Claude Code, Antigravity CLI, Codex CLI, and Pi sessions 
 
 ## Download
 
-[**Download the latest version**](https://github.com/codika-io/clave/releases/latest) (macOS Universal — Apple Silicon & Intel) · [All releases](https://github.com/codika-io/clave/releases)
+[**Download the latest version**](https://github.com/antasphere/clave/releases/latest) (macOS Universal — Apple Silicon & Intel) · [All releases](https://github.com/antasphere/clave/releases)
 
 Download the `.dmg`, drag to Applications, done.
 
@@ -39,13 +39,13 @@ Clave ships a companion agent plugin, in [`plugin/`](plugin/) in this repo, that
 **Install (any Open-Plugin-compatible host — auto-detects Claude Code, Cursor, …):**
 
 ```bash
-npx plugins add codika-io/clave
+npx plugins add antasphere/clave
 ```
 
 **Claude Code native alternative:**
 
 ```
-/plugin marketplace add codika-io/clave
+/plugin marketplace add antasphere/clave
 /plugin install clave@clave
 ```
 
@@ -56,7 +56,7 @@ Both paths install the same two skills: `/clave:create-workspace` and `/clave:re
 **Updating:**
 
 ```bash
-npx plugins add codika-io/clave   # re-run to pull latest
+npx plugins add antasphere/clave   # re-run to pull latest
 ```
 
 (Or `/plugin update clave@clave` in Claude Code native.)
@@ -93,7 +93,7 @@ That is the entire payload — three fields, nothing else, ever. The `id` is a r
 The only other network requests Clave makes are:
 
 - **Claude Code** reaches the Anthropic API through your own local Claude Code install — Clave never proxies or sees that traffic.
-- **Auto-updates** — [electron-updater](https://www.electron.build/auto-update) checks [GitHub Releases](https://github.com/codika-io/clave/releases) for new versions and installs the signed, notarized build on quit. Auto-download is off by default.
+- **Auto-updates** — [electron-updater](https://www.electron.build/auto-update) checks [GitHub Releases](https://github.com/antasphere/clave/releases) for new versions and installs the signed, notarized build on quit. Auto-download is off by default.
 - **Usage ping** — the once-a-day anonymous `POST` to `ping.clave.work` described above (optional, toggle in Settings).
 - **Git operations** — standard fetch/pull/push to whatever remotes your own repositories use.
 - **SSH / SFTP** — only to remote hosts you explicitly add.
@@ -104,7 +104,7 @@ The only other network requests Clave makes are:
 ## Build from source
 
 ```bash
-git clone https://github.com/codika-io/clave.git
+git clone https://github.com/antasphere/clave.git
 cd clave
 npm install
 npm run dev          # development with hot reload

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -58,5 +58,5 @@ appImage:
 npmRebuild: false
 publish:
   provider: github
-  owner: codika-io
+  owner: antasphere
   repo: clave

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/codika-io/clave.git"
+    "url": "https://github.com/antasphere/clave.git"
   },
-  "homepage": "https://github.com/codika-io/clave",
+  "homepage": "https://github.com/antasphere/clave",
   "main": "./out/main/index.js",
   "scripts": {
     "format": "prettier --write .",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -7,8 +7,8 @@
     "email": "team@codika.io",
     "url": "https://codika.io"
   },
-  "homepage": "https://github.com/codika-io/clave",
-  "repository": "https://github.com/codika-io/clave",
+  "homepage": "https://github.com/antasphere/clave",
+  "repository": "https://github.com/antasphere/clave",
   "license": "MIT",
   "keywords": [
     "clave",

--- a/plugin/.plugin/plugin.json
+++ b/plugin/.plugin/plugin.json
@@ -7,8 +7,8 @@
     "email": "team@codika.io",
     "url": "https://codika.io"
   },
-  "homepage": "https://github.com/codika-io/clave",
-  "repository": "https://github.com/codika-io/clave",
+  "homepage": "https://github.com/antasphere/clave",
+  "repository": "https://github.com/antasphere/clave",
   "license": "MIT",
   "keywords": [
     "clave",

--- a/plugin/CLAUDE.md
+++ b/plugin/CLAUDE.md
@@ -28,7 +28,7 @@ plugin/
 └── LICENSE
 ```
 
-The repo root also carries `.claude-plugin/marketplace.json`, which is what makes `npx plugins add codika-io/clave` resolve to this folder. It names the marketplace `clave` and points `source` at `./plugin`, so the plugin installs as `clave@clave`. If you move or rename this folder, that file moves with you.
+The repo root also carries `.claude-plugin/marketplace.json`, which is what makes `npx plugins add antasphere/clave` resolve to this folder. It names the marketplace `clave` and points `source` at `./plugin`, so the plugin installs as `clave@clave`. If you move or rename this folder, that file moves with you.
 
 ## Manifests
 
@@ -74,4 +74,4 @@ Skills surface as `/clave:<skill>` in any installed host. Note that this copies 
 
 ## History
 
-Extracted from `codika-io/clave` into its own repo `codika-io/clave-plugin` in 2026-04, and folded back in here in 2026-08 (PRDCT-1699) once the cross-repo ordering constraint proved to be the format's main source of drift. The old repo's history is preserved in this repo through the subtree merge that vendored it.
+Extracted from `antasphere/clave` into its own repo `codika-io/clave-plugin` in 2026-04, and folded back in here in 2026-08 (PRDCT-1699) once the cross-repo ordering constraint proved to be the format's main source of drift. The old repo's history is preserved in this repo through the subtree merge that vendored it.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,6 +1,6 @@
 # Clave Plugin (`clave`)
 
-The companion agent plugin for [Clave](https://github.com/codika-io/clave) — a multi-session Claude Code desktop app. It ships **inside the app repo**, in this folder, so the skills and the `.clave` file format they describe always move together.
+The companion agent plugin for [Clave](https://github.com/antasphere/clave) — a multi-session Claude Code desktop app. It ships **inside the app repo**, in this folder, so the skills and the `.clave` file format they describe always move together.
 
 Two skills: `create-workspace`, which generates `.clave` workspace files from a natural-language description, and `recover-sessions`, which rebuilds a lost workspace from the Claude Code transcripts already on your disk.
 
@@ -11,7 +11,7 @@ Conforms to the [Open Plugin Specification v1.0](https://github.com/vercel-labs/
 ### Any Open-Plugin-compatible host (Claude Code, Cursor, …)
 
 ```bash
-npx plugins add codika-io/clave
+npx plugins add antasphere/clave
 ```
 
 The `plugins` CLI auto-detects which agent tools are installed and installs into all of them.
@@ -19,7 +19,7 @@ The `plugins` CLI auto-detects which agent tools are installed and installs into
 ### Claude Code (native)
 
 ```
-/plugin marketplace add codika-io/clave
+/plugin marketplace add antasphere/clave
 /plugin install clave@clave
 ```
 
@@ -54,7 +54,7 @@ Retention is a local setting: `cleanupPeriodDays` in `~/.claude/settings.json` (
 
 ## About Clave
 
-Clave is a macOS desktop app for running many coding-agent CLI sessions in parallel with shared layouts, git panels, and daily logs. Download at [github.com/codika-io/clave](https://github.com/codika-io/clave).
+Clave is a macOS desktop app for running many coding-agent CLI sessions in parallel with shared layouts, git panels, and daily logs. Download at [github.com/antasphere/clave](https://github.com/antasphere/clave).
 
 ## License
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -259,4 +259,4 @@ fi
 rm -f "$NOTES_FILE"
 
 info "Release v${NEW_VERSION} published!"
-info "https://github.com/codika-io/clave/releases/tag/v${NEW_VERSION}"
+info "https://github.com/antasphere/clave/releases/tag/v${NEW_VERSION}"

--- a/src/main/app-menu.ts
+++ b/src/main/app-menu.ts
@@ -6,7 +6,7 @@ import { checkForUpdatesNow, openUpdaterLog, RELEASES_URL } from './auto-updater
 import { getStoredKeymapConfig } from './ipc-handlers/keymap-handlers'
 import type { KeymapActionId } from '../shared/keymaps'
 
-const REPO_URL = 'https://github.com/codika-io/clave'
+const REPO_URL = 'https://github.com/antasphere/clave'
 // electron-builder's productName, stated rather than read: `app.name` is the
 // package name ("clave") until the app is packaged, so the menu would say
 // "Quit clave" in dev and "Quit Clave" in a release.

--- a/src/main/auto-updater.ts
+++ b/src/main/auto-updater.ts
@@ -18,7 +18,7 @@ const INITIAL_DELAY = 5000
 const RETRY_DELAY = 60 * 1000 // 1 minute
 
 /** Where a user is sent when the updater cannot help itself. */
-export const RELEASES_URL = 'https://github.com/codika-io/clave/releases/latest'
+export const RELEASES_URL = 'https://github.com/antasphere/clave/releases/latest'
 
 /**
  * Which try this is. Not a counter — the only distinction that changes what we


### PR DESCRIPTION
The org move (codika-io → antasphere, 2026-09-10) left the release workflow pushing to the old path with a deploy key that now lives on the new repo: the 1.88.0 run built, signed and notarized, then failed at the bump push. This moves every GitHub path in the repo (workflow push URL, electron-builder publish owner, updater release URL, app menu link, package.json, plugin manifests, docs). The npm scope `@codika-io/clave-channel` is a package name and stays.

`[minor]` so the release that follows is the 1.88.0 the view-navigation work (#47) earns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtbSL2zPzBxsuRZ6GiZJB8